### PR TITLE
Upgrade to C++17.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-5.0
+            - llvm-toolchain-trusty-5.0
           packages:
             - clang-5.0
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,9 @@ before_install:
   - eval "${MATRIX_EVAL}"
   - ./CI/before_install.${TRAVIS_OS_NAME}.sh
 
-install: ./CI/install.${TRAVIS_OS_NAME}.sh
+install:
+  - if [ "$CXX" == "clang++" ]; then export CXXFLAGS="-std=c++17 -stdlib=libc++"; fi
+  - ./CI/install.${TRAVIS_OS_NAME}.sh
 
 script:
   - mkdir build

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,19 +12,6 @@ matrix:
             - g++-7
       env:
         - MATRIX_EVAL="export CC=gcc-7 && export CXX=g++-7"
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-5.0
-          packages:
-            - clang-5.0
-      env:
-        - MATRIX_EVAL="export CC=clang-5.0 && export CXX=clang++-5.0"
-    - os: osx
-      env:
-        - MATRIX_EVAL="export CC=gcc && export CXX=g++"
     - os: osx
       env:
         - MATRIX_EVAL="export CC=clang && export CXX=clang++"
@@ -33,9 +20,7 @@ before_install:
   - eval "${MATRIX_EVAL}"
   - ./CI/before_install.${TRAVIS_OS_NAME}.sh
 
-install:
-  - if [ "$CXX" == "clang++" ]; then export CXXFLAGS="-std=c++17 -stdlib=libc++"; fi
-  - ./CI/install.${TRAVIS_OS_NAME}.sh
+install: ./CI/install.${TRAVIS_OS_NAME}.sh
 
 script:
   - mkdir build

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,19 +9,19 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - g++-5
+            - g++-7
       env:
-        - MATRIX_EVAL="export CC=gcc-5 && export CXX=g++-5"
+        - MATRIX_EVAL="export CC=gcc-7 && export CXX=g++-7"
     - os: linux
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.6
+            - llvm-toolchain-precise-5.0
           packages:
-            - clang-3.6
+            - clang-5.0
       env:
-        - MATRIX_EVAL="export CC=clang-3.6 && export CXX=clang++-3.6"
+        - MATRIX_EVAL="export CC=clang-5.0 && export CXX=clang++-5.0"
     - os: osx
       env:
         - MATRIX_EVAL="export CC=gcc && export CXX=g++"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ PROJECT(OpenTESArena)
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/")
 
 # Set global C++ standard for all targets.
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS ON)
 

--- a/OpenTESArena/src/Math/MathUtils.h
+++ b/OpenTESArena/src/Math/MathUtils.h
@@ -8,7 +8,7 @@ namespace MathUtils
 	template <typename T>
 	const T &clamp(const T &value, const T &low, const T &high)
 	{
-		return std::min(std::max(value, low), high);
+		return std::clamp(value, low, high);
 	}
 
 	// A variant of atan2() with a range of [0, 2pi] instead of [-pi, pi].


### PR DESCRIPTION
Setting the C++ standard in CMake is hopefully enough for MSVC, GCC, and Clang. I'm more worried about Travis CI possibly needing to download and install g++-7 every time but we'll see.

References issue #143.