### PR TITLE
Correct build problem without WildMIDI present at KittyKat's instruction

### DIFF
--- a/OpenTESArena/src/Media/WildMidi.hpp
+++ b/OpenTESArena/src/Media/WildMidi.hpp
@@ -1,9 +1,9 @@
 #ifndef MEDIA_WILDMIDI_HPP
 #define MEDIA_WILDMIDI_HPP
 
-#ifdef HAVE_WILDMIDI
-
 #include "Midi.hpp"
+
+#ifdef HAVE_WILDMIDI
 
 /* Implementation for opening supported MIDI-like files through WildMidi. */
 class WildMidiDevice : public MidiDevice {


### PR DESCRIPTION
Was having problems building without WildMIDI. @kcat said it was just the include being in the wrong place.