### PR TITLE
[Don't merge] Add exclusive fullscreen mode

### DIFF
--- a/OpenTESArena/src/Game/Options.cpp
+++ b/OpenTESArena/src/Game/Options.cpp
@@ -74,7 +74,7 @@ const std::string Options::SECTION_MISC = "Misc";
 
 const int Options::MIN_FPS = 15;
 const int Options::MIN_WINDOW_MODE = 0;
-const int Options::MAX_WINDOW_MODE = 1;
+const int Options::MAX_WINDOW_MODE = 2;
 const double Options::MIN_RESOLUTION_SCALE = 0.10;
 const double Options::MAX_RESOLUTION_SCALE = 1.0;
 const double Options::MIN_VERTICAL_FOV = 40.0;

--- a/OpenTESArena/src/Interface/OptionsPanel.cpp
+++ b/OpenTESArena/src/Interface/OptionsPanel.cpp
@@ -365,9 +365,11 @@ OptionsPanel::OptionsPanel(Game &game)
 			switch (value)
 			{
 			case 0:
-				return Renderer::WindowMode::Window;
+				return Renderer::WindowMode::Windowed;
 			case 1:
-				return Renderer::WindowMode::BorderlessFull;
+				return Renderer::WindowMode::Borderless;
+			case 2:
+				return Renderer::WindowMode::Fullscreen;
 			default:
 				DebugUnhandledReturnMsg(Renderer::WindowMode, std::to_string(value));
 			}
@@ -376,7 +378,7 @@ OptionsPanel::OptionsPanel(Game &game)
 		renderer.setWindowMode(mode);
 	});
 
-	windowModeOption->setDisplayOverrides({ "Window", "Borderless Full" });
+	windowModeOption->setDisplayOverrides({ "Windowed", "Borderless", "Fullscreen" });
 	this->graphicsOptions.push_back(std::move(windowModeOption));
 
 	this->graphicsOptions.push_back(std::make_unique<IntOption>(

--- a/OpenTESArena/src/Rendering/Renderer.h
+++ b/OpenTESArena/src/Rendering/Renderer.h
@@ -41,8 +41,9 @@ public:
 
 	enum class WindowMode
 	{
-		Window,
-		BorderlessFull
+		Windowed,
+		Borderless,
+		Fullscreen,
 	};
 private:
 	static const char *DEFAULT_RENDER_SCALE_QUALITY;

--- a/options/options-default.txt
+++ b/options/options-default.txt
@@ -12,7 +12,7 @@ ScreenWidth=1280
 ScreenHeight=720
 
 # Determines how the game window is displayed.
-# 0: window, 1: borderless fullscreen
+# 0: windowed, 1: borderless fullscreen, 2: fullscreen
 WindowMode=0
 
 TargetFPS=60


### PR DESCRIPTION
Making a pull request for this since I haven't figured out why Windows 10 freaks out when switching from exclusive fullscreen to borderless fullscreen.

I'd like exclusive fullscreen to only be the desktop resolution for now but I'm having trouble getting SDL to do that with `SDL_SetWindowFullscreen()` and `SDL_SetWindowMode()`.

There are also some DPI problems that crop up if the fullscreen resolution is different from the desktop, so that's another reason to match the desktop resolution.