### PR TITLE
Fix problems in the OpenCL find script

### DIFF
--- a/cmake/FindOpenCL.cmake
+++ b/cmake/FindOpenCL.cmake
@@ -38,7 +38,7 @@ function(_FIND_OPENCL_VERSION)
   set(CMAKE_REQUIRED_QUIET ${OpenCL_FIND_QUIETLY})
 
   CMAKE_PUSH_CHECK_STATE()
-  foreach(VERSION "2_0" "1_2" "1_1" "1_0")
+  foreach(VERSION "1_2" "1_1" "1_0")
     set(CMAKE_REQUIRED_INCLUDES "${OpenCL_INCLUDE_DIR}")
 
     if(APPLE)
@@ -90,42 +90,29 @@ find_path(OpenCL_INCLUDE_DIR
 
 _FIND_OPENCL_VERSION()
 
-if(WIN32)
-  if(CMAKE_SIZEOF_VOID_P EQUAL 4)
-    find_library(OpenCL_LIBRARY
-      NAMES OpenCL
-      PATHS
-        ENV "PROGRAMFILES(X86)"
-        ENV AMDAPPSDKROOT
-        ENV INTELOCLSDKROOT
-        ENV CUDA_PATH
-        ENV NVSDKCOMPUTE_ROOT
-        ENV ATISTREAMSDKROOT
-      PATH_SUFFIXES
-        "AMD APP/lib/x86"
-        lib/x86
-        lib/Win32
-        OpenCL/common/lib/Win32)
-  elseif(CMAKE_SIZEOF_VOID_P EQUAL 8)
-    find_library(OpenCL_LIBRARY
-      NAMES OpenCL
-      PATHS
-        ENV "PROGRAMFILES(X86)"
-        ENV AMDAPPSDKROOT
-        ENV INTELOCLSDKROOT
-        ENV CUDA_PATH
-        ENV NVSDKCOMPUTE_ROOT
-        ENV ATISTREAMSDKROOT
-      PATH_SUFFIXES
-        "AMD APP/lib/x86_64"
-        lib/x86_64
-        lib/x64
-        OpenCL/common/lib/x64)
-  endif()
-else()
-  find_library(OpenCL_LIBRARY
-    NAMES OpenCL)
-endif()
+# We add a library suffix because some OpenCL packages won't provide a softlink without any, like: http://packages.ubuntu.com/trusty/amd64/nvidia-libopencl1-331/filelist
+# So hopefully .so.1 matches those cases
+list(APPEND CMAKE_FIND_LIBRARY_SUFFIXES .so.1)
+
+# We just search the directory prefixes regardless of architecture; really only the proper one should ever appear anyway and otherwise it can easily be overridden in cmake-gui
+find_library(OpenCL_LIBRARY
+  NAMES OpenCL
+  PATHS
+    ENV "PROGRAMFILES(X86)"
+    ENV "PROGRAMFILES(X86)"
+    ENV AMDAPPSDKROOT
+    ENV INTELOCLSDKROOT
+    ENV CUDA_PATH
+    ENV NVSDKCOMPUTE_ROOT
+    ENV ATISTREAMSDKROOT
+  PATH_SUFFIXES
+    "AMD APP/lib/x86"
+    lib/x86
+    lib/Win32
+
+    /usr/lib/x86_64-linux-gnu
+    /usr/lib/i386-linux-gnu
+    OpenCL/common/lib/Win32)
 
 set(OpenCL_LIBRARIES ${OpenCL_LIBRARY})
 set(OpenCL_INCLUDE_DIRS ${OpenCL_INCLUDE_DIR})

--- a/cmake/FindOpenCL.cmake
+++ b/cmake/FindOpenCL.cmake
@@ -75,7 +75,7 @@ endfunction()
 
 find_path(OpenCL_INCLUDE_DIR
   NAMES
-    CL/cl.h OpenCL/cl.h
+    cl.h
   PATHS
     ENV "PROGRAMFILES(X86)"
     ENV AMDAPPSDKROOT
@@ -83,6 +83,8 @@ find_path(OpenCL_INCLUDE_DIR
     ENV NVSDKCOMPUTE_ROOT
     ENV CUDA_PATH
     ENV ATISTREAMSDKROOT
+    
+    /usr/include/CL
   PATH_SUFFIXES
     include
     OpenCL/common/inc
@@ -93,7 +95,7 @@ _FIND_OPENCL_VERSION()
 # Once we have a working include directory, try looking specifically for cl2.hpp
 find_path(OpenCL_CL2_INCLUDE_DIR
   NAMES
-    CL/cl2.hpp OpenCL/cl2.hpp
+    cl2.hpp cl2.hpp
   PATHS
     ENV "PROGRAMFILES(X86)"
     ENV AMDAPPSDKROOT
@@ -101,6 +103,9 @@ find_path(OpenCL_CL2_INCLUDE_DIR
     ENV NVSDKCOMPUTE_ROOT
     ENV CUDA_PATH
     ENV ATISTREAMSDKROOT
+    
+    /usr/include/CL
+    ${OpenCL_INCLUDE_DIR}
   PATH_SUFFIXES
     include
     OpenCL/common/inc
@@ -121,13 +126,14 @@ find_library(OpenCL_LIBRARY
     ENV CUDA_PATH
     ENV NVSDKCOMPUTE_ROOT
     ENV ATISTREAMSDKROOT
+    
+    /usr/lib/x86_64-linux-gnu
+    /usr/lib/i386-linux-gnu
   PATH_SUFFIXES
     "AMD APP/lib/x86"
     lib/x86
     lib/Win32
 
-    /usr/lib/x86_64-linux-gnu
-    /usr/lib/i386-linux-gnu
     OpenCL/common/lib/Win32)
 
 set(OpenCL_LIBRARIES ${OpenCL_LIBRARY})
@@ -144,4 +150,5 @@ find_package_handle_standard_args(
 
 mark_as_advanced(
   OpenCL_INCLUDE_DIR
+  OpenCL_CL2_INCLUDE_DIR
   OpenCL_LIBRARY)

--- a/cmake/FindOpenCL.cmake
+++ b/cmake/FindOpenCL.cmake
@@ -87,9 +87,25 @@ find_path(OpenCL_INCLUDE_DIR
     include
     OpenCL/common/inc
     "AMD APP/include")
-
+    
 _FIND_OPENCL_VERSION()
 
+# Once we have a working include directory, try looking specifically for cl2.hpp
+find_path(OpenCL_CL2_INCLUDE_DIR
+  NAMES
+    CL/cl2.hpp OpenCL/cl2.hpp
+  PATHS
+    ENV "PROGRAMFILES(X86)"
+    ENV AMDAPPSDKROOT
+    ENV INTELOCLSDKROOT
+    ENV NVSDKCOMPUTE_ROOT
+    ENV CUDA_PATH
+    ENV ATISTREAMSDKROOT
+  PATH_SUFFIXES
+    include
+    OpenCL/common/inc
+    "AMD APP/include")
+    
 # We add a library suffix because some OpenCL packages won't provide a softlink without any, like: http://packages.ubuntu.com/trusty/amd64/nvidia-libopencl1-331/filelist
 # So hopefully .so.1 matches those cases
 list(APPEND CMAKE_FIND_LIBRARY_SUFFIXES .so.1)
@@ -123,7 +139,7 @@ include(FindPackageHandleStandardArgs)
 # at a later date.
 find_package_handle_standard_args(
   OpenCL
-  REQUIRED_VARS OpenCL_LIBRARY OpenCL_INCLUDE_DIR
+  REQUIRED_VARS OpenCL_LIBRARY OpenCL_INCLUDE_DIR OpenCL_CL2_INCLUDE_DIR
   VERSION_VAR OpenCL_VERSION_STRING)
 
 mark_as_advanced(


### PR DESCRIPTION
1. Removes OpenCL 2.0 from the search test
2. Simplifies the library search (we don't really need to search based on machine architecture)
3. Add a few extra possible search directories: /usr/lib/x86_64-linux-gnu and /usr/lib/i386-linux-gnu
4. Add .so.1 as a possible file suffix for libOpenCL because packages might not install libraries that have a softlink or library without the suffix, like: http://packages.ubuntu.com/trusty/amd64/nvidia-libopencl1-331/filelist
5. Search specifically for cl2.hpp and fail if it can't be found, also allow the directory for it to be specified if it's not found in the OpenCL install (so we can store it elsewhere)
6. Fixes the way include files are searched for (we really only want to know the root of where the  includes are, but searches within the bigger SDK's may be broken without the prefix, but I don't know what they typically look like right now either)

This should make the CMake script work more reliably, as it failed completely to find the library file if you're using something like the package above to provide libOpenCL (as it never searches /usr/libx86_64-linux-gnu or /usr/lib/i386-linux-gnu). Also it specifically checks for cl2.hpp to prevent further hear ripping when builds fail because you have regular OpenCL but not the C++ bindings from here (the file works, just needs renamed): https://github.com/KhronosGroup/OpenCL-CLHPP/blob/master/input_cl2.hpp

Not sure if any package provides cl2.hpp, but it definitely didn't come by default in the package I linked above and it can easily be yanked from that Github URL.

Also, the version checking is totally pointless right now as none of the scripts really make use of it. We can export version data to C++ visible defines for conditional compilation of OpenCL code, but right now it's totally unused.