### PR TITLE
📦 Added PMM for managing VCPKG packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,20 @@ ENDIF (COMMAND cmake_policy)
 PROJECT(OpenTESArena)
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/")
+include(CMakeDependentOption)
+
+cmake_dependent_option(USE_PACKAGE_MANAGER "Use VCPKG for managing packages" ON MSVC OFF)
+
+IF (USE_PACKAGE_MANAGER)
+    include(pmm)
+
+    # To update libs, update the commit hash with the latest commit found here: https://github.com/microsoft/vcpkg/commits/master
+    pmm(VCPKG
+        REVISION 046f8383efd70f57814faf1a8b7ef628c92ed959
+        REQUIRES sdl2 openal-soft wildmidi
+    )
+
+ENDIF(USE_PACKAGE_MANAGER)
 
 # Set global C++ standard for all targets.
 set(CMAKE_CXX_STANDARD 17)

--- a/cmake/pmm.cmake
+++ b/cmake/pmm.cmake
@@ -1,0 +1,65 @@
+## MIT License
+##
+## Copyright (c) 2018 vector-of-bool
+##
+## Permission is hereby granted, free of charge, to any person obtaining a copy
+## of this software and associated documentation files (the "Software"), to deal
+## in the Software without restriction, including without limitation the rights
+## to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+## copies of the Software, and to permit persons to whom the Software is
+## furnished to do so, subject to the following conditions:
+##
+## The above copyright notice and this permission notice shall be included in all
+## copies or substantial portions of the Software.
+##
+## THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+## IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+## FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+## AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+## LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+## OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+## SOFTWARE.
+
+# Bump this version to change what PMM version is downloaded
+set(PMM_VERSION_INIT 1.4.1)
+
+# Helpful macro to set a variable if it isn't already set
+macro(_pmm_set_if_undef varname)
+    if(NOT DEFINED "${varname}")
+        set("${varname}" "${ARGN}")
+    endif()
+endmacro()
+
+## Variables used by this script
+# The version:
+_pmm_set_if_undef(PMM_VERSION ${PMM_VERSION_INIT})
+# The base URL we download PMM from:
+_pmm_set_if_undef(PMM_URL_BASE "http://anotherfoxguy.com/pmm/")
+# The real URL we download from (Based on the version)
+_pmm_set_if_undef(PMM_URL "${PMM_URL_BASE}/${PMM_VERSION}")
+# The directory where we store our downloaded files
+_pmm_set_if_undef(PMM_DIR_BASE "${CMAKE_BINARY_DIR}/_pmm")
+_pmm_set_if_undef(PMM_DIR "${PMM_DIR_BASE}/${PMM_VERSION}")
+
+# The file that we first download
+set(_PMM_ENTRY_FILE "${PMM_DIR}/entry.cmake")
+
+if(NOT EXISTS "${_PMM_ENTRY_FILE}" OR PMM_ALWAYS_DOWNLOAD)
+    file(
+        DOWNLOAD "${PMM_URL}/entry.cmake"
+        "${_PMM_ENTRY_FILE}.tmp"
+        STATUS pair
+        )
+    list(GET pair 0 rc)
+    list(GET pair 1 msg)
+    if(rc)
+        message(FATAL_ERROR "Failed to download PMM entry file")
+    endif()
+    file(RENAME "${_PMM_ENTRY_FILE}.tmp" "${_PMM_ENTRY_FILE}")
+endif()
+
+# ^^^ DO NOT CHANGE THIS LINE vvv
+set(_PMM_BOOTSTRAP_VERSION 1)
+# ^^^ DO NOT CHANGE THIS LINE ^^^
+
+include("${_PMM_ENTRY_FILE}")

--- a/docs/setup_windows.md
+++ b/docs/setup_windows.md
@@ -7,31 +7,13 @@ This document describes how to setup a build environment for building with Visua
 1. Install [Visual Studio Community 2019](https://www.visualstudio.com/downloads/) with the C++ for games workload
 2. Install [cmake](https://cmake.org/download/) and [git](https://git-scm.com/download)
 
-### Installing vcpkg
-The easiest way to build the dependencies is with [vcpkg](https://github.com/Microsoft/vcpkg)
-
-1. Clone [vcpkg](https://github.com/Microsoft/vcpkg) to ```C:/Tools/vcpkg/```:
-  ```PowerShell
-  cd C:\Tools\vcpkg\
-  git clone https://github.com/Microsoft/vcpkg.git .
-  ```
-2. Run the bootstrapper in the root folder:
-  ```PowerShell
-  .\bootstrap-vcpkg.bat
-  ```
-
-3. Install the dependencies:
-  ```PowerShell
-  vcpkg install sdl2 openal-soft wildmidi --triplet x64-windows
-  ```
-
 ## Building
 
 1. Create `build` directory
 2. Create solution files with `cmake`:
 
   ```PowerShell
-  cmake -DCMAKE_TOOLCHAIN_FILE=C:/Tools/vcpkg/scripts/buildsystems/vcpkg.cmake ..
+  cmake ..
   ```
 3. Open the file OpenTESArena.sln and in Visual Studio, do the following: from the menu: Build -> build Solution
 


### PR DESCRIPTION
Added PMM (https://github.com/AnotherFoxGuy/pmm) for managing VCPKG on windows.
PMM takes care of downloading, bootstrapping and installing the dependencies so you don't have to run the commands manually.
It also ensures that the deps versions are always the same.

PMM can be disabled by setting `USE_PACKAGE_MANAGER=OFF`