### PR TITLE
Bugfix/Add type conversion to long for macOS + Clang compatibility

### DIFF
--- a/components/archives/archive.cpp
+++ b/components/archives/archive.cpp
@@ -58,7 +58,8 @@ ConstrainedFileStreamBuf::pos_type ConstrainedFileStreamBuf::seekoff(off_type of
     // Clear read pointers so underflow() gets called on the next read attempt.
     setg(0, 0, 0);
 
-    return newPos - mStart;
+    // Type conversion is required for macOS + Clang compatibility
+    return static_cast<long long>(newPos) - mStart;
 }
 
 ConstrainedFileStreamBuf::pos_type ConstrainedFileStreamBuf::seekpos(pos_type pos, std::ios_base::openmode mode)
@@ -69,7 +70,8 @@ ConstrainedFileStreamBuf::pos_type ConstrainedFileStreamBuf::seekpos(pos_type po
     if(pos < 0 || pos > (mEnd-mStart))
         return traits_type::eof();
 
-    if(!mFile->seekg(pos + mStart))
+    // Type conversion is required for macOS + Clang compatibility
+    if(!mFile->seekg(static_cast<long long>(pos) + mStart))
         return traits_type::eof();
 
     // Clear read pointers so underflow() gets called on the next read attempt.


### PR DESCRIPTION
As part of Mac compatibility described in #74.