### PR TITLE
Revise automap code for wilderness

### DIFF
--- a/OpenTESArena/src/Interface/AutomapPanel.h
+++ b/OpenTESArena/src/Interface/AutomapPanel.h
@@ -10,9 +10,12 @@
 
 class Color;
 class Renderer;
+class Surface;
 class TextBox;
 class VoxelData;
 class VoxelGrid;
+
+enum class CardinalDirectionName;
 
 class AutomapPanel : public Panel
 {
@@ -25,6 +28,10 @@ private:
 	// Gets the display color for a pixel on the automap, given its associated floor
 	// and wall voxel data definitions.
 	static const Color &getPixelColor(const VoxelData &floorData, const VoxelData &wallData);
+
+	// Generates a surface of the automap to be converted to a texture for rendering.
+	static Surface makeAutomap(const Int2 &playerVoxel, CardinalDirectionName playerDir,
+		bool isWild, const VoxelGrid &voxelGrid);
 
 	// Listen for when the LMB is held on a compass direction.
 	void handleMouse(double dt);

--- a/OpenTESArena/src/Interface/AutomapPanel.h
+++ b/OpenTESArena/src/Interface/AutomapPanel.h
@@ -33,6 +33,13 @@ private:
 	static Surface makeAutomap(const Int2 &playerVoxel, CardinalDirectionName playerDir,
 		bool isWild, const VoxelGrid &voxelGrid);
 
+	// Calculates screen offset of automap for rendering.
+	static Double2 makeAutomapOffset(const Int2 &playerVoxel, bool isWild,
+		int gridWidth, int gridDepth);
+
+	// Helper function for obtaining relative wild origin in new coordinate system.
+	static Int2 makeRelativeWildOrigin(const Int2 &voxel, int gridWidth, int gridDepth);
+
 	// Listen for when the LMB is held on a compass direction.
 	void handleMouse(double dt);
 

--- a/OpenTESArena/src/World/ExteriorLevelData.cpp
+++ b/OpenTESArena/src/World/ExteriorLevelData.cpp
@@ -1000,6 +1000,13 @@ Int2 ExteriorLevelData::getRelativeWildOrigin(const Int2 &voxel)
 		voxel.y - (voxel.y % (RMDFile::DEPTH * 2)));
 }
 
+Int2 ExteriorLevelData::getCenteredWildOrigin(const Int2 &voxel)
+{
+	return Int2(
+		(std::max(voxel.x - 32, 0) / RMDFile::WIDTH) * RMDFile::WIDTH,
+		(std::max(voxel.y - 32, 0) / RMDFile::DEPTH) * RMDFile::DEPTH);
+}
+
 ExteriorLevelData ExteriorLevelData::loadPremadeCity(const MIFFile::Level &level,
 	WeatherType weatherType, int currentDay, int starCount, const std::string &infName,
 	int gridWidth, int gridDepth, const MiscAssets &miscAssets, TextureManager &textureManager)

--- a/OpenTESArena/src/World/ExteriorLevelData.h
+++ b/OpenTESArena/src/World/ExteriorLevelData.h
@@ -61,6 +61,11 @@ public:
 	// and return the chunk coordinate that contains the origin.
 	static Int2 getRelativeWildOrigin(const Int2 &voxel);
 
+	// A variation on getRelativeWildOrigin() -- determine which one is actually what we want for
+	// all cases, because getRelativeWildOrigin() apparently doesn't make the automap centered.
+	// Given coordinates are expected to be in original coordinate system.
+	static Int2 getCenteredWildOrigin(const Int2 &voxel);
+
 	// Premade exterior level with a pre-defined .INF file. Only used by center province.
 	static ExteriorLevelData loadPremadeCity(const MIFFile::Level &level, WeatherType weatherType,
 		int currentDay, int starCount, const std::string &infName, int gridWidth, int gridDepth,


### PR DESCRIPTION
The automap now resizes to 128x128 voxels when in the wilderness in order to match the original game's size. It's not rendering wilderness voxels the same yet but I think it'd be nice to have that as an option because it can be hard to tell what things are in the original game.