### PR TITLE
Correct the find OpenCL for both cases

### DIFF
--- a/cmake/FindOpenCL.cmake
+++ b/cmake/FindOpenCL.cmake
@@ -75,7 +75,7 @@ endfunction()
 
 find_path(OpenCL_INCLUDE_DIR
   NAMES
-    cl.h cl.h
+    cl.h
   PATHS
     ENV "PROGRAMFILES(X86)"
     ENV AMDAPPSDKROOT

--- a/cmake/FindOpenCL.cmake
+++ b/cmake/FindOpenCL.cmake
@@ -75,7 +75,7 @@ endfunction()
 
 find_path(OpenCL_INCLUDE_DIR
   NAMES
-    CL/cl.h OpenCL/cl.h
+    cl.h cl.h
   PATHS
     ENV "PROGRAMFILES(X86)"
     ENV AMDAPPSDKROOT
@@ -84,9 +84,12 @@ find_path(OpenCL_INCLUDE_DIR
     ENV CUDA_PATH
     ENV ATISTREAMSDKROOT
     
+    /usr/include/CL
+    /usr/include/OpenCL
   PATH_SUFFIXES
     include
     OpenCL/common/inc
+    OpenCL
     "AMD APP/include")
     
 _FIND_OPENCL_VERSION()


### PR DESCRIPTION
This should make the FindOpenCL script work in my situation and the one in the Travis CI. Basically just shotgunned it because I still have no real idea what the SDK folder structure looks like, but from the discussion in #46 it seems to line up with what I added here.