### PR TITLE
Get Travis CI Clang working with more C++17 features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
     - os: osx
       osx_image: xcode9
       env:
-        - MATRIX_EVAL="brew install gcc && CC=gcc-7 && CXX=g++-7"
+        - MATRIX_EVAL="brew update-reset && brew install gcc && CC=gcc-8 && CXX=g++-8"
 
 before_install:
   - eval "${MATRIX_EVAL}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
       env:
         - MATRIX_EVAL="export CC=gcc-7 && export CXX=g++-7"
     - os: osx
+      osx_image: xcode10.1
       env:
         - MATRIX_EVAL="export CC=clang && export CXX=clang++"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ matrix:
       env:
         - MATRIX_EVAL="export CC=gcc-7 && export CXX=g++-7"
     - os: osx
-      osx_image: xcode10.1
       env:
         - MATRIX_EVAL="export CC=clang && export CXX=clang++"
+        - CXX_FLAGS="${CXX_FLAGS} -std=c++17 -stdlib=libc++"
 
 before_install:
   - eval "${MATRIX_EVAL}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ matrix:
       env:
         - MATRIX_EVAL="export CC=gcc-7 && export CXX=g++-7"
     - os: osx
+      osx_image: xcode9
       env:
-        - MATRIX_EVAL="export CC=clang && export CXX=clang++"
-        - CXX_FLAGS="${CXX_FLAGS} -std=c++17 -stdlib=libc++"
+        - MATRIX_EVAL="brew install gcc && CC=gcc-7 && CXX=g++-7"
 
 before_install:
   - eval "${MATRIX_EVAL}"


### PR DESCRIPTION
Clang works with some C++17 features like `std::string_view` but not `std::optional`, likely due to Travis CI using an older libstdc++. Probably need to get it to use libc++ instead.