### PR TITLE
Fix OS X build on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,7 @@ matrix:
       env:
         - MATRIX_EVAL="export CC=gcc-7 && export CXX=g++-7"
     - os: osx
-      osx_image: xcode9
-      env:
-        - MATRIX_EVAL="brew update-reset && brew install gcc && CC=gcc-8 && CXX=g++-8"
+      osx_image: xcode10.2
 
 before_install:
   - eval "${MATRIX_EVAL}"


### PR DESCRIPTION
For some reason the OS X builds have stopped working, with the message:

```
CMake Error at /usr/local/Cellar/cmake/3.9.2/share/cmake/Modules/CMakeDetermineCCompiler.cmake:48 (message):
  Could not find compiler set in environment variable CC:
  gcc-8.
```

After trial-and-error, I found that by updating the image to 10.2, the latest one here:
https://docs.travis-ci.com/user/reference/osx/
it is fixed. While experimenting I got a message that the gcc version installed on this image is 8.3, and it seems to build okay.