### PR TITLE
[Don't Merge] Implementation of 3d positional audio

### DIFF
--- a/OpenTESArena/src/Entities/Player.cpp
+++ b/OpenTESArena/src/Entities/Player.cpp
@@ -295,7 +295,7 @@ void Player::handleCollision(const WorldData &worldData, double dt)
 			}();
 
 			// -- Temporary hack for "on voxel enter" transitions --
-			// - @todo: replace with "on would enter voxel" event and near facing check.			
+			// - @todo: replace with "on would enter voxel" event and near facing check.
 			const bool isLevelUpDown = [&voxelData]()
 			{
 				if (voxelData.dataType == VoxelDataType::Wall)
@@ -351,7 +351,7 @@ void Player::accelerate(const Double3 &direction, double magnitude,
 		this->velocity = newVelocity;
 	}
 
-	// Don't let the horizontal velocity be greater than the max speed for the 
+	// Don't let the horizontal velocity be greater than the max speed for the
 	// current movement state (i.e., walking/running).
 	double maxSpeed = isRunning ? this->maxRunSpeed : this->maxWalkSpeed;
 	Double2 velocityXZ(this->velocity.x, this->velocity.z);
@@ -360,7 +360,7 @@ void Player::accelerate(const Double3 &direction, double magnitude,
 		velocityXZ = velocityXZ.normalized() * maxSpeed;
 	}
 
-	// If the velocity is near zero, set it to zero. This fixes a problem where 
+	// If the velocity is near zero, set it to zero. This fixes a problem where
 	// the velocity could remain at a tiny magnitude and never reach zero.
 	if (this->velocity.length() < 0.001)
 	{
@@ -371,7 +371,7 @@ void Player::accelerate(const Double3 &direction, double magnitude,
 void Player::accelerateInstant(const Double3 &direction, double magnitude)
 {
 	DebugAssert(direction.isNormalized());
-	
+
 	const Double3 additiveVelocity = direction * magnitude;
 
 	if (std::isfinite(additiveVelocity.length()))
@@ -436,6 +436,11 @@ void Player::tick(Game &game, double dt)
 	// Update player position and velocity due to collisions.
 	const WorldData &worldData = game.getGameData().getWorldData();
 	this->updatePhysics(worldData, game.getOptions().getMisc_Collision(), dt);
+
+	// Update the global audio listener.
+	auto &audioManager = game.getAudioManager();
+	audioManager.setListenerPosition(this->getPosition());
+	audioManager.setListenerOrientation(this->getDirection());
 
 	// Tick weapon animation.
 	this->weaponAnimation.tick(dt);

--- a/OpenTESArena/src/Entities/Player.cpp
+++ b/OpenTESArena/src/Entities/Player.cpp
@@ -437,11 +437,6 @@ void Player::tick(Game &game, double dt)
 	const WorldData &worldData = game.getGameData().getWorldData();
 	this->updatePhysics(worldData, game.getOptions().getMisc_Collision(), dt);
 
-	// Update the global audio listener.
-	auto &audioManager = game.getAudioManager();
-	audioManager.setListenerPosition(this->getPosition());
-	audioManager.setListenerOrientation(this->getDirection());
-
 	// Tick weapon animation.
 	this->weaponAnimation.tick(dt);
 }

--- a/OpenTESArena/src/Game/Game.cpp
+++ b/OpenTESArena/src/Game/Game.cpp
@@ -54,7 +54,7 @@ Game::Game()
 
 	this->audioManager.init(this->options.getAudio_MusicVolume(),
 		this->options.getAudio_SoundVolume(), this->options.getAudio_SoundChannels(),
-		this->options.getAudio_SoundResampling(), midiPath);
+		this->options.getAudio_SoundResampling(), this->options.getAudio_Is3DAudio(), midiPath);
 
 	// Initialize the SDL renderer and window with the given settings.
 	this->renderer.init(this->options.getGraphics_ScreenWidth(),

--- a/OpenTESArena/src/Game/Game.cpp
+++ b/OpenTESArena/src/Game/Game.cpp
@@ -485,8 +485,23 @@ void Game::loop()
 		// Update the input manager's state.
 		this->inputManager.update();
 
-		// Update the audio manager, checking for finished sounds.
-		this->audioManager.update();
+		// Update the audio manager listener (if any) and check for finished sounds.
+		if (this->gameDataIsActive())
+		{
+			const AudioManager::ListenerData listenerData = [this]()
+			{
+				const Player &player = this->getGameData().getPlayer();
+				const Double3 &position = player.getPosition();
+				const Double3 &direction = player.getDirection();
+				return AudioManager::ListenerData(position, direction);
+			}();
+
+			this->audioManager.update(&listenerData);
+		}
+		else
+		{
+			this->audioManager.update(nullptr);
+		}
 
 		// Update FPS counter.
 		this->fpsCounter.updateFrameTime(dt);

--- a/OpenTESArena/src/Game/Options.cpp
+++ b/OpenTESArena/src/Game/Options.cpp
@@ -37,7 +37,8 @@ namespace
 		{ "SoundVolume", OptionType::Double },
 		{ "MidiConfig", OptionType::String },
 		{ "SoundChannels", OptionType::Int },
-		{ "SoundResampling", OptionType::Int }
+		{ "SoundResampling", OptionType::Int },
+		{ "Is3DAudio", OptionType::Bool }
 	};
 
 	const std::vector<std::pair<std::string, OptionType>> InputMappings =
@@ -394,7 +395,7 @@ void Options::setBool(const std::string &section, const std::string &key, bool v
 	}
 
 	Options::BoolMap &sectionMap = sectionIter->second.bools;
-	
+
 	// Check that the key exists. If not, add it.
 	auto iter = sectionMap.find(key);
 	if (iter == sectionMap.end())

--- a/OpenTESArena/src/Game/Options.h
+++ b/OpenTESArena/src/Game/Options.h
@@ -153,6 +153,7 @@ void set##section##_##name(const std::string &value) \
 	OPTION_STRING(Audio, MidiConfig)
 	OPTION_INT(Audio, SoundChannels)
 	OPTION_INT(Audio, SoundResampling)
+	OPTION_BOOL(Audio, Is3DAudio)
 
 	OPTION_DOUBLE(Input, HorizontalSensitivity)
 	OPTION_DOUBLE(Input, VerticalSensitivity)

--- a/OpenTESArena/src/Interface/GameWorldPanel.cpp
+++ b/OpenTESArena/src/Interface/GameWorldPanel.cpp
@@ -83,9 +83,9 @@ namespace
 	const Color EffectTextColor(251, 239, 77);
 	const Color EffectTextShadowColor(190, 113, 0);
 
-	// Arrow cursor alignments. These offset the drawn cursor relative to the mouse 
-	// position so the cursor's click area is closer to the tip of each arrow, as is 
-	// done in the original game (slightly differently, though. I think the middle 
+	// Arrow cursor alignments. These offset the drawn cursor relative to the mouse
+	// position so the cursor's click area is closer to the tip of each arrow, as is
+	// done in the original game (slightly differently, though. I think the middle
 	// cursor was originally top-aligned, not middle-aligned, which is strange).
 	const std::array<CursorAlignment, 9> ArrowCursorAlignments =
 	{
@@ -188,7 +188,7 @@ GameWorldPanel::GameWorldPanel(Game &game)
 
 					const int timeOfDayIndex = [&gameData]()
 					{
-						// Arena has eight time ranges for each time of day. They aren't 
+						// Arena has eight time ranges for each time of day. They aren't
 						// uniformly distributed -- midnight and noon are only one minute.
 						const std::array<std::pair<Clock, int>, 8> clocksAndIndices =
 						{
@@ -269,7 +269,7 @@ GameWorldPanel::GameWorldPanel(Game &game)
 
 					// Remove newline on end.
 					text.pop_back();
-					
+
 					return text;
 				}();
 
@@ -289,7 +289,7 @@ GameWorldPanel::GameWorldPanel(Game &game)
 
 			const Int2 &richTextDimensions = richText.getDimensions();
 
-			Texture texture = Texture::generate(Texture::PatternType::Dark, 
+			Texture texture = Texture::generate(Texture::PatternType::Dark,
 				richTextDimensions.x + 12, richTextDimensions.y + 12, textureManager, renderer);
 
 			const Int2 textureCenter = center;
@@ -299,7 +299,7 @@ GameWorldPanel::GameWorldPanel(Game &game)
 				game.popSubPanel();
 			};
 
-			game.pushSubPanel<TextSubPanel>(game, center, richText, function, 
+			game.pushSubPanel<TextSubPanel>(game, center, richText, function,
 				std::move(texture), textureCenter);
 		};
 		return Button<Game&>(177, 151, 29, 22, function);
@@ -417,7 +417,7 @@ GameWorldPanel::GameWorldPanel(Game &game)
 						location.getName(gameData.getCityDataFile(), exeData) : std::string();
 				}();
 
-				game.setPanel<AutomapPanel>(game, Double2(position.x, position.z), 
+				game.setPanel<AutomapPanel>(game, Double2(position.x, position.z),
 					player.getGroundDirection(), level.getVoxelGrid(), automapLocationName);
 			}
 			else
@@ -972,8 +972,8 @@ void GameWorldPanel::handlePlayerTurning(double dt, const Int2 &mouseDelta)
 		{
 			const Int2 dimensions = game.getRenderer().getWindowDimensions();
 
-			// Get the smaller of the two dimensions, so the look sensitivity is relative 
-			// to a square instead of a rectangle. This keeps the camera look independent 
+			// Get the smaller of the two dimensions, so the look sensitivity is relative
+			// to a square instead of a rectangle. This keeps the camera look independent
 			// of the aspect ratio.
 			const int minDimension = std::min(dimensions.x, dimensions.y);
 			const double dxx = static_cast<double>(dx) / static_cast<double>(minDimension);
@@ -1005,7 +1005,7 @@ void GameWorldPanel::handlePlayerMovement(double dt)
 	if (!modernInterface)
 	{
 		// Classic interface mode.
-		// Arena uses arrow keys, but let's use the left hand side of the keyboard 
+		// Arena uses arrow keys, but let's use the left hand side of the keyboard
 		// because we like being comfortable.
 
 		// A and D turn the player, and if Ctrl is held, the player slides instead.
@@ -1022,7 +1022,7 @@ void GameWorldPanel::handlePlayerMovement(double dt)
 		bool space = inputManager.keyIsDown(SDL_SCANCODE_SPACE);
 		bool lCtrl = inputManager.keyIsDown(SDL_SCANCODE_LCTRL);
 
-		// The original game didn't have sprinting, but it seems like something 
+		// The original game didn't have sprinting, but it seems like something
 		// relevant to do anyway (at least for development).
 		bool isRunning = inputManager.keyIsDown(SDL_SCANCODE_LSHIFT);
 
@@ -1096,7 +1096,7 @@ void GameWorldPanel::handlePlayerMovement(double dt)
 			// Use a normalized direction.
 			accelDirection = accelDirection.normalized();
 
-			// Set the magnitude of the acceleration to some arbitrary number. These values 
+			// Set the magnitude of the acceleration to some arbitrary number. These values
 			// are independent of max speed.
 			double accelMagnitude = percent * (isRunning ? runSpeed : walkSpeed);
 
@@ -1143,7 +1143,7 @@ void GameWorldPanel::handlePlayerMovement(double dt)
 			// Use a normalized direction.
 			accelDirection = accelDirection.normalized();
 
-			// Set the magnitude of the acceleration to some arbitrary number. These values 
+			// Set the magnitude of the acceleration to some arbitrary number. These values
 			// are independent of max speed.
 			double accelMagnitude = isRunning ? runSpeed : walkSpeed;
 
@@ -1169,7 +1169,7 @@ void GameWorldPanel::handlePlayerMovement(double dt)
 		bool right = inputManager.keyIsDown(SDL_SCANCODE_D);
 		bool space = inputManager.keyIsDown(SDL_SCANCODE_SPACE);
 
-		// The original game didn't have sprinting, but it seems like something 
+		// The original game didn't have sprinting, but it seems like something
 		// relevant to do anyway (at least for development).
 		bool isRunning = inputManager.keyIsDown(SDL_SCANCODE_LSHIFT);
 
@@ -1210,7 +1210,7 @@ void GameWorldPanel::handlePlayerMovement(double dt)
 			// Use a normalized direction.
 			accelDirection = accelDirection.normalized();
 
-			// Set the magnitude of the acceleration to some arbitrary number. These values 
+			// Set the magnitude of the acceleration to some arbitrary number. These values
 			// are independent of max speed.
 			double accelMagnitude = isRunning ? runSpeed : walkSpeed;
 
@@ -1231,12 +1231,12 @@ void GameWorldPanel::handlePlayerMovement(double dt)
 
 void GameWorldPanel::handlePlayerAttack(const Int2 &mouseDelta)
 {
-	// @todo: run this method at fixed time-steps instead of every frame, because if, 
-	// for example, the game is running at 200 fps, then the player has to move their 
-	// cursor much faster for it to count as a swing. The GameWorldPanel would probably 
+	// @todo: run this method at fixed time-steps instead of every frame, because if,
+	// for example, the game is running at 200 fps, then the player has to move their
+	// cursor much faster for it to count as a swing. The GameWorldPanel would probably
 	// need to save its own "swing" mouse delta independently of the input manager, or
 	// maybe the game loop could call a "Panel::fixedTick()" method.
-	
+
 	// Only handle attacking if the player's weapon is currently idle.
 	auto &weaponAnimation = this->getGame().getGameData().getPlayer().getWeaponAnimation();
 	if (weaponAnimation.isIdle())
@@ -1249,7 +1249,7 @@ void GameWorldPanel::handlePlayerAttack(const Int2 &mouseDelta)
 			// Handle melee attack.
 			const Int2 dimensions = this->getGame().getRenderer().getWindowDimensions();
 
-			// Get the smaller of the two dimensions, so the percentage change in mouse position 
+			// Get the smaller of the two dimensions, so the percentage change in mouse position
 			// is relative to a square instead of a rectangle.
 			const int minDimension = std::min(dimensions.x, dimensions.y);
 
@@ -1360,7 +1360,7 @@ void GameWorldPanel::handlePlayerAttack(const Int2 &mouseDelta)
 				audioManager.playSound(SoundFile::fromName(SoundName::ArrowFire));
 			}
 		}
-	}	
+	}
 }
 
 void GameWorldPanel::handleClickInWorld(const Int2 &nativePoint, bool primaryClick,
@@ -1514,7 +1514,10 @@ void GameWorldPanel::handleClickInWorld(const Int2 &nativePoint, bool primaryCli
 						const auto &inf = level.getInfFile();
 						const std::string &soundFilename = inf.getSound(soundIndex);
 						auto &audioManager = game.getAudioManager();
-						audioManager.playSound(soundFilename);
+						auto const &doorPosition = std::make_optional(
+							Double3(voxelXZ.x + 0.5, 0.5, voxelXZ.y + 0.5)
+						);
+						audioManager.playSound(soundFilename, doorPosition);
 					}
 				}
 			}
@@ -1654,7 +1657,7 @@ void GameWorldPanel::handleTriggers(const Int2 &voxel)
 		LevelData::TextTrigger *textTrigger = level.getTextTrigger(voxel);
 		if (textTrigger != nullptr)
 		{
-			// Only display it if it should be displayed (i.e., not already displayed 
+			// Only display it if it should be displayed (i.e., not already displayed
 			// if it's a single-display text).
 			const bool canDisplay = !textTrigger->isSingleDisplay() ||
 				(textTrigger->isSingleDisplay() && !textTrigger->hasBeenDisplayed());
@@ -1684,7 +1687,7 @@ void GameWorldPanel::handleTriggers(const Int2 &voxel)
 					&shadowData,
 					game.getRenderer());
 
-				// Assign the text box and its duration to the triggered text member. It will 
+				// Assign the text box and its duration to the triggered text member. It will
 				// be displayed in the render method until the duration is no longer positive.
 				auto &gameData = game.getGameData();
 				auto &triggerText = gameData.getTriggerText();
@@ -1720,14 +1723,18 @@ void GameWorldPanel::handleDoors(double dt, const Double2 &playerPos)
 	// Lambda for playing a sound by .INF sound index if the close sound types match.
 	auto playSoundIfType = [&game, &activeLevel](
 		const VoxelData::DoorData::CloseSoundData &closeSoundData,
-		VoxelData::DoorData::CloseSoundType closeSoundType)
+		VoxelData::DoorData::CloseSoundType closeSoundType,
+		const LevelData::DoorState &doorState)
 	{
 		if (closeSoundData.type == closeSoundType)
 		{
 			const auto &inf = activeLevel.getInfFile();
 			const std::string &soundFilename = inf.getSound(closeSoundData.soundIndex);
 			auto &audioManager = game.getAudioManager();
-			audioManager.playSound(soundFilename);
+			const auto &doorPosition = std::make_optional(
+				Double3(doorState.getVoxel().x, 0.5, doorState.getVoxel().y)
+			);
+			audioManager.playSound(soundFilename, doorPosition);
 		}
 	};
 
@@ -1749,7 +1756,7 @@ void GameWorldPanel::handleDoors(double dt, const Double2 &playerPos)
 		if (door.isClosed())
 		{
 			// Only some doors play a sound when they become closed.
-			playSoundIfType(closeSoundData, VoxelData::DoorData::CloseSoundType::OnClosed);
+			playSoundIfType(closeSoundData, VoxelData::DoorData::CloseSoundType::OnClosed, door);
 
 			// Erase closed door.
 			openDoors.erase(openDoors.begin() + i);
@@ -1774,7 +1781,7 @@ void GameWorldPanel::handleDoors(double dt, const Double2 &playerPos)
 				door.setDirection(LevelData::DoorState::Direction::Closing);
 
 				// Only some doors play a sound when they start closing.
-				playSoundIfType(closeSoundData, VoxelData::DoorData::CloseSoundType::OnClosing);
+				playSoundIfType(closeSoundData, VoxelData::DoorData::CloseSoundType::OnClosing, door);
 			}
 		}
 	}
@@ -1952,7 +1959,7 @@ void GameWorldPanel::handleWorldTransition(const Physics::Hit &hit, int menuID)
 				const auto &location = gameData.getLocation();
 				const int starCount = DistantSky::getStarCountFromDensity(
 					game.getOptions().getMisc_StarDensity());
-				
+
 				if (isCity)
 				{
 					// From city to wilderness. Use the gate position to determine where to put the
@@ -2017,7 +2024,7 @@ void GameWorldPanel::handleWorldTransition(const Physics::Hit &hit, int menuID)
 							game.getMiscAssets(), game.getTextureManager(), game.getRenderer());
 					}
 				}
-				
+
 				// Reset the current music (even if it's the same one).
 				const MusicName musicName = [&game, &gameData, &location]()
 				{
@@ -2220,7 +2227,7 @@ void GameWorldPanel::drawTooltip(const std::string &text, Renderer &renderer)
 		gameInterface.getHeight() - tooltip.getHeight());
 }
 
-void GameWorldPanel::drawCompass(const Double2 &direction, 
+void GameWorldPanel::drawCompass(const Double2 &direction,
 	TextureManager &textureManager, Renderer &renderer)
 {
 	// Draw compass slider based on player direction. +X is north, +Z is east.
@@ -2230,8 +2237,8 @@ void GameWorldPanel::drawCompass(const Double2 &direction,
 	// Angle between 0 and 2 pi.
 	const double angle = std::atan2(direction.y, direction.x);
 
-	// Offset in the "slider" texture. Due to how SLIDER.IMG is drawn, there's a 
-	// small "pop-in" when turning from N to NE, because N is drawn in two places, 
+	// Offset in the "slider" texture. Due to how SLIDER.IMG is drawn, there's a
+	// small "pop-in" when turning from N to NE, because N is drawn in two places,
 	// but the second place (offset == 256) has tick marks where "NE" should be.
 	const int xOffset = static_cast<int>(240.0 +
 		std::round(256.0 * (angle / (2.0 * Constants::Pi)))) % 256;
@@ -2280,7 +2287,7 @@ void GameWorldPanel::drawProfiler(int profilerLevel, Renderer &renderer)
 		const std::string frameTimeText = String::fixedPrecision(frameTimeMS, 1);
 		const std::string text = "FPS: " + fpsText + " (" + frameTimeText + "ms)";
 		const RichTextString richText(
-			text, 
+			text,
 			FontName::D,
 			Color::White,
 			TextAlignment::Left,
@@ -2373,7 +2380,7 @@ void GameWorldPanel::drawProfiler(int profilerLevel, Renderer &renderer)
 		const Renderer::ProfilerData &profilerData = renderer.getProfilerData();
 		const std::string renderTime = String::fixedPrecision(profilerData.frameTime * 1000.0, 2);
 
-		const std::string text = 
+		const std::string text =
 			"3D render: " + renderTime + "ms" + "\n\n" +
 			"FPS Graph:" + '\n' +
 			"                               " + std::to_string(targetFps) + "\n\n\n\n" +
@@ -2483,10 +2490,10 @@ void GameWorldPanel::tick(double dt)
 	const double newClockTime = newClock.getPreciseTotalSeconds();
 	const double lamppostActivateTime = Clock::LamppostActivate.getPreciseTotalSeconds();
 	const double lamppostDeactivateTime = Clock::LamppostDeactivate.getPreciseTotalSeconds();
-	const bool activateNightLights = 
+	const bool activateNightLights =
 		(oldClockTime < lamppostActivateTime) &&
 		(newClockTime >= lamppostActivateTime);
-	const bool deactivateNightLights = 
+	const bool deactivateNightLights =
 		(oldClockTime < lamppostDeactivateTime) &&
 		(newClockTime >= lamppostDeactivateTime);
 
@@ -2603,7 +2610,7 @@ void GameWorldPanel::render(Renderer &renderer)
 	renderer.clear();
 
 	// Draw game world onto the native frame buffer. The game world buffer
-	// might not completely fill up the native buffer (bottom corners), so 
+	// might not completely fill up the native buffer (bottom corners), so
 	// clearing the native buffer beforehand is still necessary.
 	auto &gameData = this->getGame().getGameData();
 	auto &player = gameData.getPlayer();
@@ -2624,7 +2631,7 @@ void GameWorldPanel::render(Renderer &renderer)
 			return gameData.getAmbientPercent();
 		}
 	}();
-	
+
 	const double latitude = [&gameData]()
 	{
 		const Location &location = gameData.getLocation();
@@ -2766,7 +2773,7 @@ void GameWorldPanel::renderSecondary(Renderer &renderer)
 	}
 
 	// Draw each pop-up text if its duration is positive.
-	// - @todo: maybe give delta time to render()? Or store in tick()? I want to avoid 
+	// - @todo: maybe give delta time to render()? Or store in tick()? I want to avoid
 	//   subtracting the time in tick() because it would always be one frame shorter then.
 	auto &triggerText = gameData.getTriggerText();
 	auto &actionText = gameData.getActionText();

--- a/OpenTESArena/src/Interface/OptionsPanel.cpp
+++ b/OpenTESArena/src/Interface/OptionsPanel.cpp
@@ -232,6 +232,7 @@ const std::string OptionsPanel::VERTICAL_FOV_NAME = "Vertical FOV";
 // Audio.
 const std::string OptionsPanel::SOUND_CHANNELS_NAME = "Sound Channels";
 const std::string OptionsPanel::SOUND_RESAMPLING_NAME = "Sound Resampling";
+const std::string OptionsPanel::IS_3D_AUDIO_NAME = "Is 3D Audio";
 
 // Input.
 const std::string OptionsPanel::HORIZONTAL_SENSITIVITY_NAME = "Horizontal Sensitivity";
@@ -560,6 +561,20 @@ OptionsPanel::OptionsPanel(Game &game)
 
 	soundResamplingOption->setDisplayOverrides({ "Default", "Fastest", "Medium", "Best" });
 	this->audioOptions.push_back(std::move(soundResamplingOption));
+
+	this->audioOptions.push_back(std::make_unique<BoolOption>(
+		OptionsPanel::IS_3D_AUDIO_NAME,
+		"Determines whether sounds in the game world have a 3D position.\nSet to false for classic behavior.",
+		options.getAudio_Is3DAudio(),
+		[this](bool value)
+	{
+		auto &game = this->getGame();
+		auto &options = game.getOptions();
+		options.setAudio_Is3DAudio(value);
+
+		auto &audioManager = game.getAudioManager();
+		audioManager.set3D(value);
+	}));
 
 	// Create input options.
 	this->inputOptions.push_back(std::make_unique<DoubleOption>(

--- a/OpenTESArena/src/Interface/OptionsPanel.h
+++ b/OpenTESArena/src/Interface/OptionsPanel.h
@@ -148,6 +148,7 @@ private:
 	// Audio.
 	static const std::string SOUND_CHANNELS_NAME;
 	static const std::string SOUND_RESAMPLING_NAME;
+	static const std::string IS_3D_AUDIO_NAME;
 
 	// Input.
 	static const std::string HORIZONTAL_SENSITIVITY_NAME;

--- a/OpenTESArena/src/Media/AudioManager.cpp
+++ b/OpenTESArena/src/Media/AudioManager.cpp
@@ -98,8 +98,21 @@ public:
 	void setListenerPosition(const Double3 &position);
 	void setListenerOrientation(const Double3 &direction);
 
-	void update();
+	void update(const AudioManager::ListenerData *listenerData);
 };
+
+AudioManager::ListenerData::ListenerData(const Double3 &position, const Double3 &direction)
+	: position(position), direction(direction) { }
+
+const Double3 &AudioManager::ListenerData::getPosition() const
+{
+	return this->position;
+}
+
+const Double3 &AudioManager::ListenerData::getDirection() const
+{
+	return this->direction;
+}
 
 const ALint AudioManagerImpl::UNSUPPORTED_EXTENSION = -1;
 
@@ -490,7 +503,7 @@ void AudioManagerImpl::init(double musicVolume, double soundVolume, int maxChann
 		alSource3f(source, AL_POSITION, 0.0f, 0.0f, 0.0f);
 		alSource3f(source, AL_DIRECTION, 0.0f, 0.0f, 0.0f);
 		alSource3f(source, AL_VELOCITY, 0.0f, 0.0f, 0.0f);
-		alSourcef(source, AL_GAIN, this->mSfxVolume);
+		alSourcef(source, AL_GAIN, mSfxVolume);
 		alSourcef(source, AL_PITCH, 1.0f);
 		alSourcei(source, AL_SOURCE_RELATIVE, AL_FALSE);
 
@@ -725,8 +738,15 @@ void AudioManagerImpl::setListenerOrientation(const Double3 &direction)
 	alListenerfv(AL_ORIENTATION, orientation.data());
 }
 
-void AudioManagerImpl::update()
+void AudioManagerImpl::update(const AudioManager::ListenerData *listenerData)
 {
+	// Update listener values if there is a listener currently active.
+	if (listenerData != nullptr)
+	{
+		this->setListenerPosition(listenerData->getPosition());
+		this->setListenerOrientation(listenerData->getDirection());
+	}
+
 	// If a sound source is done, reset it and return the ID to the free sources.
 	for (size_t i = 0; i < mUsedSources.size(); i++)
 	{
@@ -821,17 +841,7 @@ void AudioManager::setResamplingOption(int resamplingOption)
 	pImpl->setResamplingOption(resamplingOption);
 }
 
-void AudioManager::setListenerPosition(const Double3 &position)
+void AudioManager::update(const ListenerData *listenerData)
 {
-	pImpl->setListenerPosition(position);
-}
-
-void AudioManager::setListenerOrientation(const Double3 &direction)
-{
-	pImpl->setListenerOrientation(direction);
-}
-
-void AudioManager::update()
-{
-	pImpl->update();
+	pImpl->update(listenerData);
 }

--- a/OpenTESArena/src/Media/AudioManager.cpp
+++ b/OpenTESArena/src/Media/AudioManager.cpp
@@ -96,7 +96,7 @@ public:
 	void setSoundVolume(double percent);
 	void setResamplingOption(int value);
 	void setListenerPosition(const Double3 &position);
-	void setListenerOrientation(const Double3 &at);
+	void setListenerOrientation(const Double3 &direction);
 
 	void update();
 };

--- a/OpenTESArena/src/Media/AudioManager.h
+++ b/OpenTESArena/src/Media/AudioManager.h
@@ -32,17 +32,13 @@ public:
 	// Returns whether the implementation supports resampling options.
 	bool hasResamplerExtension() const;
 
-	// Sets the global listener's position/orientation (in world coordinates).
-	void setListenerPosition(const Double3 &position);
-	void setListenerOrientation(const Double3 &at);
-
 	// Plays a music file. All music should loop until changed.
 	void playMusic(const std::string &filename);
 
-	// Plays a sound file. All sounds should play once.
-	// If 'position' is equal to std::nullopt then the sound is played globally.
+	// Plays a sound file. All sounds should play once. If 'position' is empty then the sound
+	// is played globally.
 	void playSound(const std::string &filename,
-	               const std::optional<Double3> &position = std::nullopt);
+		const std::optional<Double3> &position = std::nullopt);
 
 	// Stops the music.
 	void stopMusic();
@@ -60,6 +56,10 @@ public:
 	// necessarily map to a specific index in the resampling list. Causes an error if
 	// resampling options are not supported.
 	void setResamplingOption(int resamplingOption);
+
+	// Sets the global listener's position/orientation (in world coordinates).
+	void setListenerPosition(const Double3 &position);
+	void setListenerOrientation(const Double3 &direction);
 
 	// Updates any state not handled by a background thread, such as resetting
 	// the sources of finished sounds.

--- a/OpenTESArena/src/Media/AudioManager.h
+++ b/OpenTESArena/src/Media/AudioManager.h
@@ -2,8 +2,8 @@
 #define AUDIO_MANAGER_H
 
 #include <memory>
-#include <string>
 #include <optional>
+#include <string>
 
 #include "../Math/Vector3.h"
 
@@ -14,6 +14,19 @@ class Options;
 
 class AudioManager
 {
+public:
+	// Contains data for defining the state of an audio listener.
+	class ListenerData
+	{
+	private:
+		Double3 position;
+		Double3 direction;
+	public:
+		ListenerData(const Double3 &position, const Double3 &direction);
+
+		const Double3 &getPosition() const;
+		const Double3 &getDirection() const;
+	};
 private:
 	std::unique_ptr<AudioManagerImpl> pImpl;
 public:
@@ -57,13 +70,9 @@ public:
 	// resampling options are not supported.
 	void setResamplingOption(int resamplingOption);
 
-	// Sets the global listener's position/orientation (in world coordinates).
-	void setListenerPosition(const Double3 &position);
-	void setListenerOrientation(const Double3 &direction);
-
 	// Updates any state not handled by a background thread, such as resetting
-	// the sources of finished sounds.
-	void update();
+	// the sources of finished sounds, and updating listener values (if any).
+	void update(const ListenerData *listenerData);
 };
 
 #endif

--- a/OpenTESArena/src/Media/AudioManager.h
+++ b/OpenTESArena/src/Media/AudioManager.h
@@ -3,6 +3,9 @@
 
 #include <memory>
 #include <string>
+#include <optional>
+
+#include "../Math/Vector3.h"
 
 // This class manages what sounds and music are played by OpenAL Soft.
 
@@ -17,7 +20,7 @@ public:
 	AudioManager();
 	~AudioManager(); // Required for pImpl to stay in .cpp file.
 
-    void init(double musicVolume, double soundVolume, int maxChannels, 
+    void init(double musicVolume, double soundVolume, int maxChannels,
 		int resamplingOption, const std::string &midiConfig);
 
 	static const double MIN_VOLUME;
@@ -29,11 +32,17 @@ public:
 	// Returns whether the implementation supports resampling options.
 	bool hasResamplerExtension() const;
 
+	// Sets the global listener's position/orientation (in world coordinates).
+	void setListenerPosition(const Double3 &position);
+	void setListenerOrientation(const Double3 &at);
+
 	// Plays a music file. All music should loop until changed.
 	void playMusic(const std::string &filename);
 
 	// Plays a sound file. All sounds should play once.
-	void playSound(const std::string &filename);
+	// If 'position' is equal to std::nullopt then the sound is played globally.
+	void playSound(const std::string &filename,
+	               const std::optional<Double3> &position = std::nullopt);
 
 	// Stops the music.
 	void stopMusic();
@@ -52,7 +61,7 @@ public:
 	// resampling options are not supported.
 	void setResamplingOption(int resamplingOption);
 
-	// Updates any state not handled by a background thread, such as resetting 
+	// Updates any state not handled by a background thread, such as resetting
 	// the sources of finished sounds.
 	void update();
 };

--- a/OpenTESArena/src/Media/AudioManager.h
+++ b/OpenTESArena/src/Media/AudioManager.h
@@ -33,8 +33,8 @@ public:
 	AudioManager();
 	~AudioManager(); // Required for pImpl to stay in .cpp file.
 
-    void init(double musicVolume, double soundVolume, int maxChannels,
-		int resamplingOption, const std::string &midiConfig);
+    void init(double musicVolume, double soundVolume, int maxChannels, int resamplingOption,
+		bool is3D, const std::string &midiConfig);
 
 	static const double MIN_VOLUME;
 	static const double MAX_VOLUME;
@@ -69,6 +69,10 @@ public:
 	// necessarily map to a specific index in the resampling list. Causes an error if
 	// resampling options are not supported.
 	void setResamplingOption(int resamplingOption);
+
+	// Sets whether game world audio should be played in 2D (global) or 3D (with a listener).
+	// The 2D option is provided for parity with the original engine.
+	void set3D(bool is3D);
 
 	// Updates any state not handled by a background thread, such as resetting
 	// the sources of finished sounds, and updating listener values (if any).

--- a/options/options-default.txt
+++ b/options/options-default.txt
@@ -53,6 +53,10 @@ SoundChannels=32
 # 0: default, 1: fastest, 2: medium, 3: best.
 SoundResampling=0
 
+# Whether audio played in the game world has a 3D position or is centered
+# on the player like the original game.
+Is3DAudio=true
+
 [Input]
 # Look sensitivity is normally between 3.0 and 10.0.
 HorizontalSensitivity=5.0


### PR DESCRIPTION
I implemented a simple 3d audio system that satisfies the requests stated in issue #166 . Here are the changes:

- Added a couple of methods to the _AudioManager_ class that make it possible to change the global listener's position and orientation
- Modified the _playSound_ method to optionally accept a second argument that specifies the position of the source (if left unspecified, the sound will be played "everywhere")
- Updated the part of the code that make use of said features accordingly.

This is my first time using git(hub), so I apologize in advance if I messed up something.

Also, sorry for all of the unnecessary space removals, it was my editor's fault and I don't really know how to reverse them...

Let me know if you want me to change anything or if you think my approach could be improved :)