### PR TITLE
Fix scrollIndex not being initialized

### DIFF
--- a/OpenTESArena/src/Interface/ListBox.cpp
+++ b/OpenTESArena/src/Interface/ListBox.cpp
@@ -14,7 +14,7 @@
 
 ListBox::ListBox(int x, int y, FontName fontName, const Color &textColor, int maxDisplayed,
 	const std::vector<std::string> &elements, TextureManager &textureManager)
-	: Surface(x, y, 1, 1), textureManagerRef(textureManager)
+	: Surface(x, y, 1, 1), textureManagerRef(textureManager), scrollIndex(0)
 {
 	assert(maxDisplayed > 0);
 


### PR DESCRIPTION
Fixes #5 

The scrollIndex was sometimes getting ridiculous values because it was getting whatever value happened to be sitting in memory there. Looks like there's probably various other initialization issues, as well.