### PR TITLE
Make Travis CI builds use latest WildMIDI code

### DIFF
--- a/CI/install.linux.sh
+++ b/CI/install.linux.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-wget https://github.com/Mindwerks/wildmidi/archive/wildmidi-0.4.0.tar.gz
-tar -xzvf wildmidi-0.4.0.tar.gz
-pushd wildmidi-wildmidi-0.4.0 && mkdir build && pushd build && cmake .. && make && sudo make install && popd && popd
+wget https://github.com/Mindwerks/wildmidi/archive/master.zip
+unzip master.zip
+pushd wildmidi-master && mkdir build && pushd build && cmake .. && make && sudo make install && popd && popd

--- a/CI/install.osx.sh
+++ b/CI/install.osx.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-wget https://github.com/Mindwerks/wildmidi/archive/wildmidi-0.4.0.tar.gz
-tar -xzvf wildmidi-0.4.0.tar.gz
-pushd wildmidi-wildmidi-0.4.0 && mkdir build && pushd build && cmake .. && make && popd && popd
+wget https://github.com/Mindwerks/wildmidi/archive/master.zip
+unzip master.zip
+pushd wildmidi-master && mkdir build && pushd build && cmake .. && make && popd && popd


### PR DESCRIPTION
Since https://github.com/afritz1/OpenTESArena/issues/69 is fixed by new changes in WildMIDI, and another OpenTESArena-related issue (and a Daggerfall-related issue) are still open there and seem to be waiting for fixes, it seems to me that it's better to be testing with the latest code. On the off chance that some incompatibility happens between the latest OpenTESArena code and the latest WildMIDI code it would be good to know.