### PR TITLE
Handle more IMG files

### DIFF
--- a/OpenTESArena/src/Media/TextureFile.cpp
+++ b/OpenTESArena/src/Media/TextureFile.cpp
@@ -12,17 +12,17 @@ const std::map<TextureName, std::string> TextureFilenames =
 	// Interface.
 	{ TextureName::CharacterCreation, "interface/character_creation" },
 	{ TextureName::CompassFrame, "COMPASS.IMG" },
-	{ TextureName::CompassSlider, "interface/compass_slider" }, // SLIDER.IMG
+	{ TextureName::CompassSlider, "SLIDER.IMG" },
 	{ TextureName::Icon, "interface/icon" },
 	{ TextureName::IntroTitle, "TITLE.IMG" },
-	{ TextureName::IntroQuote, "interface/intro_quote" }, // QUOTE.IMG?
-	{ TextureName::MainMenu, "interface/main_menu" },
+	{ TextureName::IntroQuote, "QUOTE.IMG" },
+	{ TextureName::MainMenu, "MENU.IMG" },
 	{ TextureName::ParchmentPopup, "interface/parchment/parchment_popup" },
 	{ TextureName::PopUp11, "POPUP11.IMG" }, // POPUP2 or POPUP8 should be what ChooseClassPanel uses.
-	{ TextureName::QuillCursor, "interface/pointer" }, // POINTER.IMG
-	{ TextureName::SwordCursor, "interface/arenarw" }, // ARENARW.IMG
-	{ TextureName::UpDown, "interface/up_down" },
-	{ TextureName::WorldMap, "interface/world_map" },
+	{ TextureName::QuillCursor, "POINTER.IMG" },
+	{ TextureName::SwordCursor, "ARENARW.IMG" },
+	{ TextureName::UpDown, "UPDOWN.IMG" },
+	{ TextureName::WorldMap, "TAMRIEL.IMG" },
 
 	// Fonts.
 	{ TextureName::FontA, "fonts/font_a" },


### PR DESCRIPTION
Also replaces some texture file references to Arena's. I'm not sure where ```interface/parchment/parchment_popup``` comes from, though. And ```TAMRIEL.IMG``` is either not 100% correct for the race select screen, or it's supposed to use palette trickery to hide the yellow dots (we'd need to load a separate version that overrides its built-in palette for conversion), but it's good enough.