### PR TITLE
Fixes for some Visual Studio Code Analysis warnings

### DIFF
--- a/OpenTESArena/src/Assets/FLCFile.cpp
+++ b/OpenTESArena/src/Assets/FLCFile.cpp
@@ -369,7 +369,7 @@ std::unique_ptr<uint8_t[]> FLCFile::decodeDeltaFrame(const uint8_t *chunkData,
 			if (count > 0)
 			{
 				// Read "count" * 2 colors and write them to the output frame.
-				for (int i = 0; (i < count) && (x < this->width); i++)
+				for (int j = 0; (j < count) && (x < this->width); j++)
 				{
 					const uint8_t color1 = *(chunkData + offset);
 					const uint8_t color2 = *(chunkData + offset + 1);
@@ -395,7 +395,7 @@ std::unique_ptr<uint8_t[]> FLCFile::decodeDeltaFrame(const uint8_t *chunkData,
 				// Reverse the sign of count so it's positive.
 				const int8_t positiveCount = -count;
 
-				for (int i = 0; (i < positiveCount) && (x < this->width); i++)
+				for (int j = 0; (j < positiveCount) && (x < this->width); j++)
 				{
 					initialFrame.at(x + (y * this->width)) = color1;
 					x++;

--- a/OpenTESArena/src/Assets/MiscAssets.cpp
+++ b/OpenTESArena/src/Assets/MiscAssets.cpp
@@ -485,7 +485,7 @@ void MiscAssets::parseQuestionTxt()
 
 	while (std::getline(iss, line))
 	{
-		const char ch = line.at(0);
+		const unsigned char ch = static_cast<unsigned char>(line.at(0));
 
 		if (std::isalpha(ch))
 		{

--- a/OpenTESArena/src/Interface/GameWorldPanel.cpp
+++ b/OpenTESArena/src/Interface/GameWorldPanel.cpp
@@ -1485,7 +1485,6 @@ void GameWorldPanel::handleClickInWorld(const Int2 &nativePoint, bool primaryCli
 							&shadowData,
 							game.getRenderer());
 
-						auto &gameData = game.getGameData();
 						auto &actionText = gameData.getActionText();
 						const double duration = std::max(2.25,
 							static_cast<double>(text.size()) * 0.050);
@@ -2200,8 +2199,6 @@ void GameWorldPanel::render(Renderer &renderer)
 	if (!modernInterface)
 	{
 		// Draw game world interface.
-		const auto &gameInterface = textureManager.getTexture(
-			TextureFile::fromName(TextureName::GameWorldInterface), renderer);
 		renderer.drawOriginal(gameInterface.get(), 0,
 			Renderer::ORIGINAL_HEIGHT - gameInterface.getHeight());
 

--- a/OpenTESArena/src/Interface/ListBox.cpp
+++ b/OpenTESArena/src/Interface/ListBox.cpp
@@ -36,8 +36,8 @@ ListBox::ListBox(int x, int y, const Color &textColor, const std::vector<std::st
 		// Remove any new lines.
 		std::string trimmedElement = String::trimLines(element);
 
-		const int x = 0;
-		const int y = 0;
+		const int textBoxX = 0;
+		const int textBoxY = 0;
 
 		const RichTextString richText(
 			trimmedElement,
@@ -47,7 +47,7 @@ ListBox::ListBox(int x, int y, const Color &textColor, const std::vector<std::st
 			fontManager);
 
 		// Store the text box for later.
-		auto textBox = std::make_unique<TextBox>(x, y, richText, renderer);
+		auto textBox = std::make_unique<TextBox>(textBoxX, textBoxY, richText, renderer);
 		this->textBoxes.push_back(std::move(textBox));
 	}
 

--- a/OpenTESArena/src/Utilities/File.cpp
+++ b/OpenTESArena/src/Utilities/File.cpp
@@ -44,7 +44,7 @@ bool File::pathIsRelative(const std::string &filename)
 		}
 
 		// Needs a drive letter and a colon to be absolute.
-		return !(std::isalpha(filename.front()) && (filename.at(1) == ':'));
+		return !(std::isalpha(static_cast<unsigned char>(filename.front())) && (filename.at(1) == ':'));
 	}
 	else
 	{


### PR DESCRIPTION
This is a very minor PR, but something you can take a look at if you want a change of pace from the stuff you're working on.

I decided to run the project through Visual Studio 2015's Code Analysis, using "Microsoft All Rules". Here's what I got:

```\opentesarena\src\assets\arenasave.cpp(64): warning C6262: Function uses '131136' bytes of stack:  exceeds /analyze:stacksize '16384'.. This allocation was for a compiler-generated temporary for 'struct ArenaTypes::Automap' at line 64.  Consider moving some data to heap.
\opentesarena\src\assets\arenasave.cpp(110): warning C6262: Function uses '21532' bytes of stack:  exceeds /analyze:stacksize '16384'.. This allocation was for a compiler-generated temporary for 'struct ArenaTypes::SaveEngine' at line 110.  Consider moving some data to heap.
\opentesarena\src\assets\arenasave.cpp(116): warning C6262: Function uses '166640' bytes of stack:  exceeds /analyze:stacksize '16384'.. This allocation was for a compiler-generated temporary for 'struct ArenaTypes::SaveGame' at line 116.  Consider moving some data to heap.
\opentesarena\src\assets\arenasave.cpp(133): warning C6001: Using uninitialized memory 'spells'.
\opentesarena\src\assets\arenasave.cpp(146): warning C6262: Function uses '22468' bytes of stack:  exceeds /analyze:stacksize '16384'.  Consider moving some data to heap.
\opentesarena\src\assets\arenasave.cpp(159): warning C6001: Using uninitialized memory 'spellsg'.
\opentesarena\src\assets\arenasave.cpp(174): warning C6262: Function uses '28800' bytes of stack:  exceeds /analyze:stacksize '16384'.. This allocation was for a compiler-generated temporary for 'struct ArenaTypes::MQLevelState' at line 174.  Consider moving some data to heap.
\opentesarena\src\assets\arenasave.cpp(42): warning C6262: Function uses '131136' bytes of stack:  exceeds /analyze:stacksize '16384'.. This allocation was for a compiler-generated temporary for 'struct ArenaTypes::Automap' at line 42.  Consider moving some data to heap.
\opentesarena\src\assets\arenasave.cpp(31): warning C6262: Function uses '262552' bytes of stack:  exceeds /analyze:stacksize '16384'.  Consider moving some data to heap.
\opentesarena\src\assets\arenatypes.cpp(270): warning C6001: Using uninitialized memory 'playerBuffer'.
\opentesarena\src\assets\arenatypes.cpp(277): warning C6001: Using uninitialized memory 'playerDataBuffer'.
\opentesarena\src\assets\flcfile.cpp(372): warning C6246: Local declaration of 'i' hides declaration of the same name in outer scope. For additional information, see previous declaration at line '359' of '\opentesarena\src\assets\flcfile.cpp'.
\opentesarena\src\assets\flcfile.cpp(398): warning C6246: Local declaration of 'i' hides declaration of the same name in outer scope. For additional information, see previous declaration at line '359' of '\opentesarena\src\assets\flcfile.cpp'.
\opentesarena\src\assets\miscassets.cpp(490): warning C6330: 'const char' passed as _Param_(1) when 'unsigned char' is required in call to 'isalpha'.
\opentesarena\src\assets\miscassets.cpp(506): warning C6330: 'const char' passed as _Param_(1) when 'unsigned char' is required in call to 'isdigit'.
\opentesarena\src\interface\gameworldpanel.cpp(1488): warning C6246: Local declaration of 'gameData' hides declaration of the same name in outer scope. For additional information, see previous declaration at line '1334' of '\opentesarena\src\interface\gameworldpanel.cpp'.
\opentesarena\src\interface\gameworldpanel.cpp(2203): warning C6246: Local declaration of 'gameInterface' hides declaration of the same name in outer scope. For additional information, see previous declaration at line '2191' of '\opentesarena\src\interface\gameworldpanel.cpp'.
\opentesarena\src\interface\listbox.cpp(39): warning C6246: Local declaration of 'x' hides declaration of the same name in outer scope. For additional information, see previous declaration at line '19' of '\opentesarena\src\interface\listbox.cpp'.
\opentesarena\src\interface\listbox.cpp(40): warning C6246: Local declaration of 'y' hides declaration of the same name in outer scope. For additional information, see previous declaration at line '19' of '\opentesarena\src\interface\listbox.cpp'.
\opentesarena\src\rendering\renderer.cpp(82): warning C6011: Dereferencing NULL pointer 'nativeSurface'. 
\opentesarena\src\utilities\debug.cpp(90): warning C6031: Return value ignored: 'getchar'.
\opentesarena\src\utilities\file.cpp(47): warning C6330: 'const char' passed as _Param_(1) when 'unsigned char' is required in call to 'isalpha'.
\opentesarena\src\world\exteriorleveldata.cpp(257): warning C6262: Function uses '24648' bytes of stack:  exceeds /analyze:stacksize '16384'.  Consider moving some data to heap.
\opentesarena\src\world\exteriorleveldata.cpp(210): warning C6262: Function uses '99960' bytes of stack:  exceeds /analyze:stacksize '16384'.  Consider moving some data to heap.
\opentesarena\src\main.cpp(10): warning C6262: Function uses '145260' bytes of stack:  exceeds /analyze:stacksize '16384'.  Consider moving some data to heap.
```

This PR provides fixes for the masked variables (C6246) and those functions wanting an unsigned char for their parameter (C6330).

I went for non-breaking changes and just renamed the masked variables, but you may want to look at them a bit closer. The `x` and `y` of one function are passed in as parameters but not used; instead it creates `x` and `y` within it and then uses those. The `gameData` and `gameInterface` variables might not need to be re-instantiated.

If you don't like the names I chose or have a different idea how to fix it, feel free to reject this PR and do it yourself, or accept it and then modify it, or tell me what you want me to change it to. Any way is fine.

Remaining warnings:

Unitialized memory (C6001) - It's in save code that's not used yet.
Lots of stack used (C6262) - I don't know whether or not these matter. 

```\opentesarena\src\rendering\renderer.cpp(82): warning C6011: Dereferencing NULL pointer 'nativeSurface'.```

False positive maybe? You have a debug function right before this that says it will exit the program if `nativeSurface` is NULL.

```\opentesarena\src\utilities\debug.cpp(90): warning C6031: Return value ignored: 'getchar'.```

In addition to ignoring the return value, to keep the console window from closing immediately, supposedly `getchar` isn't completely reliable anyway, because there can be something in the input stream.

https://stackoverflow.com/questions/23517337/getchar-returns-immediately

An alternative for Windows they suggest is `system("pause");` Some comments I saw said that's bad practice, too, but it seems reasonable to me.
