### PR TITLE
Fix failing Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ compiler: gcc
 group: stable
 
 before_install:
-  - sudo apt-get install libsdl2-dev libopenal-dev
-  - sudo apt-get install wildmidi
+  - sudo apt-get install libegl1-mesa-dev libgles2-mesa-dev libsdl2-dev libopenal-dev wildmidi
 
 install:
   - wget https://github.com/Mindwerks/wildmidi/archive/wildmidi-0.4.0.tar.gz


### PR DESCRIPTION
Your Travis CI builds have been failing for a while due to lacking some dependencies. Adding them in fixed it. Looks like there aren't any other errors or warnings that crept in while the builds were failing.