### PR TITLE
Add city entrance jingle

### DIFF
--- a/OpenTESArena/src/Game/Game.cpp
+++ b/OpenTESArena/src/Game/Game.cpp
@@ -235,10 +235,25 @@ void Game::popSubPanel()
 	this->requestedSubPanelPop = true;
 }
 
-void Game::setMusic(MusicName name)
+void Game::setMusic(MusicName musicName, const std::optional<MusicName> &jingleMusicName)
 {
-	const std::string &filename = MusicFile::fromName(name);
-	this->audioManager.playMusic(filename);
+	if (jingleMusicName.has_value())
+	{
+		// Play jingle first and set the main music as the next music.
+		const std::string &jingleFilename = MusicFile::fromName(*jingleMusicName);
+		const bool loop = false;
+		this->audioManager.playMusic(jingleFilename, loop);
+
+		std::string nextFilename = MusicFile::fromName(musicName);
+		this->audioManager.setNextMusic(std::move(nextFilename));
+	}
+	else
+	{
+		// Play main music immediately.
+		const std::string &filename = MusicFile::fromName(musicName);
+		const bool loop = true;
+		this->audioManager.playMusic(filename, loop);
+	}
 }
 
 void Game::setGameData(std::unique_ptr<GameData> gameData)
@@ -511,11 +526,11 @@ void Game::loop()
 				return AudioManager::ListenerData(position, direction);
 			}();
 
-			this->audioManager.update(&listenerData);
+			this->audioManager.update(dt, &listenerData);
 		}
 		else
 		{
-			this->audioManager.update(nullptr);
+			this->audioManager.update(dt, nullptr);
 		}
 
 		// Update FPS counter.

--- a/OpenTESArena/src/Game/Game.h
+++ b/OpenTESArena/src/Game/Game.h
@@ -2,6 +2,7 @@
 #define GAME_H
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -160,8 +161,8 @@ public:
 	// never call this, because if they are active, then there are no sub-panels to pop.
 	void popSubPanel();
 
-	// Sets the music to the given music name.
-	void setMusic(MusicName name);
+	// Sets the music to the given music name, with an optional jingle to play first.
+	void setMusic(MusicName musicName, const std::optional<MusicName> &jingleMusicName = std::nullopt);
 
 	// Sets the current game data object. A game session is active if the game data
 	// is not null.

--- a/OpenTESArena/src/Interface/FastTravelSubPanel.cpp
+++ b/OpenTESArena/src/Interface/FastTravelSubPanel.cpp
@@ -12,6 +12,7 @@
 #include "../Game/Game.h"
 #include "../Game/GameData.h"
 #include "../Media/FontName.h"
+#include "../Media/MusicFile.h"
 #include "../Media/MusicName.h"
 #include "../Media/MusicUtils.h"
 #include "../Media/PaletteFile.h"
@@ -386,8 +387,9 @@ void FastTravelSubPanel::switchToNextPanel()
 	if (travelLocationDef.getType() == LocationDefinition::Type::City)
 	{
 		// Get weather type from game data.
+		const LocationDefinition::CityDefinition &cityDef = travelLocationDef.getCityDefinition();
 		const WeatherType weatherType = [this, &game, &gameData, &miscAssets,
-			&travelProvinceDef, &travelLocationDef]()
+			&travelProvinceDef, &travelLocationDef, &cityDef]()
 		{
 			const Int2 localPoint(travelLocationDef.getScreenX(), travelLocationDef.getScreenY());
 			const Int2 globalPoint = LocationUtils::getGlobalPoint(
@@ -395,7 +397,6 @@ void FastTravelSubPanel::switchToNextPanel()
 
 			const auto &cityData = miscAssets.getCityDataFile();
 			const int globalQuarter = LocationUtils::getGlobalQuarter(globalPoint, cityData);
-			const LocationDefinition::CityDefinition &cityDef = travelLocationDef.getCityDefinition();
 
 			const auto &weathersArray = gameData.getWeathersArray();
 			DebugAssertIndex(weathersArray, globalQuarter);
@@ -415,7 +416,9 @@ void FastTravelSubPanel::switchToNextPanel()
 		// Choose time-based music and enter the game world.
 		const MusicName musicName = gameData.nightMusicIsActive() ?
 			MusicName::Night : MusicUtils::getExteriorMusicName(weatherType);
-		game.setMusic(musicName);
+		const MusicName jingleMusicName = MusicFile::jingleFromCityTypeAndClimate(cityDef.type, cityDef.climateType);
+
+		game.setMusic(musicName, jingleMusicName);
 		game.setPanel<GameWorldPanel>(game);
 
 		// Push a text sub-panel for the city arrival pop-up.

--- a/OpenTESArena/src/Interface/MainMenuPanel.cpp
+++ b/OpenTESArena/src/Interface/MainMenuPanel.cpp
@@ -590,12 +590,31 @@ MainMenuPanel::MainMenuPanel(Game &game)
 				}
 			}();
 
+			const std::optional<MusicName> jingleMusicName = [worldType, &gameData, musicName]()
+				-> std::optional<MusicName>
+			{
+				const LocationDefinition &locationDef = gameData->getLocationDefinition();
+				const bool isCity = (worldType == WorldType::City) &&
+					(locationDef.getType() == LocationDefinition::Type::City);
+
+				if (isCity)
+				{
+					const LocationDefinition::CityDefinition &cityDef = locationDef.getCityDefinition();
+					const ClimateType climateType = cityDef.climateType;
+					return MusicFile::jingleFromCityTypeAndClimate(cityDef.type, climateType);
+				}
+				else
+				{
+					return std::nullopt;
+				}
+			}();
+
 			// Set the game data before constructing the game world panel.
 			game.setGameData(std::move(gameData));
 
 			// Initialize game world panel.
 			game.setPanel<GameWorldPanel>(game);
-			game.setMusic(musicName);
+			game.setMusic(musicName, jingleMusicName);
 		};
 		return Button<Game&, int, int, const std::string&,
 			const std::optional<VoxelDefinition::WallData::MenuType>&, WeatherType, WorldType>(function);

--- a/OpenTESArena/src/Media/AudioManager.cpp
+++ b/OpenTESArena/src/Media/AudioManager.cpp
@@ -837,18 +837,8 @@ void AudioManagerImpl::update(double dt, const AudioManager::ListenerData *liste
 	// Check if another music is staged and should start when the current one is done.
 	if (this->hasNextMusic())
 	{
-		// @todo: if currently-playing music has reached its end, then play next music.
-		// - Can't query the active music source to see if it's done playing because looping is always false and
-		//   the looping is handled manually by the buffer-filling loop.
-		// - Maybe try AL_BUFFERS_PROCESSED?
-
 		DebugAssert(mSongStream != nullptr);
-		const bool currentMusicIsDone = !mSongStream->isPlaying();
-
-		// @todo: add a small buffer of time at the end of the previous song (using dt given to update())
-		// so it changes a bit more naturally.
-		const bool canChangeToNextMusic = currentMusicIsDone;
-
+		const bool canChangeToNextMusic = !mSongStream->isPlaying();
 		if (canChangeToNextMusic)
 		{
 			// Assume that the next music always loops.

--- a/OpenTESArena/src/Media/AudioManager.h
+++ b/OpenTESArena/src/Media/AudioManager.h
@@ -45,8 +45,8 @@ public:
 	// Returns whether the implementation supports resampling options.
 	bool hasResamplerExtension() const;
 
-	// Plays a music file. All music should loop until changed.
-	void playMusic(const std::string &filename);
+	// Plays a music file.
+	void playMusic(const std::string &filename, bool loop);
 
 	// Plays a sound file. All sounds should play once. If 'position' is empty then the sound
 	// is played globally.
@@ -74,9 +74,12 @@ public:
 	// The 2D option is provided for parity with the original engine.
 	void set3D(bool is3D);
 
+	// Sets the next music to play after the current one is finished.
+	void setNextMusic(std::string &&filename);
+
 	// Updates any state not handled by a background thread, such as resetting
 	// the sources of finished sounds, and updating listener values (if any).
-	void update(const ListenerData *listenerData);
+	void update(double dt, const ListenerData *listenerData);
 };
 
 #endif


### PR DESCRIPTION
Hey @kcat, I'm working on adding the city entrance jingle which requires supporting non-looping music in the OpenALStream. How should I listen for the end-of-song event? It seems like a hard problem because OpenAL Soft is fed the buffer in a fairly opaque manner and I don't see a way to get accurate timing. Maybe it involves counting `AL_BUFFERS_PROCESSED` with some multiple of the sample rate?

For very small music files, `OpenALStream::fillBuffer()` seems to be able to fully loop through the song and continue filling before the buffer is full. I thought of maybe filling the end of the buffer with zeroes if it tries asking for more samples at the end, but that would probably just result in extra silence.

I'm implementing the next music with `mNextSong` and `AudioManager::setNextMusic()`. The change from old music to new music occurs in `AudioManagerImpl::update()`.

(~as a side note, I think it would be better to define `mNextSong` as a `std::function` so that it is up-to-date in the audio manager in case the jingle happens right at a day/night music transition~ nevermind, the day/night event would call playMusic() anyway, so nothing would be out-of-date)

Thanks :)