### PR TITLE
Address some warnings from CPPCheck

### DIFF
--- a/OpenTESArena/src/Assets/Compression.h
+++ b/OpenTESArena/src/Assets/Compression.h
@@ -19,7 +19,7 @@ class Compression
 	~Compression() = delete;
 public:
 	// Uncompresses an RLE run of bytes.
-	static void decodeRLE(const uint8_t *src, uint32_t count, 
+	static void decodeRLE(const uint8_t *src, uint32_t stopCount,
 		std::vector<uint8_t> &out);
 
 	// Works with .IMG and .CIF type 4 files.

--- a/OpenTESArena/src/Entities/Camera3D.cpp
+++ b/OpenTESArena/src/Entities/Camera3D.cpp
@@ -7,10 +7,9 @@
 #include "../Math/Quaternion.h"
 
 Camera3D::Camera3D(const Double3 &position, const Double3 &direction)
-	: position(position), forward(direction)
+	: forward(direction), right(forward.cross(Double3::UnitY).normalized()),
+	up(right.cross(forward).normalized()), position(position)
 {
-	this->right = this->forward.cross(Double3::UnitY).normalized();
-	this->up = this->right.cross(this->forward).normalized();
 }
 
 const Double3 &Camera3D::getDirection() const

--- a/OpenTESArena/src/Entities/Doodad.cpp
+++ b/OpenTESArena/src/Entities/Doodad.cpp
@@ -2,9 +2,9 @@
 
 #include "EntityType.h"
 
-Doodad::Doodad(const Double3 &position, const Animation &animation,
+Doodad::Doodad(const Animation &animation, const Double3 &position,
 	EntityManager &entityManager)
-	: Entity(entityManager), position(position), animation(animation) { }
+	: Entity(entityManager), animation(animation), position(position) { }
 
 Doodad::~Doodad()
 {
@@ -14,7 +14,7 @@ Doodad::~Doodad()
 std::unique_ptr<Entity> Doodad::clone(EntityManager &entityManager) const
 {
 	return std::unique_ptr<Doodad>(new Doodad(
-		this->position, this->animation, entityManager));
+		this->animation, this->position, entityManager));
 }
 
 EntityType Doodad::getEntityType() const

--- a/OpenTESArena/src/Entities/Doodad.h
+++ b/OpenTESArena/src/Entities/Doodad.h
@@ -15,7 +15,7 @@ private:
 	Animation animation;
 	Double3 position;
 public:
-	Doodad(const Double3 &position, const Animation &animation,
+	Doodad(const Animation &animation, const Double3 &position,
 		EntityManager &entityManager);
 	virtual ~Doodad();
 

--- a/OpenTESArena/src/Entities/NonPlayer.cpp
+++ b/OpenTESArena/src/Entities/NonPlayer.cpp
@@ -8,9 +8,9 @@ NonPlayer::NonPlayer(const Double3 &position, const Double2 &direction,
 	const std::vector<Animation> &moveAnimations,
 	const Animation &attackAnimation, const Animation &deathAnimation, 
 	EntityManager &entityManager)
-	: Entity(entityManager), camera(position, direction), velocity(0.0, 0.0),
-	idleAnimations(idleAnimations), moveAnimations(moveAnimations), 
-	attackAnimation(attackAnimation), deathAnimation(deathAnimation) { }
+	: Entity(entityManager), idleAnimations(idleAnimations), moveAnimations(moveAnimations),
+	attackAnimation(attackAnimation), deathAnimation(deathAnimation),
+	camera(position, direction), velocity(0.0, 0.0) { }
 
 NonPlayer::~NonPlayer()
 {

--- a/OpenTESArena/src/Entities/Player.cpp
+++ b/OpenTESArena/src/Entities/Player.cpp
@@ -15,16 +15,10 @@ Player::Player(const std::string &displayName, GenderName gender, int raceID,
 	const CharacterClass &charClass, int portraitID, const Double3 &position, 
 	const Double3 &direction, const Double3 &velocity, double maxWalkSpeed, 
 	double maxRunSpeed)
-	: charClass(charClass), displayName(displayName), camera(position, direction), 
-	velocity(velocity), weaponAnimation(WeaponType::Fists /* Placeholder for now. */) 
+	: displayName(displayName), gender(gender), raceID(raceID), charClass(charClass), portraitID(portraitID), camera(position, direction),
+	velocity(velocity), maxWalkSpeed(maxWalkSpeed), maxRunSpeed(maxRunSpeed), weaponAnimation(WeaponType::Fists /* Placeholder for now. */)
 {
 	assert(portraitID >= 0);
-
-	this->maxWalkSpeed = maxWalkSpeed;
-	this->maxRunSpeed = maxRunSpeed;
-	this->gender = gender;
-	this->raceID = raceID;
-	this->portraitID = portraitID;
 }
 
 Player::~Player()

--- a/OpenTESArena/src/Entities/Player.h
+++ b/OpenTESArena/src/Entities/Player.h
@@ -12,15 +12,15 @@ enum class GenderName;
 class Player
 {
 private:
-	CharacterClass charClass;
-	Camera3D camera;
-	WeaponAnimation weaponAnimation;
-	Double3 velocity;
-	double maxWalkSpeed, maxRunSpeed; // Eventually a function of 'Speed'.
+	std::string displayName;
 	GenderName gender;
 	int raceID;
-	std::string displayName;
+	CharacterClass charClass;
 	int portraitID;
+	Camera3D camera;
+	Double3 velocity;
+	double maxWalkSpeed, maxRunSpeed; // Eventually a function of 'Speed'.
+	WeaponAnimation weaponAnimation;
 	// Other stats...
 public:
 	Player(const std::string &displayName, GenderName gender, int raceID,

--- a/OpenTESArena/src/Game/GameData.cpp
+++ b/OpenTESArena/src/Game/GameData.cpp
@@ -459,7 +459,7 @@ std::unique_ptr<GameData> GameData::createDefault(const std::string &playerName,
 		const double timePerFrame = 0.10;
 		Animation animation(textureIDs, timePerFrame, true);
 
-		std::unique_ptr<Doodad> doodad(new Doodad(position, animation, entityManager));
+		std::unique_ptr<Doodad> doodad(new Doodad(animation, position, entityManager));
 
 		// Assign the entity ID with the first texture.
 		renderer.addFlat(doodad->getID(), position, Double2::UnitX, 

--- a/OpenTESArena/src/Game/Options.cpp
+++ b/OpenTESArena/src/Game/Options.cpp
@@ -11,12 +11,12 @@ const double Options::MAX_RESOLUTION_SCALE = 1.0;
 const double Options::MIN_VERTICAL_FOV = 40.0;
 const double Options::MAX_VERTICAL_FOV = 150.0;
 
-Options::Options(std::string &&dataPath, int screenWidth, int screenHeight, bool fullscreen,
+Options::Options(std::string &&arenaPath, int screenWidth, int screenHeight, bool fullscreen,
 	int targetFPS, double resolutionScale, double verticalFOV, double letterboxAspect,
 	double cursorScale, double hSensitivity, double vSensitivity, std::string &&soundfont,
 	double musicVolume, double soundVolume, int soundChannels, bool skipIntro,
 	PlayerInterface playerInterface)
-	: arenaPath(std::move(dataPath)), soundfont(std::move(soundfont))
+	: arenaPath(std::move(arenaPath)), soundfont(std::move(soundfont))
 {
 	// Make sure each of the values is in a valid range.
 	Debug::check(screenWidth > 0, "Options", "Screen width must be positive.");

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
@@ -36,7 +36,7 @@
 ChooseAttributesPanel::ChooseAttributesPanel(Game *game,
 	const CharacterClass &charClass, const std::string &name, 
 	GenderName gender, int raceID)
-	: Panel(game), headOffsets(), gender(gender), charClass(charClass), name(name)
+	: Panel(game), headOffsets(), charClass(charClass), gender(gender), name(name)
 {
 	this->nameTextBox = [game, name]()
 	{

--- a/OpenTESArena/src/Interface/ChooseClassPanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseClassPanel.cpp
@@ -220,7 +220,6 @@ void ChooseClassPanel::handleEvent(const SDL_Event &e)
 
 std::string ChooseClassPanel::getClassArmors(const CharacterClass &characterClass) const
 {
-	int lengthCounter = 0;
 	const int armorCount = static_cast<int>(characterClass.getAllowedArmors().size());
 
 	// Sort as they are listed in the CharacterClassParser.
@@ -239,6 +238,7 @@ std::string ChooseClassPanel::getClassArmors(const CharacterClass &characterClas
 		// Collect all allowed armor display names for the class.
 		for (int i = 0; i < armorCount; ++i)
 		{
+			int lengthCounter = 0;
 			const auto materialType = allowedArmors.at(i);
 			auto materialString = ArmorMaterial::typeToString(materialType);
 			lengthCounter += static_cast<int>(materialString.size());
@@ -266,7 +266,6 @@ std::string ChooseClassPanel::getClassArmors(const CharacterClass &characterClas
 
 std::string ChooseClassPanel::getClassShields(const CharacterClass &characterClass) const
 {
-	int lengthCounter = 0;
 	const int shieldCount = static_cast<int>(characterClass.getAllowedShields().size());
 
 	// Sort as they are listed in the CharacterClassParser.
@@ -285,6 +284,7 @@ std::string ChooseClassPanel::getClassShields(const CharacterClass &characterCla
 		// Collect all allowed shield display names for the class.
 		for (int i = 0; i < shieldCount; ++i)
 		{
+			int lengthCounter = 0;
 			const auto shieldType = allowedShields.at(i);
 			auto dummyMetal = MetalType::Iron;
 			auto typeString = Shield(shieldType, dummyMetal).typeToString();
@@ -313,7 +313,6 @@ std::string ChooseClassPanel::getClassShields(const CharacterClass &characterCla
 
 std::string ChooseClassPanel::getClassWeapons(const CharacterClass &characterClass) const
 {
-	int lengthCounter = 0;
 	const int weaponCount = static_cast<int>(characterClass.getAllowedWeapons().size());
 
 	// Sort as they are listed in the CharacterClassParser.
@@ -333,6 +332,7 @@ std::string ChooseClassPanel::getClassWeapons(const CharacterClass &characterCla
 		// Collect all allowed weapon display names for the class.
 		for (int i = 0; i < weaponCount; ++i)
 		{
+			int lengthCounter = 0;
 			const auto weaponType = allowedWeapons.at(i);
 			const auto dummyMetal = MetalType::Iron;
 			auto typeString = Weapon(weaponType, dummyMetal).typeToString();

--- a/OpenTESArena/src/Interface/CinematicPanel.cpp
+++ b/OpenTESArena/src/Interface/CinematicPanel.cpp
@@ -10,7 +10,7 @@
 #include "../Rendering/Texture.h"
 
 CinematicPanel::CinematicPanel(Game *game,
-	const std::string &sequenceName, const std::string &paletteName,
+	const std::string &paletteName, const std::string &sequenceName,
 	double secondsPerImage, const std::function<void(Game*)> &endingAction)
 	: Panel(game), paletteName(paletteName), sequenceName(sequenceName)
 {

--- a/OpenTESArena/src/Interface/MainMenuPanel.cpp
+++ b/OpenTESArena/src/Interface/MainMenuPanel.cpp
@@ -88,8 +88,8 @@ MainMenuPanel::MainMenuPanel(Game *game)
 
 			std::unique_ptr<Panel> cinematicPanel(new CinematicPanel(
 				game,
-				TextureFile::fromName(TextureSequenceName::OpeningScroll),
 				PaletteFile::fromName(PaletteName::Default),
+				TextureFile::fromName(TextureSequenceName::OpeningScroll),
 				0.042,
 				changeToNewGameStory));
 			game->setPanel(std::move(cinematicPanel));

--- a/OpenTESArena/src/Interface/Panel.cpp
+++ b/OpenTESArena/src/Interface/Panel.cpp
@@ -121,8 +121,8 @@ std::unique_ptr<Panel> Panel::defaultPanel(Game *game)
 	{
 		std::unique_ptr<Panel> scrollingPanel(new CinematicPanel(
 			game,
-			TextureFile::fromName(TextureSequenceName::OpeningScroll),
 			PaletteFile::fromName(PaletteName::Default),
+			TextureFile::fromName(TextureSequenceName::OpeningScroll),
 			0.042,
 			changeToIntroStory));
 		game->setPanel(std::move(scrollingPanel));
@@ -162,8 +162,8 @@ std::unique_ptr<Panel> Panel::defaultPanel(Game *game)
 	{
 		std::unique_ptr<Panel> introBook(new CinematicPanel(
 			game,
-			TextureFile::fromName(TextureSequenceName::IntroBook),
 			PaletteFile::fromName(PaletteName::Default),
+			TextureFile::fromName(TextureSequenceName::IntroBook),
 			0.142, // Roughly 7 fps.
 			changeToTitle));
 		return std::move(introBook);

--- a/OpenTESArena/src/Media/TextureManager.h
+++ b/OpenTESArena/src/Media/TextureManager.h
@@ -19,6 +19,7 @@ struct SDL_Surface;
 class TextureManager
 {
 private:
+	Renderer &renderer;
 	std::unordered_map<std::string, Palette> palettes;
 
 	// The filename and palette name are concatenated when mapping to avoid using two 
@@ -27,7 +28,6 @@ private:
 	std::unordered_map<std::string, Texture> textures;
 	std::unordered_map<std::string, std::vector<SDL_Surface*>> surfaceSets;
 	std::unordered_map<std::string, std::vector<Texture>> textureSets;
-	Renderer &renderer;
 	std::string activePalette;
 
 	// Specialty method for loading a COL file into the palettes map.

--- a/OpenTESArena/src/Media/TextureManager.h
+++ b/OpenTESArena/src/Media/TextureManager.h
@@ -70,7 +70,7 @@ public:
 	// Sets the palette to use for subsequent images. The source of the palette can be
 	// from a loose .COL file, or can be built into an IMG. If the IMG does not have a 
 	// built-in palette, an error occurs.
-	void setPalette(const std::string &filename);
+	void setPalette(const std::string &paletteName);
 };
 
 #endif

--- a/OpenTESArena/src/World/VoxelBuilder.cpp
+++ b/OpenTESArena/src/World/VoxelBuilder.cpp
@@ -58,9 +58,9 @@ std::vector<Rect3D> VoxelBuilder::makeSizedBlock(int x, int y, int z, float y1, 
 	return rects;
 }
 
-std::vector<Rect3D> VoxelBuilder::makeBlock(int cellX, int cellY, int cellZ)
+std::vector<Rect3D> VoxelBuilder::makeBlock(int x, int y, int z)
 {
-	return VoxelBuilder::makeSizedBlock(cellX, cellY, cellZ, 0.0f, 1.0f);
+	return VoxelBuilder::makeSizedBlock(x, y, z, 0.0f, 1.0f);
 }
 
 Rect3D VoxelBuilder::makeCeiling(int x, int y, int z)

--- a/OpenTESArena/src/World/VoxelGrid.h
+++ b/OpenTESArena/src/World/VoxelGrid.h
@@ -29,8 +29,8 @@ public:
 
 	// Gets the voxel data associated with an ID. If the voxel ID of air is 0,
 	// then pass the voxel ID minus 1 instead to get the first one.
-	VoxelData &getVoxelData(int index);
-	const VoxelData &getVoxelData(int index) const;
+	VoxelData &getVoxelData(int id);
+	const VoxelData &getVoxelData(int id) const;
 
 	// Adds a voxel data object and returns its assigned ID (index).
 	int addVoxelData(const VoxelData &voxelData);


### PR DESCRIPTION
This is just some cleanup, which I enjoy doing, to address warnings that show when checking the code with the CPPCheck code analyzer tool.

One change involved switching the order of arguments in the camera3D constructor from (position, direction) to (direction, position) to match the order the variables are declared. This is only called in one place right now but if you like the current order I could change this back.

Also, I didn't touch these but just in case it is useful for you, there are the following currently unused variables, according to CPPCheck:

Filename           Lines                                     Variable names
IMGFile.cpp      207, 208, 209, 210                 xoff, yoff, width, height
CFAFile.cpp      29, 30, 72                               unknown1, unknown2, dstOffset
DFAFile.cpp      26, 27, 58                               unknown1, unknown2, chunkSize
ItemParser.cpp 36                                          text
Renderer.cpp    360                                       screenHeight
FontFile.cpp     59                                          counts

And the unused private function
NonPlayer.h     34                                          NonPlayer::getAnimationType

