### PR TITLE
Preventing the app from crashing if there are no Arena files

### DIFF
--- a/OpenTESArena/src/Game/Game.cpp
+++ b/OpenTESArena/src/Game/Game.cpp
@@ -14,17 +14,15 @@
 #include "../Assets/CityDataFile.h"
 #include "../Assets/TextAssets.h"
 #include "../Interface/Panel.h"
-#include "../Math/Vector2.h"
-#include "../Media/AudioManager.h"
 #include "../Media/FontManager.h"
 #include "../Media/MusicFile.h"
 #include "../Media/MusicName.h"
 #include "../Media/PPMFile.h"
 #include "../Media/TextureManager.h"
-#include "../Media/TextureName.h"
 #include "../Rendering/Renderer.h"
 #include "../Rendering/Surface.h"
 #include "../Utilities/Debug.h"
+#include "../Utilities/File.h"
 
 #include "components/vfs/manager.hpp"
 
@@ -36,7 +34,8 @@ Game::Game()
 	this->options = OptionsParser::parse();
 
 	// Initialize virtual file system using the Arena path in the options file.
-	VFS::Manager::get().initialize(std::string(this->options->getArenaPath()));
+    std::string arena = File::toString(this->options->getArenaPath());
+	VFS::Manager::get().initialize(std::string(arena));
 
 	// Initialize the OpenAL Soft audio manager.
 	this->audioManager.init(*this->options.get());


### PR DESCRIPTION
It will now be handled the same way that missing options are handled.