### PR TITLE
Fix EOL check in text parsers

### DIFF
--- a/OpenTESArena/src/Entities/CharacterClassParser.cpp
+++ b/OpenTESArena/src/Entities/CharacterClassParser.cpp
@@ -91,12 +91,13 @@ std::vector<std::unique_ptr<CharacterClass>> CharacterClassParser::parse()
 	// For each line, get the substrings between commas.
 	while (std::getline(iss, line))
 	{
-		const char &firstColumn = line.at(0);
-
 		// Ignore comments and blank lines.
+		if (line.length() == 0)
+			continue;
+
+		const char &firstColumn = line.at(0);
 		if ((firstColumn == comment) ||
-			(firstColumn == '\r') ||
-			(firstColumn == '\n'))
+		    (firstColumn == '\r'))
 		{
 			continue;
 		}
@@ -175,7 +176,7 @@ std::vector<std::unique_ptr<CharacterClass>> CharacterClassParser::parse()
 		// Get the set of weapons (read until the end of the line).
 		index += 2;
 		oldIndex = index;
-		while ((line.at(index) != '\r') && (line.at(index) != '\n'))
+		while ((index < line.length()) && (line.at(index) != '\r'))
 		{
 			++index;
 		}

--- a/OpenTESArena/src/Utilities/KvpTextMap.cpp
+++ b/OpenTESArena/src/Utilities/KvpTextMap.cpp
@@ -28,10 +28,12 @@ KvpTextMap::KvpTextMap(const std::string &filename)
 	while (std::getline(iss, line))
 	{
 		// Ignore comments and blank lines.
+		if (line.length() == 0)
+			continue;
+
 		const char firstChar = line.at(0);
 		if ((firstChar == KvpTextMap::COMMENT) ||
-			(firstChar == '\r') ||
-			(firstChar == '\n'))
+		    (firstChar == '\r'))
 		{
 			continue;
 		}


### PR DESCRIPTION
The default behavior of `getline` is to get the next line without the
EOL symbol(s). Hence, `line.at(0)` should in theory always throw an
exception for an empty line, since there would be no characters in the
string.

However, this doesn't happen on Windows. The EOL sequence on Windows
is '\r' '\n', but `getline` uses just '\n' as a delimiter, resulting
in '\r' being left in the string, hence making the code work.

The code doesn't work if the EOL sequence of the text files is just
LF. This fix should solve that, while still keeping the code
compatible with CRLF endings on Windows. Checking for '\n' is now
redundant.