### PR TITLE
Improved weapon fitting in modern mode

### DIFF
--- a/OpenTESArena/src/Assets/MIFFile.cpp
+++ b/OpenTESArena/src/Assets/MIFFile.cpp
@@ -183,7 +183,7 @@ int MIFFile::Level::load(const uint8_t *levelStart)
 	// size in WILD.MIF (six bytes short of where it should be, probably due to FLAT
 	// tag and size not being accounted for, causing this loader to incorrectly start
 	// a second level six bytes from the end of the file).
-	return static_cast<int>(std::distance(levelStart, tagStart));
+	return static_cast<int>(levelEnd - levelStart);
 }
 
 int MIFFile::Level::getHeight() const

--- a/OpenTESArena/src/Assets/MIFFile.cpp
+++ b/OpenTESArena/src/Assets/MIFFile.cpp
@@ -183,7 +183,7 @@ int MIFFile::Level::load(const uint8_t *levelStart)
 	// size in WILD.MIF (six bytes short of where it should be, probably due to FLAT
 	// tag and size not being accounted for, causing this loader to incorrectly start
 	// a second level six bytes from the end of the file).
-	return static_cast<int>(levelEnd - levelStart);
+	return static_cast<int>(std::distance(levelStart, tagStart));
 }
 
 int MIFFile::Level::getHeight() const

--- a/OpenTESArena/src/Entities/WeaponAnimation.cpp
+++ b/OpenTESArena/src/Entities/WeaponAnimation.cpp
@@ -161,6 +161,26 @@ bool WeaponAnimation::isIdle() const
 	return this->state == WeaponAnimation::State::Idle;
 }
 
+bool WeaponAnimation::isLeft() const
+{
+	if ((this->weaponID == 16) || (this->weaponID == 17) || (this->weaponID == -1)) 
+	{
+		return false;
+	}
+	
+	return (this->state == WeaponAnimation::State::Left);
+}
+
+bool WeaponAnimation::isRight() const
+{
+	if ((this->weaponID == 16) || (this->weaponID == 17) || (this->weaponID == -1)) 
+	{
+		return false;
+	}
+	
+	return (this->state == WeaponAnimation::State::Idle) || (this->state == WeaponAnimation::State::Sheathing) || (this->state == WeaponAnimation::State::Unsheathing) || (this->state == WeaponAnimation::State::Right);
+}
+
 const std::string &WeaponAnimation::getAnimationFilename() const
 {
 	return this->animationFilename;

--- a/OpenTESArena/src/Entities/WeaponAnimation.h
+++ b/OpenTESArena/src/Entities/WeaponAnimation.h
@@ -60,6 +60,14 @@ public:
 	// Returns whether the weapon is currently not moving. This is relevant when
 	// determining if the state can safely be changed without interrupting something.
 	bool isIdle() const;
+	
+	// Returns whether the weapon should be on the right side of the screen. This is 
+	// relevant in modern mode for aspect ratios other than stretch.
+	bool isLeft() const;
+	
+	//Returns whether the weapon should be on the left side of the screen. This is 
+	// relevant in modern mode for aspect ratios other than stretch.
+	bool isRight() const;
 
 	// Gets the filename associated with the weapon (i.e., AXE, HAMMER, etc.).
 	// This is used with the current index to determine which frame is drawn.

--- a/OpenTESArena/src/Interface/GameWorldPanel.cpp
+++ b/OpenTESArena/src/Interface/GameWorldPanel.cpp
@@ -1801,8 +1801,37 @@ void GameWorldPanel::renderSecondary(Renderer &renderer)
 			const int newRight = renderer.nativeToOriginal(
 				Int2(renderer.getWindowDimensions().x, 0)).x;
 
-			const int weaponX = newLeft + static_cast<int>(std::round(
-				static_cast<double>(newRight - newLeft) * weaponOffsetXPercent));
+			//const int weaponXAdjusted = newLeft + static_cast<int>(std::round(
+				//static_cast<double>(newRight - newLeft) * weaponOffsetXPercent));
+			
+			int weaponX = weaponOffset.x;
+			
+			if (renderer.getLetterboxMode() == 1)
+			{
+				if (weaponAnimation.isLeft()) 
+				{
+					weaponX = weaponOffset.x-55;
+				} else if (weaponAnimation.isRight())
+				{
+					weaponX = weaponOffset.x+55;
+				} else 
+				{
+					weaponX = weaponOffset.x;
+				}
+			} else if (renderer.getLetterboxMode() == 0)
+			{
+				if (weaponAnimation.isLeft()) 
+				{
+					weaponX = weaponOffset.x-20;
+				} else if (weaponAnimation.isRight())
+				{
+					weaponX = weaponOffset.x+20;
+				} else 
+				{
+					weaponX = weaponOffset.x;
+				}
+			}
+				
 			const int weaponY = static_cast<int>(std::round(
 				static_cast<double>(weaponOffset.y) * weaponScale));
 			const int weaponWidth = static_cast<int>(std::round(
@@ -1812,7 +1841,7 @@ void GameWorldPanel::renderSecondary(Renderer &renderer)
 					Renderer::ORIGINAL_HEIGHT - weaponY)) * weaponScale));
 
 			renderer.drawOriginal(weaponTexture.get(),
-				weaponX, weaponY, weaponWidth, weaponHeight);
+				weaponX, weaponY, weaponTexture.getWidth(), weaponHeight);//weaponX, weaponY, weaponWidth, weaponHeight);
 		}
 		else
 		{

--- a/OpenTESArena/src/Rendering/Renderer.cpp
+++ b/OpenTESArena/src/Rendering/Renderer.cpp
@@ -114,6 +114,11 @@ double Renderer::getLetterboxAspect() const
 	}
 }
 
+int Renderer::getLetterboxMode() const
+{
+	return this->letterboxMode;
+}
+
 Int2 Renderer::getWindowDimensions() const
 {
 	const SDL_Surface *nativeSurface = this->getWindowSurface();

--- a/OpenTESArena/src/Rendering/Renderer.h
+++ b/OpenTESArena/src/Rendering/Renderer.h
@@ -62,6 +62,9 @@ public:
 
 	// Gets the letterbox aspect associated with the current letterbox mode.
 	double getLetterboxAspect() const;
+	
+	//Gets the current letterbox mode.
+	int getLetterboxMode() const;
 
 	// Gets the width and height of the active window.
 	Int2 getWindowDimensions() const;

--- a/OpenTESArena/src/Rendering/SoftwareRenderer.cpp
+++ b/OpenTESArena/src/Rendering/SoftwareRenderer.cpp
@@ -4234,12 +4234,12 @@ void SoftwareRenderer::rayCast2D(int x, const Camera &camera, const Ray &ray,
 		if (onXAxis)
 		{
 			zDistance = (static_cast<double>(cell.x) - 
-				camera.eye.x + static_cast<double>((1 - stepX) / 2)) / ray.dirX;
+				camera.eye.x + static_cast<double>((1 - stepX) * .5)) / ray.dirX;
 		}
 		else
 		{
 			zDistance = (static_cast<double>(cell.z) -
-				camera.eye.z + static_cast<double>((1 - stepZ) / 2)) / ray.dirZ;
+				camera.eye.z + static_cast<double>((1 - stepZ) * .5)) / ray.dirZ;
 		}
 	};
 


### PR DESCRIPTION
I changed the offset of the weapons depending on which side of the screen they intersected with. This way I could preserve the original width without causing the weapons to cut off. There can be some improvements made to the offset values, I didn't measure them exactly to the pixel.