### PR TITLE
Build and install WildMIDI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,11 @@ before_install:
 - sudo mv cl2.hpp /usr/include/CL/
 - sudo apt-get install wildmidi
 
+install:
+  - wget https://github.com/Mindwerks/wildmidi/archive/wildmidi-0.4.0.tar.gz
+  - tar -xzvf wildmidi-0.4.0.tar.gz
+  - pushd wildmidi-wildmidi-0.4.0 && mkdir build && pushd build && cmake .. && make && sudo make install && popd && popd
+
 script:
 - mkdir build
 - cd build


### PR DESCRIPTION
Previously I'd been trying to install the package wildmidi. I think this was not detected because it didn't have wildmidi_lib.h. See http://packages.ubuntu.com/en/trusty/i386/wildmidi/filelist.

Package libwildmidi-dev, http://packages.ubuntu.com/en/trusty/i386/libwildmidi-dev/filelist, was detected but had errors. I think it may be too old of a version or something.

So, I built WildMIDI from the 0.40.0 source linked on the OpenTESArena front page using this as a guide:
https://docs.travis-ci.com/user/installing-dependencies/

They recommend building dependencies in shell scripts called from the .travis.yml file, but I think it's fine as it is for now. If the setup gets longer and more complicated it could be moved out to a shell script, or of course you could do so now if you like.
