### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,14 @@ os: linux
 compiler: gcc
 group: stable
 
-before_install:    
+before_install:
+  - sudo apt-get install mercurial
+  - hg clone http://hg.libsdl.org/SDL -r release-2.0.5
+  - mkdir SDL/out
+  - cd SDL/out
+  - cmake .. -DVIDEO_MIR=0
+  - make && sudo make install
+  - cd ../../
   - sudo apt-get install libsdl2-dev
   - sudo apt-get install libsdl2-image-dev
   - sudo apt-get install libopenal-dev


### PR DESCRIPTION
Package repos will be lagging behind on SDL 2.0.5 for a while (as we now require some functionality specific to 2.0.5 in TESArena now), so we clone via mercurial the 2.0.5 release and build it.  It should work, but we won't fully know until we merge and have Travis test within its environment. 

This is why the last Travis build failed -- we pulled SDL2 from repos which pulled down some version < 2.0.5 which will not include the functionality that was recently depended upon.