### PR TITLE
Set image decoder history values to palette index 32

### DIFF
--- a/OpenTESArena/src/Interface/Panel.cpp
+++ b/OpenTESArena/src/Interface/Panel.cpp
@@ -87,8 +87,7 @@ std::unique_ptr<Panel> Panel::defaultPanel(GameState *gameState)
 	};
 
 	return std::unique_ptr<Panel>(new CinematicPanel(gameState,
-		TextureSequenceName::IntroBook,
-		CinematicPanel::DEFAULT_MOVIE_SECONDS_PER_IMAGE,
+		TextureSequenceName::IntroBook, 0.142 /* roughly 7fps */,
 		changeToTitle));
 }
 

--- a/OpenTESArena/src/Media/TextureManager.cpp
+++ b/OpenTESArena/src/Media/TextureManager.cpp
@@ -54,7 +54,7 @@ namespace
 		auto dst = out.begin();
 
 		std::array<uint8_t, 4096> history;
-		std::fill(history.begin(), history.end(), 0);
+		std::fill(history.begin(), history.end(), 0x20);
 		int historypos = 0;
 
 		// This appears to be some form of LZ compression. It starts with a 1-byte-
@@ -148,7 +148,7 @@ namespace
         };
 
         std::array<uint8_t, 4096> history;
-        std::fill(history.begin(), history.end(), 0);
+        std::fill(history.begin(), history.end(), 0x20);
         int historypos = 0;
 
         std::array<uint16_t,941> NodeIdxMap;


### PR DESCRIPTION
Also fix the IntroBook playback speed to match the source video.