### PR TITLE
Start support for loading Arena's IMG files

### DIFF
--- a/OpenTESArena/src/Media/TextureFile.cpp
+++ b/OpenTESArena/src/Media/TextureFile.cpp
@@ -14,7 +14,7 @@ const std::map<TextureName, std::string> TextureFilenames =
 	{ TextureName::CompassFrame, "interface/compass_frame" },
 	{ TextureName::CompassSlider, "interface/compass_slider" },
 	{ TextureName::Icon, "interface/icon" },
-	{ TextureName::IntroTitle, "interface/intro_title" },
+	{ TextureName::IntroTitle, "TITLE.IMG" },
 	{ TextureName::IntroQuote, "interface/intro_quote" },
 	{ TextureName::MainMenu, "interface/main_menu" },
 	{ TextureName::ParchmentPopup, "interface/parchment/parchment_popup" },

--- a/OpenTESArena/src/Media/TextureManager.cpp
+++ b/OpenTESArena/src/Media/TextureManager.cpp
@@ -27,7 +27,71 @@ typedef std::array<Color,256> Palette;
 
 Palette DefaultPalette;
 
+template<typename T>
+void decode04Type(T src, T srcend, std::vector<uint8_t> &out)
+{
+    auto dst = out.begin();
+
+    std::array<uint8_t, 4096> history;
+    std::fill(history.begin(), history.end(), 0);
+    int historypos = 0;
+
+    // This appears to be some form of LZ compression. It starts with a 1-byte-
+    // wide bitmask, where each bit declares if the next pixel comes directly
+    // from the input, or refers back to a previous run of output pixels that
+    // get duplicated. After each bit in the mask is used, another byte is read
+    // for another bitmask and the cycle repeats until the end of input.
+    int bitcount = 0;
+    int mask = 0;
+    while(src != srcend)
+    {
+        if(!bitcount)
+        {
+            bitcount = 8;
+            mask = *(src++);
+        }
+        else
+            mask >>= 1;
+
+        if((mask&1))
+        {
+            if(src == srcend)
+                throw std::runtime_error("Unexpected end of image");
+            if(dst == out.end())
+                throw std::runtime_error("Decoded image overflow");
+            history[historypos++ & 0x0FFF] = *src;
+            *(dst++) = *(src++);
+        }
+        else
+        {
+            if(std::distance(src, srcend) < 2)
+                throw std::runtime_error("Unexpected end of image");
+            uint8_t byte1 = *(src++);
+            uint8_t byte2 = *(src++);
+            int tocopy = (byte2 & 0x0F) + 3;
+            int copypos = (((byte2 & 0xF0) << 4) | byte1) + 18;
+
+            if(std::distance(dst, out.end()) < tocopy)
+                throw std::runtime_error("Decoded image overflow");
+
+            for(int i = 0;i < tocopy;++i)
+            {
+                *dst = history[copypos++ & 0x0FFF];
+                history[historypos++ & 0x0FFF] = *(dst++);
+            }
+        }
+        --bitcount;
+    }
+
+    std::fill(dst, out.end(), 0);
+}
+
 // These might be useful as public misc utility functions
+
+uint16_t getLE16(const uint8_t *buf)
+{
+    return buf[0] | (buf[1]<<8);
+}
 
 uint32_t getLE32(const uint8_t *buf)
 {
@@ -140,8 +204,8 @@ SDL_Surface *TextureManager::loadFromFile(const std::string &fullPath)
 {
 	// Load the SDL_Surface from file.
 	auto *unOptSurface = IMG_Load(fullPath.c_str());
-	Debug::check(unOptSurface != nullptr, "Texture Manager",
-		"Could not open texture \"" + fullPath + "\".");
+    Debug::check(unOptSurface != nullptr, "Texture Manager",
+            "Could not open texture \"" + fullPath + "\".");
 
 	// Try to optimize the SDL_Surface.
 	auto *optSurface = SDL_ConvertSurface(unOptSurface, this->format, 0);
@@ -150,6 +214,119 @@ SDL_Surface *TextureManager::loadFromFile(const std::string &fullPath)
 		"Could not optimize texture \"" + fullPath + "\".");
 
 	return optSurface;
+}
+
+SDL_Surface* TextureManager::loadImgFile(const std::string& fullPath)
+{
+    VFS::IStreamPtr stream = VFS::Manager::get().open(fullPath.c_str());
+    Debug::check(stream != nullptr, "Texture Manager",
+        "Could not open texture \"" + fullPath + "\".");
+
+    std::array<uint8_t,12> imghdr;
+    stream->read(reinterpret_cast<char*>(imghdr.data()), imghdr.size());
+    Debug::check(stream->gcount() == imghdr.size(), "Texture Manager",
+        "Could not read texture \"" + fullPath + "\" header.");
+
+    uint16_t xoff = getLE16(imghdr.data());
+    uint16_t yoff = getLE16(imghdr.data()+2);
+    uint16_t width = getLE16(imghdr.data()+4);
+    uint16_t height = getLE16(imghdr.data()+6);
+    uint16_t flags = getLE16(imghdr.data()+8);
+    uint16_t srclen = getLE16(imghdr.data()+10);
+
+    std::vector<uint8_t> srcdata(srclen);
+    stream->read(reinterpret_cast<char*>(srcdata.data()), srcdata.size());
+    Debug::check(stream->gcount() == srcdata.size(), "Texture Manager",
+        "Could not read texture \"" + fullPath + "\" data.");
+
+    Palette custompal;
+    if(flags & 0x0100)
+    {
+        std::array<uint8_t,768> rawpal;
+
+        stream->read(reinterpret_cast<char*>(rawpal.data()), rawpal.size());
+        Debug::check(stream->gcount() == rawpal.size(), "Texture Manager",
+            "Could not read texture \"" + fullPath + "\" palette.");
+
+        auto iter = rawpal.begin();
+        /* Unlike COL files, embedded palettes are stored with components in
+         * the range of 0...63 rather than 0...255 (this was because old VGA
+         * hardware only had 6-bit DACs, giving a maximum intensity value of
+         * 63, while newer hardware had 8-bit DACs for up to 255.
+         */
+        uint8_t r = std::min<uint8_t>(*(iter++), 63) * 255 / 63;
+        uint8_t g = std::min<uint8_t>(*(iter++), 63) * 255 / 63;
+        uint8_t b = std::min<uint8_t>(*(iter++), 63) * 255 / 63;
+        custompal[0] = Color(r, g, b, 0);
+        /* Remaining are solid, so give them 255 alpha. */
+        std::generate(custompal.begin()+1, custompal.end(),
+            [&iter]() -> Color
+            {
+                uint8_t r = std::min<uint8_t>(*(iter++), 63) * 255 / 63;
+                uint8_t g = std::min<uint8_t>(*(iter++), 63) * 255 / 63;
+                uint8_t b = std::min<uint8_t>(*(iter++), 63) * 255 / 63;
+                return {r, g, b, 255};
+            }
+        );
+    }
+
+    const Palette &palette = (flags&0x0100) ? custompal : DefaultPalette;
+    if((flags&0x00ff) == 0x0000)
+    {
+        // Uncompressed
+        assert(srcdata.size() == width*height);
+
+        // Create temporary ARGB surface
+        SDL_Surface *surface = SDL_CreateRGBSurface(
+            0, width, height, 32, 0x00ff0000, 0x0000ff00, 0x000000ff, 0xff000000
+        );
+        if(SDL_LockSurface(surface) == 0)
+        {
+            uint32_t *pixels = static_cast<uint32_t*>(surface->pixels);
+            std::transform(srcdata.begin(), srcdata.end(), pixels,
+                [&palette](uint8_t col) -> uint32_t
+                {
+                    return palette[col].toARGB();
+                }
+            );
+            SDL_UnlockSurface(surface);
+        }
+
+        auto *optSurface = SDL_ConvertSurface(surface, this->format, 0);
+        SDL_FreeSurface(surface);
+
+        return optSurface;
+    }
+    if((flags&0x00ff) == 0x0004)
+    {
+        // Type 4 compression
+        std::vector<uint8_t> decomp(width*height);
+        decode04Type(srcdata.begin(), srcdata.end(), decomp);
+
+        // Create temporary ARGB surface
+        SDL_Surface *surface = SDL_CreateRGBSurface(
+            0, width, height, 32, 0x00ff0000, 0x0000ff00, 0x000000ff, 0xff000000
+        );
+        if(SDL_LockSurface(surface) == 0)
+        {
+            uint32_t *pixels = static_cast<uint32_t*>(surface->pixels);
+            std::transform(decomp.begin(), decomp.end(), pixels,
+                [&palette](uint8_t col) -> uint32_t
+                {
+                    return palette[col].toARGB();
+                }
+            );
+            SDL_UnlockSurface(surface);
+        }
+
+        auto *optSurface = SDL_ConvertSurface(surface, this->format, 0);
+        SDL_FreeSurface(surface);
+
+        return optSurface;
+    }
+
+    Debug::crash("Texture Manager", "Unhandled IMG flags, 0x"+to_hexstring(flags)+".");
+    return nullptr;
 }
 
 const SDL_PixelFormat *TextureManager::getFormat() const
@@ -165,6 +342,19 @@ const Surface &TextureManager::getSurface(const std::string &filename)
 		const auto &surface = this->surfaces.at(filename);
 		return surface;
 	}
+	auto dot = filename.rfind('.');
+    if(dot != std::string::npos && filename.compare(dot, filename.length()-dot, ".IMG") == 0)
+    {
+        auto *optSurface = this->loadImgFile(filename);
+
+        // Create surface from SDL_Surface. No need to optimize it again.
+        Surface surface(optSurface);
+
+        // Add the new texture.
+        auto iter = this->surfaces.insert(std::make_pair(filename, surface)).first;
+        SDL_FreeSurface(optSurface);
+        return iter->second;
+    }
 	else
 	{
 		// Load optimized SDL_Surface from file.

--- a/OpenTESArena/src/Media/TextureManager.h
+++ b/OpenTESArena/src/Media/TextureManager.h
@@ -26,7 +26,8 @@ private:
 	std::map<std::string, Surface> surfaces;
 	const SDL_PixelFormat *format;
 
-	SDL_Surface *loadFromFile(const std::string &fullPath);
+    SDL_Surface *loadFromFile(const std::string &fullPath);
+	SDL_Surface *loadImgFile(const std::string &fullPath);
 public:
 	TextureManager(const SDL_PixelFormat *format);
 	~TextureManager();


### PR DESCRIPTION
Currently supports only uncompressed and "type-4" compression. IMG files that
use "type-8" compression, or which are actually "headerless"/raw, are currently
unsupported.

Also note that due to the original game using 8-bit color, the correct palette
needs to be used for conversion. Some IMG files contain their own palette, but
otherwise the correct palette needs to be selected when loading it (which
currently only the default PAL.COL palette is used; the others are DREARY.COL,
DAYTIME.COL, and CHARSHT.COL).