### PR TITLE
Simplify Travis-CI files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: cpp
 sudo: required
-group: stable
 
 matrix:
   include:
@@ -24,11 +23,9 @@ matrix:
       env:
         - MATRIX_EVAL="export CC=clang-3.6 && export CXX=clang++-3.6"
     - os: osx
-      osx_image: xcode8
       env:
         - MATRIX_EVAL="export CC=gcc && export CXX=g++"
     - os: osx
-      osx_image: xcode8
       env:
         - MATRIX_EVAL="export CC=clang && export CXX=clang++"
 

--- a/CI/before_install.linux.sh
+++ b/CI/before_install.linux.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-sudo apt-get install libegl1-mesa-dev libgles2-mesa-dev libsdl2-dev libopenal-dev wildmidi
+sudo apt-get install libegl1-mesa-dev libgles2-mesa-dev libsdl2-dev libopenal-dev

--- a/CI/before_install.osx.sh
+++ b/CI/before_install.osx.sh
@@ -1,12 +1,3 @@
 #!/bin/bash
 
-brew update
-
-#Upgrade packages included on the default image
-#See https://docs.travis-ci.com/user/reference/osx/#Compilers-and-Build-toolchain
-brew outdated cmake || brew upgrade cmake
-brew outdated pkgconfig || brew upgrade pkgconfig
-
-#Install packages not included on the default image
-brew install openal-soft
 brew install sdl2

--- a/CI/install.osx.sh
+++ b/CI/install.osx.sh
@@ -1,1 +1,5 @@
 #!/bin/bash
+
+wget https://github.com/Mindwerks/wildmidi/archive/wildmidi-0.4.0.tar.gz
+tar -xzvf wildmidi-0.4.0.tar.gz
+pushd wildmidi-wildmidi-0.4.0 && mkdir build && pushd build && cmake .. && make && popd && popd


### PR DESCRIPTION
This is intended to clean up and simplify the Travis-CI files, particularly for OS-X builds, by making the commands as minimal as I could make them. WildMIDI is downloaded and built for OS-X now, but not yet installed and used in the compilation of OpenTESArena.

This is the result of a lot of trial-and-error. I don't use OS-X or Linux, so the criteria for me was whether or not Travis-CI successfully built. Input from others who are more knowledgeable is welcome.

Changes:
`travis.yml`
**Removed** `group: stable` - Not necessary
**Changed OS-X to a single Clang build** - As far as I can see, master is currently building both of these targets with Clang, not one with Clang and the other with GCC. They both are reporting

```
-- The C compiler identification is AppleClang 8.0.0.8000038
-- The CXX compiler identification is AppleClang 8.0.0.8000038
```

I experimented with trying to get one build to use GCC, but couldn't get it to work. I don't know that it's actually worthwhile to build with both compilers for OS-X; I have no idea what the usual compiler used on OS-X is. At any rate, the OS-X build can be simplified to just `os: osx`, which is nice.

**Removed** `osx_image: xcode8` - Not necessary, and if present causes the below warning to appear

```
Warning! PATH is not properly set up, '/Users/travis/.rvm/gems/ruby-2.0.0-p648/bin' is not at first place,
         usually this is caused by shell initialization files - check them for 'PATH=...' entries,
         it might also help to re-add RVM to your dotfiles: 'rvm get stable --auto-dotfiles',
         to fix temporarily in this shell session run: 'rvm use ruby-2.0.0-p648'.
```

(Note: `osx_image: xcode8.3` does not create the above warning)

`CI/before_install.linux.sh` 
**Removed** `wildmidi` **from the** `sudo apt-get install` **command** - not necessary

`CI/before_install.osx.sh`
**Removed all brew commands except for** `brew install sdl2` - other commands not necessary

I also looked into the below warnings in the OS-X builds but I think that these are problems on the Travis-CI end. They appear even with a practically empty travis.yml file.

```
Fix WWDRCA Certificate
Unable to delete certificate matching "0950B6CD3D2F37EA246A1AAA20DFAADBD6FE1F75"security: AppleWWDRCA.cer: already in /Library/Keychains/System.keychain
```

```
/Users/travis/.travis/job_stages: line 475: yarn: command not found
```

```
/Users/travis/.travis/job_stages: line 166: shell_session_update: command not found
```

Additionally, when WildMIDI is built in the OS-X builds, the below warning appears.

```
CMake Warning (dev):
  Policy CMP0042 is not set: MACOSX_RPATH is enabled by default.  Run "cmake
  --help-policy CMP0042" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.
  MACOSX_RPATH is not specified for the following targets:
   libwildmidi_dynamic
This warning is for project developers.  Use -Wno-dev to suppress it.
```

but it also appears for the Travis-CI build logs at https://github.com/Mindwerks/wildmidi/tree/master/CI.

I could not get the built WildMIDI to be used in the compilation of OpenTESArena, because `make install` will fail for the OS-X build. If we can get this I suppose that we'll have MIDI support on OS-X.