### PR TITLE
Texture manager refactor

### DIFF
--- a/OpenTESArena/src/Game/Game.cpp
+++ b/OpenTESArena/src/Game/Game.cpp
@@ -74,9 +74,6 @@ Game::Game()
 		static_cast<Renderer::WindowMode>(this->options.getGraphics_WindowMode()),
 		this->options.getGraphics_LetterboxMode());
 
-	// Initialize the texture manager.
-	this->textureManager.init();
-
 	// Determine which version of the game the Arena path is pointing to.
 	const bool isFloppyVersion = [this, arenaPathIsRelative]()
 	{

--- a/OpenTESArena/src/Interface/AutomapPanel.h
+++ b/OpenTESArena/src/Interface/AutomapPanel.h
@@ -6,6 +6,7 @@
 #include "Button.h"
 #include "Panel.h"
 #include "../Math/Vector2.h"
+#include "../Media/TextureUtils.h"
 #include "../Rendering/Texture.h"
 #include "../World/VoxelUtils.h"
 
@@ -38,6 +39,7 @@ private:
 	std::unique_ptr<TextBox> locationTextBox;
 	Button<Game&> backToGameButton;
 	Texture mapTexture;
+	TextureID backgroundTextureID;
 
 	// XZ coordinate offset in automap space, stored as a real so scroll position can be sub-pixel.
 	Double2 automapOffset;

--- a/OpenTESArena/src/Interface/CharacterEquipmentPanel.cpp
+++ b/OpenTESArena/src/Interface/CharacterEquipmentPanel.cpp
@@ -265,10 +265,6 @@ void CharacterEquipmentPanel::render(Renderer &renderer)
 	// Clear full screen.
 	renderer.clear();
 
-	// Set palette.
-	auto &textureManager = this->getGame().getTextureManager();
-	textureManager.setPalette(PaletteFile::fromName(PaletteName::CharSheet));
-
 	// Get a reference to the active player data.
 	const auto &player = this->getGame().getGameData().getPlayer();
 
@@ -287,21 +283,46 @@ void CharacterEquipmentPanel::render(Renderer &renderer)
 	const Int2 pantsOffset = PortraitFile::getPantsOffset(player.isMale());
 
 	// Draw the current portrait and clothes.
+	auto &textureManager = this->getGame().getTextureManager();
 	const Int2 &headOffset = this->headOffsets.at(player.getPortraitID());
-	const auto &head = textureManager.getTextures(headsFilename,
-		PaletteFile::fromName(PaletteName::CharSheet), renderer).at(player.getPortraitID());
-	const auto &body = textureManager.getTexture(bodyFilename, renderer);
-	const auto &shirt = textureManager.getTexture(shirtFilename, renderer);
-	const auto &pants = textureManager.getTexture(pantsFilename, renderer);
-	renderer.drawOriginal(body, Renderer::ORIGINAL_WIDTH - body.getWidth(), 0);
-	renderer.drawOriginal(pants, pantsOffset.x, pantsOffset.y);
-	renderer.drawOriginal(head, headOffset.x, headOffset.y);
-	renderer.drawOriginal(shirt, shirtOffset.x, shirtOffset.y);
+	const Texture &headTexture = [this, &textureManager, &headsFilename, &player]() -> const Texture&
+	{
+		const TextureManager::IdGroup<TextureID> headTextureIDs =
+			this->getTextureIDs(headsFilename, PaletteFile::fromName(PaletteName::CharSheet));
+		const TextureID headTextureID = headTextureIDs.startID + player.getPortraitID();
+		return textureManager.getTexture(headTextureID);
+	}();
+
+	const Texture &bodyTexture = [this, &textureManager, &bodyFilename]() -> const Texture&
+	{
+		const TextureID bodyTextureID = this->getTextureID(
+			bodyFilename, PaletteFile::fromName(PaletteName::CharSheet));
+		return textureManager.getTexture(bodyTextureID);
+	}();
+
+	const Texture &shirtTexture = [this, &textureManager, &shirtFilename]() -> const Texture&
+	{
+		const TextureID shirtTextureID = this->getTextureID(
+			shirtFilename, PaletteFile::fromName(PaletteName::CharSheet));
+		return textureManager.getTexture(shirtTextureID);
+	}();
+
+	const Texture &pantsTexture = [this, &textureManager, &pantsFilename]() -> const Texture&
+	{
+		const TextureID pantsTextureID = this->getTextureID(
+			pantsFilename, PaletteFile::fromName(PaletteName::CharSheet));
+		return textureManager.getTexture(pantsTextureID);
+	}();
+	renderer.drawOriginal(bodyTexture, Renderer::ORIGINAL_WIDTH - bodyTexture.getWidth(), 0);
+	renderer.drawOriginal(pantsTexture, pantsOffset.x, pantsOffset.y);
+	renderer.drawOriginal(headTexture, headOffset.x, headOffset.y);
+	renderer.drawOriginal(shirtTexture, shirtOffset.x, shirtOffset.y);
 
 	// Draw character equipment background.
-	const auto &equipmentBackground = textureManager.getTexture(
-		TextureFile::fromName(TextureName::CharacterEquipment), renderer);
-	renderer.drawOriginal(equipmentBackground);
+	const TextureID equipmentBackgroundTextureID = this->getTextureID(
+		TextureName::CharacterEquipment, PaletteName::CharSheet);
+	const auto &equipmentBackgroundTexture = textureManager.getTexture(equipmentBackgroundTextureID);
+	renderer.drawOriginal(equipmentBackgroundTexture);
 
 	// Draw text boxes: player name, race, class.
 	renderer.drawOriginal(this->playerNameTextBox->getTexture(),

--- a/OpenTESArena/src/Interface/CharacterEquipmentPanel.cpp
+++ b/OpenTESArena/src/Interface/CharacterEquipmentPanel.cpp
@@ -202,13 +202,7 @@ CharacterEquipmentPanel::CharacterEquipmentPanel(Game &game)
 
 Panel::CursorData CharacterEquipmentPanel::getCurrentCursor() const
 {
-	auto &game = this->getGame();
-	auto &renderer = game.getRenderer();
-	auto &textureManager = game.getTextureManager();
-	const auto &texture = textureManager.getTexture(
-		TextureFile::fromName(TextureName::SwordCursor),
-		PaletteFile::fromName(PaletteName::Default), renderer);
-	return CursorData(&texture, CursorAlignment::TopLeft);
+	return this->getDefaultCursor();
 }
 
 void CharacterEquipmentPanel::handleEvent(const SDL_Event &e)

--- a/OpenTESArena/src/Interface/CharacterPanel.cpp
+++ b/OpenTESArena/src/Interface/CharacterPanel.cpp
@@ -125,13 +125,7 @@ CharacterPanel::CharacterPanel(Game &game)
 
 Panel::CursorData CharacterPanel::getCurrentCursor() const
 {
-	auto &game = this->getGame();
-	auto &renderer = game.getRenderer();
-	auto &textureManager = game.getTextureManager();
-	const auto &texture = textureManager.getTexture(
-		TextureFile::fromName(TextureName::SwordCursor),
-		PaletteFile::fromName(PaletteName::Default), renderer);
-	return CursorData(&texture, CursorAlignment::TopLeft);
+	return this->getDefaultCursor();
 }
 
 void CharacterPanel::handleEvent(const SDL_Event &e)
@@ -171,10 +165,6 @@ void CharacterPanel::render(Renderer &renderer)
 	// Clear full screen.
 	renderer.clear();
 
-	// Set palette.
-	auto &textureManager = this->getGame().getTextureManager();
-	textureManager.setPalette(PaletteFile::fromName(PaletteName::CharSheet));
-
 	// Get a reference to the active player data.
 	const auto &player = this->getGame().getGameData().getPlayer();
 
@@ -193,25 +183,52 @@ void CharacterPanel::render(Renderer &renderer)
 	const Int2 pantsOffset = PortraitFile::getPantsOffset(player.isMale());
 
 	// Draw the current portrait and clothes.
+	auto &textureManager = this->getGame().getTextureManager();
 	const Int2 &headOffset = this->headOffsets.at(player.getPortraitID());
-	const auto &head = textureManager.getTextures(headsFilename,
-		PaletteFile::fromName(PaletteName::CharSheet), renderer).at(player.getPortraitID());
-	const auto &body = textureManager.getTexture(bodyFilename, renderer);
-	const auto &shirt = textureManager.getTexture(shirtFilename, renderer);
-	const auto &pants = textureManager.getTexture(pantsFilename, renderer);
-	renderer.drawOriginal(body, Renderer::ORIGINAL_WIDTH - body.getWidth(), 0);
-	renderer.drawOriginal(pants, pantsOffset.x, pantsOffset.y);
-	renderer.drawOriginal(head, headOffset.x, headOffset.y);
-	renderer.drawOriginal(shirt, shirtOffset.x, shirtOffset.y);
+	const Texture &headTexture = [this, &textureManager, &headsFilename, &player]() -> const Texture&
+	{
+		const TextureManager::IdGroup<TextureID> headTextureIDs =
+			this->getTextureIDs(headsFilename, PaletteFile::fromName(PaletteName::CharSheet));
+		const TextureID headTextureID = headTextureIDs.startID + player.getPortraitID();
+		return textureManager.getTexture(headTextureID);
+	}();
+
+	const Texture &bodyTexture = [this, &textureManager, &bodyFilename]() -> const Texture&
+	{
+		const TextureID bodyTextureID = this->getTextureID(
+			bodyFilename, PaletteFile::fromName(PaletteName::CharSheet));
+		return textureManager.getTexture(bodyTextureID);
+	}();
+
+	const Texture &shirtTexture = [this, &textureManager, &shirtFilename]() -> const Texture&
+	{
+		const TextureID shirtTextureID = this->getTextureID(
+			shirtFilename, PaletteFile::fromName(PaletteName::CharSheet));
+		return textureManager.getTexture(shirtTextureID);
+	}();
+
+	const Texture &pantsTexture = [this, &textureManager, &pantsFilename]() -> const Texture&
+	{
+		const TextureID pantsTextureID = this->getTextureID(
+			pantsFilename, PaletteFile::fromName(PaletteName::CharSheet));
+		return textureManager.getTexture(pantsTextureID);
+	}();
+
+	renderer.drawOriginal(bodyTexture, Renderer::ORIGINAL_WIDTH - bodyTexture.getWidth(), 0);
+	renderer.drawOriginal(pantsTexture, pantsOffset.x, pantsOffset.y);
+	renderer.drawOriginal(headTexture, headOffset.x, headOffset.y);
+	renderer.drawOriginal(shirtTexture, shirtOffset.x, shirtOffset.y);
 
 	// Draw character stats background.
-	const auto &statsBackground = textureManager.getTexture(
-		TextureFile::fromName(TextureName::CharacterStats), renderer);
-	renderer.drawOriginal(statsBackground);
+	const TextureID statsBackgroundTextureID = this->getTextureID(
+		TextureName::CharacterStats, PaletteName::CharSheet);
+	const Texture &statsBackgroundTexture = textureManager.getTexture(statsBackgroundTextureID);
+	renderer.drawOriginal(statsBackgroundTexture);
 
 	// Draw "Next Page" texture.
-	const auto &nextPageTexture = textureManager.getTexture(
-		TextureFile::fromName(TextureName::NextPage), renderer);
+	const TextureID nextPageTextureID = this->getTextureID(
+		TextureName::NextPage, PaletteName::CharSheet);
+	const Texture &nextPageTexture = textureManager.getTexture(nextPageTextureID);
 	renderer.drawOriginal(nextPageTexture, 108, 179);
 
 	// Draw text boxes: player name, race, class.

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
@@ -286,10 +286,6 @@ ChooseAttributesPanel::ChooseAttributesPanel(Game &game)
 							return std::make_unique<GameData>(std::move(player), miscAssets);
 						}();
 
-						// Set palette (important for texture loading).
-						auto &textureManager = game.getTextureManager();
-						textureManager.setPalette(PaletteFile::fromName(PaletteName::Default));
-
 						// Find starting dungeon location definition.
 						const int provinceIndex = LocationUtils::CENTER_PROVINCE_ID;
 						const WorldMapDefinition &worldMapDef = gameData->getWorldMapDefinition();
@@ -325,6 +321,7 @@ ChooseAttributesPanel::ChooseAttributesPanel(Game &game)
 							DebugCrash("Could not init .MIF file \"" + mifName + "\".");
 						}
 
+						auto &textureManager = game.getTextureManager();
 						if (!gameData->loadInterior(*locationDefPtr, provinceDef,
 							VoxelDefinition::WallData::MenuType::Dungeon, mif, miscAssets,
 							textureManager, renderer))

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
@@ -651,13 +651,7 @@ ChooseAttributesPanel::ChooseAttributesPanel(Game &game)
 
 Panel::CursorData ChooseAttributesPanel::getCurrentCursor() const
 {
-	auto &game = this->getGame();
-	auto &renderer = game.getRenderer();
-	auto &textureManager = game.getTextureManager();
-	const auto &texture = textureManager.getTexture(
-		TextureFile::fromName(TextureName::SwordCursor),
-		PaletteFile::fromName(PaletteName::Default), renderer);
-	return CursorData(&texture, CursorAlignment::TopLeft);
+	return this->getDefaultCursor();
 }
 
 void ChooseAttributesPanel::handleEvent(const SDL_Event &e)
@@ -707,11 +701,7 @@ void ChooseAttributesPanel::render(Renderer &renderer)
 	// Clear full screen.
 	renderer.clear();
 
-	// Set palette.
 	auto &game = this->getGame();
-	auto &textureManager = game.getTextureManager();
-	textureManager.setPalette(PaletteFile::fromName(PaletteName::CharSheet));
-
 	const auto &charCreationState = game.getCharacterCreationState();
 	const bool male = charCreationState.isMale();
 	const int raceIndex = charCreationState.getRaceIndex();
@@ -736,21 +726,51 @@ void ChooseAttributesPanel::render(Renderer &renderer)
 	const Int2 pantsOffset = PortraitFile::getPantsOffset(male);
 
 	// Draw the current portrait and clothes.
+	auto &textureManager = game.getTextureManager();
 	const Int2 &headOffset = this->headOffsets.at(portraitIndex);
-	const auto &head = textureManager.getTextures(headsFilename,
-		PaletteFile::fromName(PaletteName::CharSheet), renderer).at(portraitIndex);
-	const auto &body = textureManager.getTexture(bodyFilename, renderer);
-	const auto &shirt = textureManager.getTexture(shirtFilename, renderer);
-	const auto &pants = textureManager.getTexture(pantsFilename, renderer);
-	renderer.drawOriginal(body, Renderer::ORIGINAL_WIDTH - body.getWidth(), 0);
-	renderer.drawOriginal(pants, pantsOffset.x, pantsOffset.y);
-	renderer.drawOriginal(head, headOffset.x, headOffset.y);
-	renderer.drawOriginal(shirt, shirtOffset.x, shirtOffset.y);
+	const Texture &headTexture = [this, &textureManager, portraitIndex, &headsFilename]() -> const Texture&
+	{
+		const TextureManager::IdGroup<TextureID> headTextureIDs =
+			this->getTextureIDs(headsFilename, PaletteFile::fromName(PaletteName::CharSheet));
+		const TextureID headTextureID = headTextureIDs.startID + portraitIndex;
+		return textureManager.getTexture(headTextureID);
+	}();
+
+	const Texture &bodyTexture = [this, &textureManager, &bodyFilename]() -> const Texture&
+	{
+		const TextureID bodyTextureID = this->getTextureID(
+			bodyFilename, PaletteFile::fromName(PaletteName::CharSheet));
+		return textureManager.getTexture(bodyTextureID);
+	}();
+
+	const Texture &shirtTexture = [this, &textureManager, &shirtFilename]() -> const Texture&
+	{
+		const TextureID shirtTextureID = this->getTextureID(
+			shirtFilename, PaletteFile::fromName(PaletteName::CharSheet));
+		return textureManager.getTexture(shirtTextureID);
+	}();
+
+	const Texture &pantsTexture = [this, &textureManager, &pantsFilename]() -> const Texture&
+	{
+		const TextureID pantsTextureID = this->getTextureID(
+			pantsFilename, PaletteFile::fromName(PaletteName::CharSheet));
+		return textureManager.getTexture(pantsTextureID);
+	}();
+
+	renderer.drawOriginal(bodyTexture, Renderer::ORIGINAL_WIDTH - bodyTexture.getWidth(), 0);
+	renderer.drawOriginal(pantsTexture, pantsOffset.x, pantsOffset.y);
+	renderer.drawOriginal(headTexture, headOffset.x, headOffset.y);
+	renderer.drawOriginal(shirtTexture, shirtOffset.x, shirtOffset.y);
 
 	// Draw attributes texture.
-	const auto &attributesBackground = textureManager.getTexture(
-		TextureFile::fromName(TextureName::CharacterStats), renderer);
-	renderer.drawOriginal(attributesBackground);
+	const Texture &attributesBackgroundTexture = [this, &textureManager]() -> const Texture&
+	{
+		const TextureID attributesBackgroundTextureID = this->getTextureID(
+			TextureName::CharacterStats, PaletteName::CharSheet);
+		return textureManager.getTexture(attributesBackgroundTextureID);
+	}();
+
+	renderer.drawOriginal(attributesBackgroundTexture);
 
 	// Draw text boxes: player name, race, class.
 	renderer.drawOriginal(this->nameTextBox->getTexture(),

--- a/OpenTESArena/src/Interface/ChooseClassCreationPanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseClassCreationPanel.cpp
@@ -131,13 +131,7 @@ ChooseClassCreationPanel::ChooseClassCreationPanel(Game &game)
 
 Panel::CursorData ChooseClassCreationPanel::getCurrentCursor() const
 {
-	auto &game = this->getGame();
-	auto &renderer = game.getRenderer();
-	auto &textureManager = game.getTextureManager();
-	const auto &texture = textureManager.getTexture(
-		TextureFile::fromName(TextureName::SwordCursor),
-		PaletteFile::fromName(PaletteName::Default), renderer);
-	return CursorData(&texture, CursorAlignment::TopLeft);
+	return this->getDefaultCursor();
 }
 
 void ChooseClassCreationPanel::handleEvent(const SDL_Event &e)
@@ -192,15 +186,12 @@ void ChooseClassCreationPanel::render(Renderer &renderer)
 	// Clear full screen.
 	renderer.clear();
 
-	// Set palette.
-	auto &textureManager = this->getGame().getTextureManager();
-	textureManager.setPalette(PaletteFile::fromName(PaletteName::Default));
-
 	// Draw background.
-	const auto &background = textureManager.getTexture(
-		TextureFile::fromName(TextureName::CharacterCreation),
-		PaletteFile::fromName(PaletteName::BuiltIn), renderer);
-	renderer.drawOriginal(background);
+	auto &textureManager = this->getGame().getTextureManager();
+	const TextureID backgroundTextureID = this->getTextureID(
+		TextureName::CharacterCreation, PaletteName::BuiltIn);
+	const Texture &backgroundTexture = textureManager.getTexture(backgroundTextureID);
+	renderer.drawOriginal(backgroundTexture);
 
 	// Draw parchments: title, generate, select.
 	const int parchmentX = (Renderer::ORIGINAL_WIDTH / 2) - 

--- a/OpenTESArena/src/Interface/ChooseClassPanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseClassPanel.cpp
@@ -165,13 +165,7 @@ ChooseClassPanel::ChooseClassPanel(Game &game)
 
 Panel::CursorData ChooseClassPanel::getCurrentCursor() const
 {
-	auto &game = this->getGame();
-	auto &renderer = game.getRenderer();
-	auto &textureManager = game.getTextureManager();
-	const auto &texture = textureManager.getTexture(
-		TextureFile::fromName(TextureName::SwordCursor),
-		PaletteFile::fromName(PaletteName::Default), renderer);
-	return CursorData(&texture, CursorAlignment::TopLeft);
+	return this->getDefaultCursor();
 }
 
 void ChooseClassPanel::handleEvent(const SDL_Event &e)
@@ -438,23 +432,21 @@ void ChooseClassPanel::render(Renderer &renderer)
 	// Clear full screen.
 	renderer.clear();
 
-	// Set palette.
+	// Draw background.
 	auto &game = this->getGame();
 	auto &textureManager = game.getTextureManager();
-	textureManager.setPalette(PaletteFile::fromName(PaletteName::Default));
-
-	// Draw background.
-	const auto &background = textureManager.getTexture(
-		TextureFile::fromName(TextureName::CharacterCreation),
-		PaletteFile::fromName(PaletteName::BuiltIn), renderer);
-	renderer.drawOriginal(background);
+	const TextureID backgroundTextureID = this->getTextureID(
+		TextureName::CharacterCreation, PaletteName::BuiltIn);
+	const Texture &backgroundTexture = textureManager.getTexture(backgroundTextureID);
+	renderer.drawOriginal(backgroundTexture);
 
 	// Draw list pop-up.
-	const auto &listPopUp = textureManager.getTexture(
+	const TextureID listPopUpTextureID = this->getTextureID(
 		TextureFile::fromName(TextureName::PopUp2),
-		TextureFile::fromName(TextureName::CharacterCreation), renderer);
-	renderer.drawOriginal(listPopUp, 55, 9,
-		listPopUp.getWidth(), listPopUp.getHeight());
+		TextureFile::fromName(TextureName::CharacterCreation));
+	const Texture &listPopUpTexture = textureManager.getTexture(listPopUpTextureID);
+	renderer.drawOriginal(listPopUpTexture, 55, 9,
+		listPopUpTexture.getWidth(), listPopUpTexture.getHeight());
 
 	// Draw text: title, list.
 	renderer.drawOriginal(this->titleTextBox->getTexture(),

--- a/OpenTESArena/src/Interface/ChooseGenderPanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseGenderPanel.cpp
@@ -123,13 +123,7 @@ ChooseGenderPanel::ChooseGenderPanel(Game &game)
 
 Panel::CursorData ChooseGenderPanel::getCurrentCursor() const
 {
-	auto &game = this->getGame();
-	auto &renderer = game.getRenderer();
-	auto &textureManager = game.getTextureManager();
-	const auto &texture = textureManager.getTexture(
-		TextureFile::fromName(TextureName::SwordCursor),
-		PaletteFile::fromName(PaletteName::Default), renderer);
-	return CursorData(&texture, CursorAlignment::TopLeft);
+	return this->getDefaultCursor();
 }
 
 void ChooseGenderPanel::handleEvent(const SDL_Event &e)
@@ -166,15 +160,12 @@ void ChooseGenderPanel::render(Renderer &renderer)
 	// Clear full screen.
 	renderer.clear();
 
-	// Set palette.
-	auto &textureManager = this->getGame().getTextureManager();
-	textureManager.setPalette(PaletteFile::fromName(PaletteName::Default));
-
 	// Draw background.
-	const auto &background = textureManager.getTexture(
-		TextureFile::fromName(TextureName::CharacterCreation),
-		PaletteFile::fromName(PaletteName::BuiltIn), renderer);
-	renderer.drawOriginal(background);
+	auto &textureManager = this->getGame().getTextureManager();
+	const TextureID backgroundTextureID = this->getTextureID(
+		TextureName::CharacterCreation, PaletteName::BuiltIn);
+	const Texture &backgroundTexture = textureManager.getTexture(backgroundTextureID);
+	renderer.drawOriginal(backgroundTexture);
 
 	// Draw parchments: title, male, and female.
 	const int parchmentX = (Renderer::ORIGINAL_WIDTH / 2) -

--- a/OpenTESArena/src/Interface/ChooseNamePanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseNamePanel.cpp
@@ -112,13 +112,7 @@ ChooseNamePanel::ChooseNamePanel(Game &game)
 
 Panel::CursorData ChooseNamePanel::getCurrentCursor() const
 {
-	auto &game = this->getGame();
-	auto &renderer = game.getRenderer();
-	auto &textureManager = game.getTextureManager();
-	const auto &texture = textureManager.getTexture(
-		TextureFile::fromName(TextureName::SwordCursor),
-		PaletteFile::fromName(PaletteName::Default), renderer);
-	return CursorData(&texture, CursorAlignment::TopLeft);
+	return this->getDefaultCursor();
 }
 
 void ChooseNamePanel::handleEvent(const SDL_Event &e)
@@ -180,15 +174,12 @@ void ChooseNamePanel::render(Renderer &renderer)
 	// Clear full screen.
 	renderer.clear();
 
-	// Set palette.
-	auto &textureManager = this->getGame().getTextureManager();
-	textureManager.setPalette(PaletteFile::fromName(PaletteName::Default));
-
 	// Draw background.
-	const auto &background = textureManager.getTexture(
-		TextureFile::fromName(TextureName::CharacterCreation),
-		PaletteFile::fromName(PaletteName::BuiltIn), renderer);
-	renderer.drawOriginal(background);
+	auto &textureManager = this->getGame().getTextureManager();
+	const TextureID backgroundTextureID = this->getTextureID(
+		TextureName::CharacterCreation, PaletteName::BuiltIn);
+	const Texture &backgroundTexture = textureManager.getTexture(backgroundTextureID);
+	renderer.drawOriginal(backgroundTexture);
 
 	// Draw parchment: title.
 	renderer.drawOriginal(this->parchment,

--- a/OpenTESArena/src/Interface/ChooseRacePanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseRacePanel.cpp
@@ -547,13 +547,7 @@ int ChooseRacePanel::getProvinceMaskID(const Int2 &position) const
 
 Panel::CursorData ChooseRacePanel::getCurrentCursor() const
 {
-	auto &game = this->getGame();
-	auto &renderer = game.getRenderer();
-	auto &textureManager = game.getTextureManager();
-	const auto &texture = textureManager.getTexture(
-		TextureFile::fromName(TextureName::SwordCursor),
-		PaletteFile::fromName(PaletteName::Default), renderer);
-	return CursorData(&texture, CursorAlignment::TopLeft);
+	return this->getDefaultCursor();
 }
 
 void ChooseRacePanel::handleEvent(const SDL_Event &e)

--- a/OpenTESArena/src/Interface/ChooseRacePanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseRacePanel.cpp
@@ -605,23 +605,21 @@ void ChooseRacePanel::render(Renderer &renderer)
 	// Clear full screen.
 	renderer.clear();
 
-	// Set palette.
-	auto &textureManager = this->getGame().getTextureManager();
-	textureManager.setPalette(PaletteFile::fromName(PaletteName::Default));
-
 	// Draw background map.
-	const auto &raceSelectMap = textureManager.getTexture(
-		TextureFile::fromName(TextureName::RaceSelect),
-		PaletteFile::fromName(PaletteName::BuiltIn), renderer);
-	renderer.drawOriginal(raceSelectMap);
+	auto &textureManager = this->getGame().getTextureManager();
+	const TextureID raceSelectMapTextureID = this->getTextureID(
+		TextureName::RaceSelect, PaletteName::BuiltIn);
+	const Texture &raceSelectMapTexture = textureManager.getTexture(raceSelectMapTextureID);
+	renderer.drawOriginal(raceSelectMapTexture);
 
 	// Arena just covers up the "exit" text at the bottom right.
-	const auto &exitCover = textureManager.getTexture(
+	const TextureID exitCoverTextureID = this->getTextureID(
 		TextureFile::fromName(TextureName::NoExit),
-		TextureFile::fromName(TextureName::RaceSelect), renderer);
-	renderer.drawOriginal(exitCover,
-		Renderer::ORIGINAL_WIDTH - exitCover.getWidth(),
-		Renderer::ORIGINAL_HEIGHT - exitCover.getHeight());
+		TextureFile::fromName(TextureName::RaceSelect));
+	const Texture &exitCoverTexture = textureManager.getTexture(exitCoverTextureID);
+	renderer.drawOriginal(exitCoverTexture,
+		Renderer::ORIGINAL_WIDTH - exitCoverTexture.getWidth(),
+		Renderer::ORIGINAL_HEIGHT - exitCoverTexture.getHeight());
 }
 
 void ChooseRacePanel::renderSecondary(Renderer &renderer)

--- a/OpenTESArena/src/Interface/CinematicPanel.cpp
+++ b/OpenTESArena/src/Interface/CinematicPanel.cpp
@@ -67,11 +67,13 @@ void CinematicPanel::render(Renderer &renderer)
 	// Clear full screen.
 	renderer.clear();
 
-	// Draw current frame of the cinematic.
-	auto &textureManager = this->getGame().getTextureManager();
+	// Get texture IDs in advance of any texture references.
 	const TextureManager::IdGroup<TextureID> textureIDs =
 		this->getTextureIDs(this->sequenceName, this->paletteName);
 	const TextureID textureID = textureIDs.startID + this->imageIndex;
+
+	// Draw current frame of the cinematic.
+	auto &textureManager = this->getGame().getTextureManager();
 	const Texture &texture = textureManager.getTexture(textureID);
 	renderer.drawOriginal(texture);
 }

--- a/OpenTESArena/src/Interface/CinematicPanel.cpp
+++ b/OpenTESArena/src/Interface/CinematicPanel.cpp
@@ -48,17 +48,16 @@ void CinematicPanel::tick(double dt)
 		this->imageIndex++;
 	}
 
-	// Get a reference to all images in the sequence.
 	auto &game = this->getGame();
 	auto &renderer = game.getRenderer();
 	auto &textureManager = game.getTextureManager();
-	const auto &textures = textureManager.getTextures(
-		this->sequenceName, this->paletteName, renderer);
+	const TextureManager::IdGroup<TextureID> textureIDs =
+		this->getTextureIDs(this->sequenceName, this->paletteName);
 
 	// If at the end, then prepare for the next panel.
-	if (this->imageIndex >= textures.size())
+	if (this->imageIndex >= textureIDs.count)
 	{
-		this->imageIndex = static_cast<int>(textures.size() - 1);
+		this->imageIndex = static_cast<int>(textureIDs.count - 1);
 		this->skipButton.click(game);
 	}
 }
@@ -68,12 +67,11 @@ void CinematicPanel::render(Renderer &renderer)
 	// Clear full screen.
 	renderer.clear();
 
-	// Get a reference to all images in the sequence.
+	// Draw current frame of the cinematic.
 	auto &textureManager = this->getGame().getTextureManager();
-	const auto &textures = textureManager.getTextures(
-		this->sequenceName, this->paletteName, renderer);
-
-	// Draw image.
-	const auto &texture = textures.at(this->imageIndex);
+	const TextureManager::IdGroup<TextureID> textureIDs =
+		this->getTextureIDs(this->sequenceName, this->paletteName);
+	const TextureID textureID = textureIDs.startID + this->imageIndex;
+	const Texture &texture = textureManager.getTexture(textureID);
 	renderer.drawOriginal(texture);
 }

--- a/OpenTESArena/src/Interface/FastTravelSubPanel.cpp
+++ b/OpenTESArena/src/Interface/FastTravelSubPanel.cpp
@@ -566,7 +566,8 @@ void FastTravelSubPanel::render(Renderer &renderer)
 	// Draw horse animation.
 	auto &textureManager = this->getGame().getTextureManager();
 	const TextureManager::IdGroup<TextureID> animationTextureIDs = this->getAnimationTextureIDs();
-	const TextureID animationTextureID = animationTextureIDs.startID + this->frameIndex;
+	const TextureID animationTextureID =
+		animationTextureIDs.startID + static_cast<int>(this->frameIndex);
 	const Texture &animFrame = textureManager.getTexture(animationTextureID);
 
 	const int x = (Renderer::ORIGINAL_WIDTH / 2) - (animFrame.getWidth() / 2);

--- a/OpenTESArena/src/Interface/FastTravelSubPanel.h
+++ b/OpenTESArena/src/Interface/FastTravelSubPanel.h
@@ -6,6 +6,7 @@
 
 #include "Panel.h"
 #include "ProvinceMapPanel.h"
+#include "../Media/TextureUtils.h"
 
 // This sub-panel is the glue between the province map's travel button and the game world.
 
@@ -25,8 +26,8 @@ private:
 	// Gets the filename used for the world map image (intended for getting its palette).
 	const std::string &getBackgroundFilename() const;
 
-	// Gets the animation for display.
-	const std::vector<Texture> &getAnimation() const;
+	// Gets the animation texture IDs for display.
+	TextureManager::IdGroup<TextureID> getAnimationTextureIDs() const;
 
 	// Creates a text sub-panel for display when the player arrives at a city.
 	// - @todo: holiday pop-up function.

--- a/OpenTESArena/src/Interface/GameWorldPanel.cpp
+++ b/OpenTESArena/src/Interface/GameWorldPanel.cpp
@@ -671,12 +671,12 @@ Int2 GameWorldPanel::getInterfaceCenter(bool modernInterface, TextureManager &te
 	}
 	else
 	{
-		const Texture &gameInterface =
-			GameWorldPanel::getGameWorldInterfaceTexture(textureManager, renderer);
+		const TextureID gameInterfaceTextureID =
+			GameWorldPanel::getGameWorldInterfaceTextureID(textureManager, renderer);
+		const Texture &gameInterfaceTexture = textureManager.getTexture(gameInterfaceTextureID);
 
-		return Int2(
-			Renderer::ORIGINAL_WIDTH / 2,
-			(Renderer::ORIGINAL_HEIGHT - gameInterface.getHeight()) / 2);
+		return Int2(Renderer::ORIGINAL_WIDTH / 2,
+			(Renderer::ORIGINAL_HEIGHT - gameInterfaceTexture.getHeight()) / 2);
 	}
 }
 
@@ -728,7 +728,7 @@ Panel::CursorData GameWorldPanel::getCurrentCursor() const
 	}
 }
 
-const Texture &GameWorldPanel::getGameWorldInterfaceTexture(
+TextureID GameWorldPanel::getGameWorldInterfaceTextureID(
 	TextureManager &textureManager, Renderer &renderer)
 {
 	const std::string &paletteFilename = PaletteFile::fromName(PaletteName::Default);
@@ -745,154 +745,47 @@ const Texture &GameWorldPanel::getGameWorldInterfaceTexture(
 		DebugCrash("Couldn't get texture ID for \"" + textureFilename + "\".");
 	}
 
-	const Texture &texture = textureManager.getTexture(textureID);
-	return texture;
+	return textureID;
 }
 
-const Texture &GameWorldPanel::getCompassFrameTexture() const
+TextureID GameWorldPanel::getCompassFrameTextureID() const
 {
-	auto &game = this->getGame();
-	auto &textureManager = game.getTextureManager();
-	auto &renderer = game.getRenderer();
-
-	const std::string &paletteFilename = PaletteFile::fromName(PaletteName::Default);
-	PaletteID paletteID;
-	if (!textureManager.tryGetPaletteID(paletteFilename.c_str(), &paletteID))
-	{
-		DebugCrash("Couldn't get palette ID for \"" + paletteFilename + "\".");
-	}
-
-	const std::string &textureFilename = TextureFile::fromName(TextureName::CompassFrame);
-	TextureID textureID;
-	if (!textureManager.tryGetTextureID(textureFilename.c_str(), paletteID, renderer, &textureID))
-	{
-		DebugCrash("Couldn't get texture ID for \"" + textureFilename + "\".");
-	}
-
-	const Texture &texture = textureManager.getTexture(textureID);
-	return texture;
+	return this->getTextureID(TextureName::CompassFrame, PaletteName::Default);
 }
 
-const Texture &GameWorldPanel::getCompassSliderTexture() const
+TextureID GameWorldPanel::getCompassSliderTextureID() const
 {
-	auto &game = this->getGame();
-	auto &textureManager = game.getTextureManager();
-	auto &renderer = game.getRenderer();
-
-	const std::string &paletteFilename = PaletteFile::fromName(PaletteName::Default);
-	PaletteID paletteID;
-	if (!textureManager.tryGetPaletteID(paletteFilename.c_str(), &paletteID))
-	{
-		DebugCrash("Couldn't get palette ID for \"" + paletteFilename + "\".");
-	}
-
-	const std::string &textureFilename = TextureFile::fromName(TextureName::CompassSlider);
-	TextureID textureID;
-	if (!textureManager.tryGetTextureID(textureFilename.c_str(), paletteID, renderer, &textureID))
-	{
-		DebugCrash("Couldn't get texture ID for \"" + textureFilename + "\".");
-	}
-
-	const Texture &texture = textureManager.getTexture(textureID);
-	return texture;
+	return this->getTextureID(TextureName::CompassSlider, PaletteName::Default);
 }
 
-const Texture &GameWorldPanel::getPlayerPortraitTexture(
+TextureID GameWorldPanel::getPlayerPortraitTextureID(
 	const std::string &portraitsFilename, int portraitID) const
 {
-	auto &game = this->getGame();
-	auto &textureManager = game.getTextureManager();
-	auto &renderer = game.getRenderer();
-
-	const std::string &paletteFilename = PaletteFile::fromName(PaletteName::Default);
-	PaletteID paletteID;
-	if (!textureManager.tryGetPaletteID(paletteFilename.c_str(), &paletteID))
-	{
-		DebugCrash("Couldn't get palette ID for \"" + paletteFilename + "\".");
-	}
-
-	TextureManager::IdGroup<TextureID> textureIDs;
-	if (!textureManager.tryGetTextureIDs(portraitsFilename.c_str(), paletteID, renderer, &textureIDs))
-	{
-		DebugCrash("Couldn't get texture ID for \"" + portraitsFilename + "\".");
-	}
-
+	const TextureManager::IdGroup<TextureID> textureIDs =
+		this->getTextureIDs(portraitsFilename, PaletteFile::fromName(PaletteName::Default));
 	const TextureID textureID = textureIDs.startID + portraitID;
-	const Texture &texture = textureManager.getTexture(textureID);
-	return texture;
+	return textureID;
 }
 
-const Texture &GameWorldPanel::getStatusGradientTexture(int gradientID) const
+TextureID GameWorldPanel::getStatusGradientTextureID(int gradientID) const
 {
-	auto &game = this->getGame();
-	auto &textureManager = game.getTextureManager();
-	auto &renderer = game.getRenderer();
-
-	const std::string &paletteFilename = PaletteFile::fromName(PaletteName::Default);
-	PaletteID paletteID;
-	if (!textureManager.tryGetPaletteID(paletteFilename.c_str(), &paletteID))
-	{
-		DebugCrash("Couldn't get palette ID for \"" + paletteFilename + "\".");
-	}
-
-	const std::string &textureFilename = TextureFile::fromName(TextureName::StatusGradients);
-	TextureManager::IdGroup<TextureID> textureIDs;
-	if (!textureManager.tryGetTextureIDs(textureFilename.c_str(), paletteID, renderer, &textureIDs))
-	{
-		DebugCrash("Couldn't get texture ID for \"" + textureFilename + "\".");
-	}
-
+	const TextureManager::IdGroup<TextureID> textureIDs =
+		this->getTextureIDs(TextureName::StatusGradients, PaletteName::Default);
 	const TextureID textureID = textureIDs.startID + gradientID;
-	const Texture &texture = textureManager.getTexture(textureID);
-	return texture;
+	return textureID;
 }
 
-const Texture &GameWorldPanel::getNoSpellTexture() const
+TextureID GameWorldPanel::getNoSpellTextureID() const
 {
-	auto &game = this->getGame();
-	auto &textureManager = game.getTextureManager();
-	auto &renderer = game.getRenderer();
-
-	const std::string &paletteFilename = PaletteFile::fromName(PaletteName::Default);
-	PaletteID paletteID;
-	if (!textureManager.tryGetPaletteID(paletteFilename.c_str(), &paletteID))
-	{
-		DebugCrash("Couldn't get palette ID for \"" + paletteFilename + "\".");
-	}
-
-	const std::string &textureFilename = TextureFile::fromName(TextureName::NoSpell);
-	TextureID textureID;
-	if (!textureManager.tryGetTextureID(textureFilename.c_str(), paletteID, renderer, &textureID))
-	{
-		DebugCrash("Couldn't get texture ID for \"" + textureFilename + "\".");
-	}
-
-	const Texture &texture = textureManager.getTexture(textureID);
-	return texture;
+	return this->getTextureID(TextureName::NoSpell, PaletteName::Default);
 }
 
-const Texture &GameWorldPanel::getWeaponTexture(const std::string &weaponFilename, int index) const
+TextureID GameWorldPanel::getWeaponTextureID(const std::string &weaponFilename, int index) const
 {
-	auto &game = this->getGame();
-	auto &textureManager = game.getTextureManager();
-	auto &renderer = game.getRenderer();
-
-	const std::string &paletteFilename = PaletteFile::fromName(PaletteName::Default);
-	PaletteID paletteID;
-	if (!textureManager.tryGetPaletteID(paletteFilename.c_str(), &paletteID))
-	{
-		DebugCrash("Couldn't get palette ID for \"" + paletteFilename + "\".");
-	}
-
-	TextureManager::IdGroup<TextureID> textureIDs;
-	if (!textureManager.tryGetTextureIDs(weaponFilename.c_str(), paletteID, renderer, &textureIDs))
-	{
-		DebugCrash("Couldn't get texture ID for \"" + weaponFilename + "\".");
-	}
-
+	const TextureManager::IdGroup<TextureID> textureIDs =
+		this->getTextureIDs(weaponFilename, PaletteFile::fromName(PaletteName::Default));
 	const TextureID textureID = textureIDs.startID + index;
-	const Texture &texture = textureManager.getTexture(textureID);
-	return texture;
+	return textureID;
 }
 
 void GameWorldPanel::updateCursorRegions(int width, int height)
@@ -1672,13 +1565,13 @@ void GameWorldPanel::handlePlayerAttack(const Int2 &mouseDelta)
 					// the requirements here.
 					auto &textureManager = game.getTextureManager();
 					auto &renderer = game.getRenderer();
-					const auto &gameWorldInterface =
-						GameWorldPanel::getGameWorldInterfaceTexture(textureManager, renderer);
-					const int originalCursorY = renderer.nativeToOriginal(
-						inputManager.getMousePosition()).y;
-
+					const TextureID gameWorldInterfaceTextureID =
+						GameWorldPanel::getGameWorldInterfaceTextureID(textureManager, renderer);
+					const Texture &gameWorldInterfaceTexture =
+						textureManager.getTexture(gameWorldInterfaceTextureID);
+					const int originalCursorY = renderer.nativeToOriginal(inputManager.getMousePosition()).y;
 					return rightClick && (originalCursorY <
-						(Renderer::ORIGINAL_HEIGHT - gameWorldInterface.getHeight()));
+						(Renderer::ORIGINAL_HEIGHT - gameWorldInterfaceTexture.getHeight()));
 				}
 				else
 				{
@@ -2674,17 +2567,24 @@ void GameWorldPanel::drawTooltip(const std::string &text, Renderer &renderer)
 		text, FontName::D, this->getGame().getFontManager(), renderer);
 
 	auto &textureManager = this->getGame().getTextureManager();
-	const auto &gameInterface = GameWorldPanel::getGameWorldInterfaceTexture(textureManager, renderer);
+	const TextureID gameWorldInterfaceTextureID =
+		GameWorldPanel::getGameWorldInterfaceTextureID(textureManager, renderer);
+	const Texture &gameWorldInterfaceTexture = textureManager.getTexture(gameWorldInterfaceTextureID);
 
-	renderer.drawOriginal(tooltip, 0, Renderer::ORIGINAL_HEIGHT -
-		gameInterface.getHeight() - tooltip.getHeight());
+	const int x = 0;
+	const int y = Renderer::ORIGINAL_HEIGHT -
+		gameWorldInterfaceTexture.getHeight() - tooltip.getHeight();
+	renderer.drawOriginal(tooltip, x, y);
 }
 
 void GameWorldPanel::drawCompass(const NewDouble2 &direction,
 	TextureManager &textureManager, Renderer &renderer)
 {
+	const TextureID compassSliderTextureID = this->getCompassSliderTextureID();
+	const TextureID compassFrameTextureID = this->getCompassFrameTextureID();
+
 	// Draw compass slider based on player direction.
-	const Texture &compassSlider = this->getCompassSliderTexture();
+	const Texture &compassSlider = textureManager.getTexture(compassSliderTextureID);
 
 	// Angle between 0 and 2 pi.
 	const double angle = std::atan2(-direction.y, -direction.x);
@@ -2710,7 +2610,7 @@ void GameWorldPanel::drawCompass(const NewDouble2 &direction,
 	renderer.drawOriginalClipped(compassSlider, clipRect, sliderX, sliderY);
 
 	// Draw the compass frame over the slider.
-	const Texture &compassFrame = this->getCompassFrameTexture();
+	const Texture &compassFrame = textureManager.getTexture(compassFrameTextureID);
 	renderer.drawOriginal(compassFrame,
 		(Renderer::ORIGINAL_WIDTH / 2) - (compassFrame.getWidth() / 2), 0);
 }
@@ -3092,8 +2992,25 @@ void GameWorldPanel::render(Renderer &renderer)
 		options.getMisc_ChunkDistance(), level.getCeilingHeight(), level.getOpenDoors(),
 		level.getFadingVoxels(), level.getVoxelGrid(), level.getEntityManager());
 
+	// Get texture IDs in advance of any texture references.
 	auto &textureManager = game.getTextureManager();
-	const auto &gameInterface = GameWorldPanel::getGameWorldInterfaceTexture(textureManager, renderer);
+	const TextureID gameWorldInterfaceTextureID =
+		GameWorldPanel::getGameWorldInterfaceTextureID(textureManager, renderer);
+
+	const TextureID statusGradientTextureID = [this]()
+	{
+		const int gradientID = 0; // Default for now.
+		return this->getStatusGradientTextureID(gradientID);
+	}();
+	
+	const TextureID playerPortraitTextureID = [this, &player]()
+	{
+		const std::string &headsFilename =
+			PortraitFile::getHeads(player.isMale(), player.getRaceID(), true);
+		return this->getPlayerPortraitTextureID(headsFilename, player.getPortraitID());
+	}();
+
+	const TextureID noSpellTextureID = this->getNoSpellTextureID();
 
 	const auto &inputManager = game.getInputManager();
 	const Int2 mousePosition = inputManager.getMousePosition();
@@ -3104,21 +3021,21 @@ void GameWorldPanel::render(Renderer &renderer)
 	if (!modernInterface)
 	{
 		// Draw game world interface.
-		renderer.drawOriginal(gameInterface, 0,
-			Renderer::ORIGINAL_HEIGHT - gameInterface.getHeight());
+		const Texture &gameWorldInterfaceTexture = textureManager.getTexture(gameWorldInterfaceTextureID);
+		renderer.drawOriginal(gameWorldInterfaceTexture, 0,
+			Renderer::ORIGINAL_HEIGHT - gameWorldInterfaceTexture.getHeight());
 
 		// Draw player portrait.
-		const auto &headsFilename = PortraitFile::getHeads(player.isMale(), player.getRaceID(), true);
-		const auto &portrait = this->getPlayerPortraitTexture(headsFilename, player.getPortraitID());
-		const auto &status = this->getStatusGradientTexture(0);
-		renderer.drawOriginal(status, 14, 166);
-		renderer.drawOriginal(portrait, 14, 166);
+		const Texture &statusGradientTexture = textureManager.getTexture(statusGradientTextureID);
+		const Texture &playerPortraitTexture = textureManager.getTexture(playerPortraitTextureID);
+		renderer.drawOriginal(statusGradientTexture, 14, 166);
+		renderer.drawOriginal(playerPortraitTexture, 14, 166);
 
 		// If the player's class can't use magic, show the darkened spell icon.
 		if (!player.getCharacterClass().canCastMagic())
 		{
-			const auto &nonMagicIcon = this->getNoSpellTexture();
-			renderer.drawOriginal(nonMagicIcon, 91, 177);
+			const Texture &noSpellTexture = textureManager.getTexture(noSpellTextureID);
+			renderer.drawOriginal(noSpellTexture, 91, 177);
 		}
 
 		// Draw text: player name.
@@ -3130,26 +3047,36 @@ void GameWorldPanel::render(Renderer &renderer)
 void GameWorldPanel::renderSecondary(Renderer &renderer)
 {
 	DebugAssert(this->getGame().gameDataIsActive());
-
-	// Several interface objects are in this method because they are hidden by the status
-	// pop-up and the spells list.
-	auto &textureManager = this->getGame().getTextureManager();
-	const auto &gameInterface = GameWorldPanel::getGameWorldInterfaceTexture(textureManager, renderer);
-
+	
 	auto &gameData = this->getGame().getGameData();
 	auto &player = gameData.getPlayer();
 	const auto &options = this->getGame().getOptions();
 	const bool modernInterface = options.getGraphics_ModernInterface();
+
+	// Several interface objects are in this method because they are hidden by the status
+	// pop-up and the spells list.
+	auto &textureManager = this->getGame().getTextureManager();
+	const TextureID gameWorldInterfaceTextureID =
+		GameWorldPanel::getGameWorldInterfaceTextureID(textureManager, renderer);
 
 	// Display player's weapon if unsheathed. The position also depends on whether
 	// the interface is in classic or modern mode.
 	const auto &weaponAnimation = player.getWeaponAnimation();
 	if (!weaponAnimation.isSheathed())
 	{
-		const int index = weaponAnimation.getFrameIndex();
-		const std::string &weaponFilename = weaponAnimation.getAnimationFilename();
-		const Texture &weaponTexture = this->getWeaponTexture(weaponFilename, index);
-		const Int2 &weaponOffset = this->weaponOffsets.at(index);
+		const int weaponAnimIndex = weaponAnimation.getFrameIndex();
+		const TextureID weaponTextureID = [this, &weaponAnimation, weaponAnimIndex]()
+		{
+			const std::string &weaponFilename = weaponAnimation.getAnimationFilename();
+			return this->getWeaponTextureID(weaponFilename, weaponAnimIndex);
+		}();
+
+		const Texture &gameWorldInterfaceTexture =
+			textureManager.getTexture(gameWorldInterfaceTextureID);
+		const Texture &weaponTexture = textureManager.getTexture(weaponTextureID);
+
+		DebugAssertIndex(this->weaponOffsets, weaponAnimIndex);
+		const Int2 &weaponOffset = this->weaponOffsets[weaponAnimIndex];
 
 		// Draw the current weapon image depending on interface mode.
 		if (modernInterface)
@@ -3171,7 +3098,7 @@ void GameWorldPanel::renderSecondary(Renderer &renderer)
 			// Values to scale original weapon dimensions by.
 			const double weaponScaleX = newDiff / static_cast<double>(Renderer::ORIGINAL_WIDTH);
 			const double weaponScaleY = static_cast<double>(Renderer::ORIGINAL_HEIGHT) /
-				static_cast<double>(Renderer::ORIGINAL_HEIGHT - gameInterface.getHeight());
+				static_cast<double>(Renderer::ORIGINAL_HEIGHT - gameWorldInterfaceTexture.getHeight());
 
 			const int weaponX = newLeft +
 				static_cast<int>(std::round(newDiff * weaponOffsetXPercent));
@@ -3194,7 +3121,7 @@ void GameWorldPanel::renderSecondary(Renderer &renderer)
 			// Clamp the max weapon height non-negative since some weapon animations like the
 			// morning star can cause it to become -1.
 			const int maxWeaponHeight = std::max(
-				(Renderer::ORIGINAL_HEIGHT - gameInterface.getHeight()) - weaponOffset.y, 0);
+				(Renderer::ORIGINAL_HEIGHT - gameWorldInterfaceTexture.getHeight()) - weaponOffset.y, 0);
 
 			// Add 1 to the height because Arena's renderer has an off-by-one bug, and a 1 pixel
 			// gap appears unless a small change is added.
@@ -3218,13 +3145,13 @@ void GameWorldPanel::renderSecondary(Renderer &renderer)
 		const Texture *triggerTextTexture;
 		gameData.getTriggerTextRenderInfo(&triggerTextTexture);
 
+		const Texture &gameWorldInterfaceTexture = textureManager.getTexture(gameWorldInterfaceTextureID);
 		const int centerX = (Renderer::ORIGINAL_WIDTH / 2) - (triggerTextTexture->getWidth() / 2) - 1;
-		const int centerY = [modernInterface, &gameInterface, triggerTextTexture]()
+		const int centerY = [modernInterface, &gameWorldInterfaceTexture, triggerTextTexture]()
 		{
 			const int interfaceOffset = modernInterface ?
-				(gameInterface.getHeight() / 2) : gameInterface.getHeight();
-			return Renderer::ORIGINAL_HEIGHT - interfaceOffset -
-				triggerTextTexture->getHeight() - 2;
+				(gameWorldInterfaceTexture.getHeight() / 2) : gameWorldInterfaceTexture.getHeight();
+			return Renderer::ORIGINAL_HEIGHT - interfaceOffset - triggerTextTexture->getHeight() - 2;
 		}();
 
 		renderer.drawOriginal(*triggerTextTexture, centerX, centerY);

--- a/OpenTESArena/src/Interface/GameWorldPanel.cpp
+++ b/OpenTESArena/src/Interface/GameWorldPanel.cpp
@@ -344,9 +344,9 @@ GameWorldPanel::GameWorldPanel(Game &game)
 		return Button<>(147, 151, 29, 22, function);
 	}();
 
-	this->statusButton = []()
+	this->statusButton = [this]()
 	{
-		auto function = [](Game &game)
+		auto function = [this](Game &game)
 		{
 			auto &textureManager = game.getTextureManager();
 			auto &renderer = game.getRenderer();
@@ -671,8 +671,9 @@ Int2 GameWorldPanel::getInterfaceCenter(bool modernInterface, TextureManager &te
 	}
 	else
 	{
-		const auto &gameInterface = textureManager.getTexture(
-			TextureFile::fromName(TextureName::GameWorldInterface), renderer);
+		const Texture &gameInterface =
+			GameWorldPanel::getGameWorldInterfaceTexture(textureManager, renderer);
+
 		return Int2(
 			Renderer::ORIGINAL_WIDTH / 2,
 			(Renderer::ORIGINAL_HEIGHT - gameInterface.getHeight()) / 2);
@@ -700,17 +701,198 @@ Panel::CursorData GameWorldPanel::getCurrentCursor() const
 		{
 			if (this->nativeCursorRegions[i].contains(mousePosition))
 			{
-				const auto &texture = textureManager.getTextures(
-					TextureFile::fromName(TextureName::ArrowCursors), renderer).at(i);
+				// Get the relevant arrow cursor.
+				const std::string &paletteFilename = PaletteFile::fromName(PaletteName::Default);
+				PaletteID paletteID;
+				if (!textureManager.tryGetPaletteID(paletteFilename.c_str(), &paletteID))
+				{
+					DebugCrash("Couldn't get palette ID for \"" + paletteFilename + "\".");
+				}
+
+				const std::string &textureFilename = TextureFile::fromName(TextureName::ArrowCursors);
+				TextureManager::IdGroup<TextureID> textureIDs;
+				if (!textureManager.tryGetTextureIDs(textureFilename.c_str(), paletteID,
+					renderer, &textureIDs))
+				{
+					DebugCrash("Couldn't get texture IDs for \"" + textureFilename + "\".");
+				}
+
+				const TextureID textureID = textureIDs.startID + i;
+				const Texture &texture = textureManager.getTexture(textureID);
 				return CursorData(&texture, ArrowCursorAlignments.at(i));
 			}
 		}
 
-		// If not in any of the arrow regions, use the default sword cursor.
-		const auto &texture = textureManager.getTexture(
-			TextureFile::fromName(TextureName::SwordCursor), renderer);
-		return CursorData(&texture, CursorAlignment::TopLeft);
+		// Not in any of the arrow regions.
+		return this->getDefaultCursor();
 	}
+}
+
+const Texture &GameWorldPanel::getGameWorldInterfaceTexture(
+	TextureManager &textureManager, Renderer &renderer)
+{
+	const std::string &paletteFilename = PaletteFile::fromName(PaletteName::Default);
+	PaletteID paletteID;
+	if (!textureManager.tryGetPaletteID(paletteFilename.c_str(), &paletteID))
+	{
+		DebugCrash("Couldn't get palette ID for \"" + paletteFilename + "\".");
+	}
+
+	const std::string &textureFilename = TextureFile::fromName(TextureName::GameWorldInterface);
+	TextureID textureID;
+	if (!textureManager.tryGetTextureID(textureFilename.c_str(), paletteID, renderer, &textureID))
+	{
+		DebugCrash("Couldn't get texture ID for \"" + textureFilename + "\".");
+	}
+
+	const Texture &texture = textureManager.getTexture(textureID);
+	return texture;
+}
+
+const Texture &GameWorldPanel::getCompassFrameTexture() const
+{
+	auto &game = this->getGame();
+	auto &textureManager = game.getTextureManager();
+	auto &renderer = game.getRenderer();
+
+	const std::string &paletteFilename = PaletteFile::fromName(PaletteName::Default);
+	PaletteID paletteID;
+	if (!textureManager.tryGetPaletteID(paletteFilename.c_str(), &paletteID))
+	{
+		DebugCrash("Couldn't get palette ID for \"" + paletteFilename + "\".");
+	}
+
+	const std::string &textureFilename = TextureFile::fromName(TextureName::CompassFrame);
+	TextureID textureID;
+	if (!textureManager.tryGetTextureID(textureFilename.c_str(), paletteID, renderer, &textureID))
+	{
+		DebugCrash("Couldn't get texture ID for \"" + textureFilename + "\".");
+	}
+
+	const Texture &texture = textureManager.getTexture(textureID);
+	return texture;
+}
+
+const Texture &GameWorldPanel::getCompassSliderTexture() const
+{
+	auto &game = this->getGame();
+	auto &textureManager = game.getTextureManager();
+	auto &renderer = game.getRenderer();
+
+	const std::string &paletteFilename = PaletteFile::fromName(PaletteName::Default);
+	PaletteID paletteID;
+	if (!textureManager.tryGetPaletteID(paletteFilename.c_str(), &paletteID))
+	{
+		DebugCrash("Couldn't get palette ID for \"" + paletteFilename + "\".");
+	}
+
+	const std::string &textureFilename = TextureFile::fromName(TextureName::CompassSlider);
+	TextureID textureID;
+	if (!textureManager.tryGetTextureID(textureFilename.c_str(), paletteID, renderer, &textureID))
+	{
+		DebugCrash("Couldn't get texture ID for \"" + textureFilename + "\".");
+	}
+
+	const Texture &texture = textureManager.getTexture(textureID);
+	return texture;
+}
+
+const Texture &GameWorldPanel::getPlayerPortraitTexture(
+	const std::string &portraitsFilename, int portraitID) const
+{
+	auto &game = this->getGame();
+	auto &textureManager = game.getTextureManager();
+	auto &renderer = game.getRenderer();
+
+	const std::string &paletteFilename = PaletteFile::fromName(PaletteName::Default);
+	PaletteID paletteID;
+	if (!textureManager.tryGetPaletteID(paletteFilename.c_str(), &paletteID))
+	{
+		DebugCrash("Couldn't get palette ID for \"" + paletteFilename + "\".");
+	}
+
+	TextureManager::IdGroup<TextureID> textureIDs;
+	if (!textureManager.tryGetTextureIDs(portraitsFilename.c_str(), paletteID, renderer, &textureIDs))
+	{
+		DebugCrash("Couldn't get texture ID for \"" + portraitsFilename + "\".");
+	}
+
+	const TextureID textureID = textureIDs.startID + portraitID;
+	const Texture &texture = textureManager.getTexture(textureID);
+	return texture;
+}
+
+const Texture &GameWorldPanel::getStatusGradientTexture(int gradientID) const
+{
+	auto &game = this->getGame();
+	auto &textureManager = game.getTextureManager();
+	auto &renderer = game.getRenderer();
+
+	const std::string &paletteFilename = PaletteFile::fromName(PaletteName::Default);
+	PaletteID paletteID;
+	if (!textureManager.tryGetPaletteID(paletteFilename.c_str(), &paletteID))
+	{
+		DebugCrash("Couldn't get palette ID for \"" + paletteFilename + "\".");
+	}
+
+	const std::string &textureFilename = TextureFile::fromName(TextureName::StatusGradients);
+	TextureManager::IdGroup<TextureID> textureIDs;
+	if (!textureManager.tryGetTextureIDs(textureFilename.c_str(), paletteID, renderer, &textureIDs))
+	{
+		DebugCrash("Couldn't get texture ID for \"" + textureFilename + "\".");
+	}
+
+	const TextureID textureID = textureIDs.startID + gradientID;
+	const Texture &texture = textureManager.getTexture(textureID);
+	return texture;
+}
+
+const Texture &GameWorldPanel::getNoSpellTexture() const
+{
+	auto &game = this->getGame();
+	auto &textureManager = game.getTextureManager();
+	auto &renderer = game.getRenderer();
+
+	const std::string &paletteFilename = PaletteFile::fromName(PaletteName::Default);
+	PaletteID paletteID;
+	if (!textureManager.tryGetPaletteID(paletteFilename.c_str(), &paletteID))
+	{
+		DebugCrash("Couldn't get palette ID for \"" + paletteFilename + "\".");
+	}
+
+	const std::string &textureFilename = TextureFile::fromName(TextureName::NoSpell);
+	TextureID textureID;
+	if (!textureManager.tryGetTextureID(textureFilename.c_str(), paletteID, renderer, &textureID))
+	{
+		DebugCrash("Couldn't get texture ID for \"" + textureFilename + "\".");
+	}
+
+	const Texture &texture = textureManager.getTexture(textureID);
+	return texture;
+}
+
+const Texture &GameWorldPanel::getWeaponTexture(const std::string &weaponFilename, int index) const
+{
+	auto &game = this->getGame();
+	auto &textureManager = game.getTextureManager();
+	auto &renderer = game.getRenderer();
+
+	const std::string &paletteFilename = PaletteFile::fromName(PaletteName::Default);
+	PaletteID paletteID;
+	if (!textureManager.tryGetPaletteID(paletteFilename.c_str(), &paletteID))
+	{
+		DebugCrash("Couldn't get palette ID for \"" + paletteFilename + "\".");
+	}
+
+	TextureManager::IdGroup<TextureID> textureIDs;
+	if (!textureManager.tryGetTextureIDs(weaponFilename.c_str(), paletteID, renderer, &textureIDs))
+	{
+		DebugCrash("Couldn't get texture ID for \"" + weaponFilename + "\".");
+	}
+
+	const TextureID textureID = textureIDs.startID + index;
+	const Texture &texture = textureManager.getTexture(textureID);
+	return texture;
 }
 
 void GameWorldPanel::updateCursorRegions(int width, int height)
@@ -1490,8 +1672,8 @@ void GameWorldPanel::handlePlayerAttack(const Int2 &mouseDelta)
 					// the requirements here.
 					auto &textureManager = game.getTextureManager();
 					auto &renderer = game.getRenderer();
-					const auto &gameWorldInterface = textureManager.getTexture(
-						TextureFile::fromName(TextureName::GameWorldInterface), renderer);
+					const auto &gameWorldInterface =
+						GameWorldPanel::getGameWorldInterfaceTexture(textureManager, renderer);
 					const int originalCursorY = renderer.nativeToOriginal(
 						inputManager.getMousePosition()).y;
 
@@ -2492,8 +2674,7 @@ void GameWorldPanel::drawTooltip(const std::string &text, Renderer &renderer)
 		text, FontName::D, this->getGame().getFontManager(), renderer);
 
 	auto &textureManager = this->getGame().getTextureManager();
-	const auto &gameInterface = textureManager.getTexture(
-		TextureFile::fromName(TextureName::GameWorldInterface), renderer);
+	const auto &gameInterface = GameWorldPanel::getGameWorldInterfaceTexture(textureManager, renderer);
 
 	renderer.drawOriginal(tooltip, 0, Renderer::ORIGINAL_HEIGHT -
 		gameInterface.getHeight() - tooltip.getHeight());
@@ -2503,8 +2684,7 @@ void GameWorldPanel::drawCompass(const NewDouble2 &direction,
 	TextureManager &textureManager, Renderer &renderer)
 {
 	// Draw compass slider based on player direction.
-	const auto &compassSlider = textureManager.getTexture(
-		TextureFile::fromName(TextureName::CompassSlider), renderer);
+	const Texture &compassSlider = this->getCompassSliderTexture();
 
 	// Angle between 0 and 2 pi.
 	const double angle = std::atan2(-direction.y, -direction.x);
@@ -2530,8 +2710,7 @@ void GameWorldPanel::drawCompass(const NewDouble2 &direction,
 	renderer.drawOriginalClipped(compassSlider, clipRect, sliderX, sliderY);
 
 	// Draw the compass frame over the slider.
-	const auto &compassFrame = textureManager.getTexture(
-		TextureFile::fromName(TextureName::CompassFrame), renderer);
+	const Texture &compassFrame = this->getCompassFrameTexture();
 	renderer.drawOriginal(compassFrame,
 		(Renderer::ORIGINAL_WIDTH / 2) - (compassFrame.getWidth() / 2), 0);
 }
@@ -2914,10 +3093,7 @@ void GameWorldPanel::render(Renderer &renderer)
 		level.getFadingVoxels(), level.getVoxelGrid(), level.getEntityManager());
 
 	auto &textureManager = game.getTextureManager();
-	textureManager.setPalette(PaletteFile::fromName(PaletteName::Default));
-
-	const auto &gameInterface = textureManager.getTexture(
-		TextureFile::fromName(TextureName::GameWorldInterface), renderer);
+	const auto &gameInterface = GameWorldPanel::getGameWorldInterfaceTexture(textureManager, renderer);
 
 	const auto &inputManager = game.getInputManager();
 	const Int2 mousePosition = inputManager.getMousePosition();
@@ -2932,20 +3108,16 @@ void GameWorldPanel::render(Renderer &renderer)
 			Renderer::ORIGINAL_HEIGHT - gameInterface.getHeight());
 
 		// Draw player portrait.
-		const auto &headsFilename = PortraitFile::getHeads(
-			player.isMale(), player.getRaceID(), true);
-		const auto &portrait = textureManager.getTextures(
-			headsFilename, renderer).at(player.getPortraitID());
-		const auto &status = textureManager.getTextures(
-			TextureFile::fromName(TextureName::StatusGradients), renderer).at(0);
+		const auto &headsFilename = PortraitFile::getHeads(player.isMale(), player.getRaceID(), true);
+		const auto &portrait = this->getPlayerPortraitTexture(headsFilename, player.getPortraitID());
+		const auto &status = this->getStatusGradientTexture(0);
 		renderer.drawOriginal(status, 14, 166);
 		renderer.drawOriginal(portrait, 14, 166);
 
 		// If the player's class can't use magic, show the darkened spell icon.
 		if (!player.getCharacterClass().canCastMagic())
 		{
-			const auto &nonMagicIcon = textureManager.getTexture(
-				TextureFile::fromName(TextureName::NoSpell), renderer);
+			const auto &nonMagicIcon = this->getNoSpellTexture();
 			renderer.drawOriginal(nonMagicIcon, 91, 177);
 		}
 
@@ -2962,10 +3134,7 @@ void GameWorldPanel::renderSecondary(Renderer &renderer)
 	// Several interface objects are in this method because they are hidden by the status
 	// pop-up and the spells list.
 	auto &textureManager = this->getGame().getTextureManager();
-	textureManager.setPalette(PaletteFile::fromName(PaletteName::Default));
-
-	const auto &gameInterface = textureManager.getTexture(
-		TextureFile::fromName(TextureName::GameWorldInterface), renderer);
+	const auto &gameInterface = GameWorldPanel::getGameWorldInterfaceTexture(textureManager, renderer);
 
 	auto &gameData = this->getGame().getGameData();
 	auto &player = gameData.getPlayer();
@@ -2979,8 +3148,7 @@ void GameWorldPanel::renderSecondary(Renderer &renderer)
 	{
 		const int index = weaponAnimation.getFrameIndex();
 		const std::string &weaponFilename = weaponAnimation.getAnimationFilename();
-		const Texture &weaponTexture = textureManager.getTextures(
-			weaponFilename, renderer).at(index);
+		const Texture &weaponTexture = this->getWeaponTexture(weaponFilename, index);
 		const Int2 &weaponOffset = this->weaponOffsets.at(index);
 
 		// Draw the current weapon image depending on interface mode.

--- a/OpenTESArena/src/Interface/GameWorldPanel.h
+++ b/OpenTESArena/src/Interface/GameWorldPanel.h
@@ -35,6 +35,15 @@ private:
 	std::array<Rect, 9> nativeCursorRegions;
 	std::vector<Int2> weaponOffsets;
 
+	// Helper functions for various UI textures.
+	static const Texture &getGameWorldInterfaceTexture(TextureManager &textureManager, Renderer &renderer);
+	const Texture &getCompassFrameTexture() const;
+	const Texture &getCompassSliderTexture() const;
+	const Texture &getPlayerPortraitTexture(const std::string &portraitsFilename, int portraitID) const;
+	const Texture &getStatusGradientTexture(int gradientID) const;
+	const Texture &getNoSpellTexture() const;
+	const Texture &getWeaponTexture(const std::string &weaponFilename, int index) const;
+
 	// Modifies the values in the native cursor regions array so rectangles in
 	// the current window correctly represent regions for different arrow cursors.
 	void updateCursorRegions(int width, int height);
@@ -90,8 +99,8 @@ public:
 
 	// Gets the center of the screen for pop-up related functions. The position depends on
 	// whether modern interface mode is set.
-	static Int2 getInterfaceCenter(bool modernInterface, TextureManager &textureManager,
-		Renderer &renderer);
+	static Int2 getInterfaceCenter(bool modernInterface,
+		TextureManager &textureManager, Renderer &renderer);
 
 	virtual Panel::CursorData getCurrentCursor() const override;
 	virtual void handleEvent(const SDL_Event &e) override;

--- a/OpenTESArena/src/Interface/GameWorldPanel.h
+++ b/OpenTESArena/src/Interface/GameWorldPanel.h
@@ -9,6 +9,7 @@
 #include "TextBox.h"
 #include "../Game/Physics.h"
 #include "../Math/Rect.h"
+#include "../Media/TextureUtils.h"
 #include "../World/VoxelDefinition.h"
 #include "../World/VoxelUtils.h"
 
@@ -36,13 +37,13 @@ private:
 	std::vector<Int2> weaponOffsets;
 
 	// Helper functions for various UI textures.
-	static const Texture &getGameWorldInterfaceTexture(TextureManager &textureManager, Renderer &renderer);
-	const Texture &getCompassFrameTexture() const;
-	const Texture &getCompassSliderTexture() const;
-	const Texture &getPlayerPortraitTexture(const std::string &portraitsFilename, int portraitID) const;
-	const Texture &getStatusGradientTexture(int gradientID) const;
-	const Texture &getNoSpellTexture() const;
-	const Texture &getWeaponTexture(const std::string &weaponFilename, int index) const;
+	static TextureID getGameWorldInterfaceTextureID(TextureManager &textureManager, Renderer &renderer);
+	TextureID getCompassFrameTextureID() const;
+	TextureID getCompassSliderTextureID() const;
+	TextureID getPlayerPortraitTextureID(const std::string &portraitsFilename, int portraitID) const;
+	TextureID getStatusGradientTextureID(int gradientID) const;
+	TextureID getNoSpellTextureID() const;
+	TextureID getWeaponTextureID(const std::string &weaponFilename, int index) const;
 
 	// Modifies the values in the native cursor regions array so rectangles in
 	// the current window correctly represent regions for different arrow cursors.

--- a/OpenTESArena/src/Interface/ImagePanel.cpp
+++ b/OpenTESArena/src/Interface/ImagePanel.cpp
@@ -55,10 +55,9 @@ void ImagePanel::render(Renderer &renderer)
 	// Clear full screen.
 	renderer.clear();
 
-	auto &textureManager = this->getGame().getTextureManager();
-
 	// Draw image.
-	const auto &image = textureManager.getTexture(
-		this->textureName, this->paletteName, renderer);
-	renderer.drawOriginal(image);
+	auto &textureManager = this->getGame().getTextureManager();
+	const TextureID textureID = this->getTextureID(this->textureName, this->paletteName);
+	const Texture &texture = textureManager.getTexture(textureID);
+	renderer.drawOriginal(texture);
 }

--- a/OpenTESArena/src/Interface/ImageSequencePanel.cpp
+++ b/OpenTESArena/src/Interface/ImageSequencePanel.cpp
@@ -94,11 +94,13 @@ void ImageSequencePanel::render(Renderer &renderer)
 	// Clear full screen.
 	renderer.clear();
 
-	auto &textureManager = this->getGame().getTextureManager();
-
 	// Draw image.
-	const auto &image = textureManager.getTexture(
-		this->textureNames.at(this->imageIndex),
-		this->paletteNames.at(this->imageIndex), renderer);
-	renderer.drawOriginal(image);
+	auto &textureManager = this->getGame().getTextureManager();
+	DebugAssertIndex(this->textureNames, this->imageIndex);
+	DebugAssertIndex(this->paletteNames, this->imageIndex);
+	const std::string &textureName = this->textureNames[this->imageIndex];
+	const std::string &paletteName = this->paletteNames[this->imageIndex];
+	const TextureID textureID = this->getTextureID(textureName, paletteName);
+	const Texture &texture = textureManager.getTexture(textureID);
+	renderer.drawOriginal(texture);
 }

--- a/OpenTESArena/src/Interface/LoadSavePanel.cpp
+++ b/OpenTESArena/src/Interface/LoadSavePanel.cpp
@@ -148,13 +148,7 @@ int LoadSavePanel::getClickedIndex(const Int2 &point)
 
 Panel::CursorData LoadSavePanel::getCurrentCursor() const
 {
-	auto &game = this->getGame();
-	auto &renderer = game.getRenderer();
-	auto &textureManager = game.getTextureManager();
-	const auto &texture = textureManager.getTexture(
-		TextureFile::fromName(TextureName::SwordCursor),
-		PaletteFile::fromName(PaletteName::Default), renderer);
-	return CursorData(&texture, CursorAlignment::TopLeft);
+	return this->getDefaultCursor();
 }
 
 void LoadSavePanel::handleEvent(const SDL_Event &e)

--- a/OpenTESArena/src/Interface/LoadSavePanel.cpp
+++ b/OpenTESArena/src/Interface/LoadSavePanel.cpp
@@ -182,14 +182,12 @@ void LoadSavePanel::render(Renderer &renderer)
 	// Clear full screen.
 	renderer.clear();
 
-	// Set palette.
-	auto &textureManager = this->getGame().getTextureManager();
-	textureManager.setPalette(PaletteFile::fromName(PaletteName::Default));
-
 	// Draw slots background.
-	const auto &slotsBackground = textureManager.getTexture(
-		TextureFile::fromName(TextureName::LoadSave), renderer);
-	renderer.drawOriginal(slotsBackground);
+	auto &textureManager = this->getGame().getTextureManager();
+	const TextureID slotsBackgroundTextureID = this->getTextureID(
+		TextureName::LoadSave, PaletteName::Default);
+	const Texture &slotsBackgroundTexture = textureManager.getTexture(slotsBackgroundTextureID);
+	renderer.drawOriginal(slotsBackgroundTexture);
 
 	// Draw save text.
 	for (const auto &textBox : this->saveTextBoxes)

--- a/OpenTESArena/src/Interface/LogbookPanel.cpp
+++ b/OpenTESArena/src/Interface/LogbookPanel.cpp
@@ -56,17 +56,28 @@ LogbookPanel::LogbookPanel(Game &game)
 		};
 		return Button<Game&>(center, 34, 14, function);
 	}();
+
+	auto &textureManager = game.getTextureManager();
+	const std::string &backgroundTextureName = TextureFile::fromName(TextureName::Logbook);
+	const std::string &backgroundPaletteName = backgroundTextureName;
+	PaletteID backgroundPaletteID;
+	if (!textureManager.tryGetPaletteID(backgroundPaletteName.c_str(), &backgroundPaletteID))
+	{
+		DebugLogWarning("Couldn't get palette ID for \"" + backgroundPaletteName + "\".");
+		return;
+	}
+
+	auto &renderer = game.getRenderer();
+	if (!textureManager.tryGetTextureID(backgroundTextureName.c_str(), backgroundPaletteID,
+		renderer, &this->backgroundTextureID))
+	{
+		DebugLogWarning("Couldn't get texture ID for \"" + backgroundTextureName + "\".");
+	}
 }
 
 Panel::CursorData LogbookPanel::getCurrentCursor() const
 {
-	auto &game = this->getGame();
-	auto &renderer = game.getRenderer();
-	auto &textureManager = game.getTextureManager();
-	const auto &texture = textureManager.getTexture(
-		TextureFile::fromName(TextureName::SwordCursor),
-		PaletteFile::fromName(PaletteName::Default), renderer);
-	return CursorData(&texture, CursorAlignment::TopLeft);
+	return this->getDefaultCursor();
 }
 
 void LogbookPanel::handleEvent(const SDL_Event &e)
@@ -100,15 +111,10 @@ void LogbookPanel::render(Renderer &renderer)
 	// Clear full screen.
 	renderer.clear();
 
-	// Set palette.
+	// Logbook background.
 	auto &textureManager = this->getGame().getTextureManager();
-	textureManager.setPalette(PaletteFile::fromName(PaletteName::Default));
-
-	// Draw logbook background.
-	const auto &logbookBackground = textureManager.getTexture(
-		TextureFile::fromName(TextureName::Logbook),
-		PaletteFile::fromName(PaletteName::BuiltIn), renderer);
-	renderer.drawOriginal(logbookBackground);
+	const Texture &backgroundTexture = textureManager.getTexture(this->backgroundTextureID);
+	renderer.drawOriginal(backgroundTexture);
 
 	// Draw text: title.
 	renderer.drawOriginal(this->titleTextBox->getTexture(),

--- a/OpenTESArena/src/Interface/LogbookPanel.h
+++ b/OpenTESArena/src/Interface/LogbookPanel.h
@@ -3,6 +3,7 @@
 
 #include "Button.h"
 #include "Panel.h"
+#include "../Media/TextureUtils.h"
 
 class Renderer;
 class TextBox;
@@ -12,6 +13,7 @@ class LogbookPanel : public Panel
 private:
 	std::unique_ptr<TextBox> titleTextBox;
 	Button<Game&> backButton;
+	TextureID backgroundTextureID;
 public:
 	LogbookPanel(Game &game);
 	virtual ~LogbookPanel() = default;

--- a/OpenTESArena/src/Interface/MainMenuPanel.cpp
+++ b/OpenTESArena/src/Interface/MainMenuPanel.cpp
@@ -296,7 +296,7 @@ MainMenuPanel::MainMenuPanel(Game &game)
 
 			game.setPanel<CinematicPanel>(
 				game,
-				PaletteFile::fromName(PaletteName::Default),
+				PaletteFile::fromName(PaletteName::BuiltIn),
 				TextureFile::fromName(TextureSequenceName::OpeningScroll),
 				1.0 / 24.0,
 				changeToNewGameStory);

--- a/OpenTESArena/src/Interface/MainMenuPanel.cpp
+++ b/OpenTESArena/src/Interface/MainMenuPanel.cpp
@@ -1022,13 +1022,7 @@ WorldType MainMenuPanel::getSelectedTestWorldType() const
 
 Panel::CursorData MainMenuPanel::getCurrentCursor() const
 {
-	auto &game = this->getGame();
-	auto &renderer = game.getRenderer();
-	auto &textureManager = game.getTextureManager();
-	const auto &texture = textureManager.getTexture(
-		TextureFile::fromName(TextureName::SwordCursor),
-		PaletteFile::fromName(PaletteName::Default), renderer);
-	return CursorData(&texture, CursorAlignment::TopLeft);
+	return this->getDefaultCursor();
 }
 
 void MainMenuPanel::handleEvent(const SDL_Event &e)
@@ -1156,33 +1150,28 @@ void MainMenuPanel::render(Renderer &renderer)
 	// Clear full screen.
 	renderer.clear();
 
-	// Set palette.
-	auto &textureManager = this->getGame().getTextureManager();
-	textureManager.setPalette(PaletteFile::fromName(PaletteName::Default));
-
 	// Draw main menu.
-	const auto &mainMenu = textureManager.getTexture(
-		TextureFile::fromName(TextureName::MainMenu),
-		PaletteFile::fromName(PaletteName::BuiltIn), renderer);
-	renderer.drawOriginal(mainMenu);
+	auto &textureManager = this->getGame().getTextureManager();
+	const TextureID mainMenuTextureID = this->getTextureID(TextureName::MainMenu, PaletteName::BuiltIn);
+	const Texture &mainMenuTexture = textureManager.getTexture(mainMenuTextureID);
+	renderer.drawOriginal(mainMenuTexture);
 
 	// Draw test buttons.
-	const auto &arrows = textureManager.getTexture(
-		TextureFile::fromName(TextureName::UpDown),
-		PaletteFile::fromName(PaletteName::CharSheet), renderer);
-	renderer.drawOriginal(arrows, this->testTypeUpButton.getX(),
+	const TextureID arrowsTextureID = this->getTextureID(TextureName::UpDown, PaletteName::CharSheet);
+	const Texture &arrowsTexture = textureManager.getTexture(arrowsTextureID);
+	renderer.drawOriginal(arrowsTexture, this->testTypeUpButton.getX(),
 		this->testTypeUpButton.getY());
-	renderer.drawOriginal(arrows, this->testIndexUpButton.getX(),
+	renderer.drawOriginal(arrowsTexture, this->testIndexUpButton.getX(),
 		this->testIndexUpButton.getY());
 
 	if (this->testType == TestType_Interior)
 	{
-		renderer.drawOriginal(arrows, this->testIndex2UpButton.getX(),
+		renderer.drawOriginal(arrowsTexture, this->testIndex2UpButton.getX(),
 			this->testIndex2UpButton.getY());
 	}
 	else if ((this->testType == TestType_City) || (this->testType == TestType_Wilderness))
 	{
-		renderer.drawOriginal(arrows, this->testWeatherUpButton.getX(),
+		renderer.drawOriginal(arrowsTexture, this->testWeatherUpButton.getX(),
 			this->testWeatherUpButton.getY());
 	}
 

--- a/OpenTESArena/src/Interface/MainQuestSplashPanel.cpp
+++ b/OpenTESArena/src/Interface/MainQuestSplashPanel.cpp
@@ -118,15 +118,13 @@ void MainQuestSplashPanel::render(Renderer &renderer)
 	// Clear full screen.
 	renderer.clear();
 
-	// Set palette.
-	auto &game = this->getGame();
-	auto &textureManager = game.getTextureManager();
-	textureManager.setPalette(PaletteFile::fromName(PaletteName::Default));
-
 	// Draw staff dungeon splash image.
-	const auto &splashImage = textureManager.getTexture(
-		this->splashFilename, PaletteFile::fromName(PaletteName::BuiltIn), renderer);
-	renderer.drawOriginal(splashImage);
+	auto &textureManager = this->getGame().getTextureManager();
+	const std::string &textureName = this->splashFilename;
+	const std::string &paletteName = textureName;
+	const TextureID splashImageTextureID = this->getTextureID(textureName, paletteName);
+	const Texture &splashImageTexture = textureManager.getTexture(splashImageTextureID);
+	renderer.drawOriginal(splashImageTexture);
 
 	// Draw text.
 	renderer.drawOriginal(this->textBox->getTexture(),

--- a/OpenTESArena/src/Interface/MainQuestSplashPanel.cpp
+++ b/OpenTESArena/src/Interface/MainQuestSplashPanel.cpp
@@ -91,13 +91,7 @@ MainQuestSplashPanel::MainQuestSplashPanel(Game &game, int provinceID)
 
 Panel::CursorData MainQuestSplashPanel::getCurrentCursor() const
 {
-	auto &game = this->getGame();
-	auto &renderer = game.getRenderer();
-	auto &textureManager = game.getTextureManager();
-	const auto &texture = textureManager.getTexture(
-		TextureFile::fromName(TextureName::SwordCursor),
-		PaletteFile::fromName(PaletteName::Default), renderer);
-	return CursorData(&texture, CursorAlignment::TopLeft);
+	return this->getDefaultCursor();
 }
 
 void MainQuestSplashPanel::handleEvent(const SDL_Event &e)

--- a/OpenTESArena/src/Interface/MessageBoxSubPanel.cpp
+++ b/OpenTESArena/src/Interface/MessageBoxSubPanel.cpp
@@ -26,9 +26,24 @@ Panel::CursorData MessageBoxSubPanel::getCurrentCursor() const
 	auto &game = this->getGame();
 	auto &renderer = game.getRenderer();
 	auto &textureManager = game.getTextureManager();
-	const auto &texture = textureManager.getTexture(
-		TextureFile::fromName(TextureName::SwordCursor),
-		PaletteFile::fromName(PaletteName::Default), renderer);
+
+	const std::string &paletteFilename = PaletteFile::fromName(PaletteName::Default);
+	PaletteID paletteID;
+	if (!textureManager.tryGetPaletteID(paletteFilename.c_str(), &paletteID))
+	{
+		DebugLogWarning("Couldn't get palette ID for \"" + paletteFilename + "\".");
+		return CursorData::EMPTY;
+	}
+
+	const std::string &textureFilename = TextureFile::fromName(TextureName::SwordCursor);
+	TextureID textureID;
+	if (!textureManager.tryGetTextureID(textureFilename.c_str(), paletteID, renderer, &textureID))
+	{
+		DebugLogWarning("Couldn't get texture ID for \"" + textureFilename + "\".");
+		return CursorData::EMPTY;
+	}
+
+	const Texture &texture = textureManager.getTexture(textureID);
 	return CursorData(&texture, CursorAlignment::TopLeft);
 }
 

--- a/OpenTESArena/src/Interface/OptionsPanel.cpp
+++ b/OpenTESArena/src/Interface/OptionsPanel.cpp
@@ -839,13 +839,7 @@ void OptionsPanel::drawDescription(const std::string &text, Renderer &renderer)
 
 Panel::CursorData OptionsPanel::getCurrentCursor() const
 {
-	auto &game = this->getGame();
-	auto &renderer = game.getRenderer();
-	auto &textureManager = game.getTextureManager();
-	const auto &texture = textureManager.getTexture(
-		TextureFile::fromName(TextureName::SwordCursor),
-		PaletteFile::fromName(PaletteName::Default), renderer);
-	return CursorData(&texture, CursorAlignment::TopLeft);
+	return this->getDefaultCursor();
 }
 
 void OptionsPanel::handleEvent(const SDL_Event &e)

--- a/OpenTESArena/src/Interface/OptionsPanel.cpp
+++ b/OpenTESArena/src/Interface/OptionsPanel.cpp
@@ -991,15 +991,12 @@ void OptionsPanel::render(Renderer &renderer)
 	// Clear full screen.
 	renderer.clear();
 
-	// Set palette.
-	auto &textureManager = this->getGame().getTextureManager();
-	textureManager.setPalette(PaletteFile::fromName(PaletteName::Default));
-
 	// Draw solid background.
 	const Color backgroundColor(60, 60, 68);
 	renderer.clearOriginal(backgroundColor);
 
 	// Draw return button and tabs.
+	auto &textureManager = this->getGame().getTextureManager();
 	Texture tabBackground = Texture::generate(Texture::PatternType::Custom1,
 		GraphicsTabRect.getWidth(), GraphicsTabRect.getHeight(), textureManager, renderer);
 	for (int i = 0; i < 5; i++)

--- a/OpenTESArena/src/Interface/Panel.cpp
+++ b/OpenTESArena/src/Interface/Panel.cpp
@@ -19,6 +19,7 @@
 #include "../Media/FontManager.h"
 #include "../Media/PaletteFile.h"
 #include "../Media/PaletteName.h"
+#include "../Media/PaletteUtils.h"
 #include "../Media/TextureFile.h"
 #include "../Media/TextureName.h"
 #include "../Media/TextureSequenceName.h"
@@ -143,23 +144,19 @@ std::unique_ptr<Panel> Panel::defaultPanel(Game &game)
 	auto changeToQuote = [changeToScrolling](Game &game)
 	{
 		const double secondsToDisplay = 5.0;
-		game.setPanel<ImagePanel>(
-			game,
-			PaletteFile::fromName(PaletteName::BuiltIn),
-			TextureFile::fromName(TextureName::IntroQuote),
-			secondsToDisplay,
-			changeToScrolling);
+		const std::string &textureName = TextureFile::fromName(TextureName::IntroQuote);
+		const std::string &paletteName = textureName;
+		game.setPanel<ImagePanel>(game, paletteName, textureName,
+			secondsToDisplay, changeToScrolling);
 	};
 
 	auto makeIntroTitlePanel = [changeToQuote, &game]()
 	{
 		const double secondsToDisplay = 5.0;
-		return std::make_unique<ImagePanel>(
-			game,
-			PaletteFile::fromName(PaletteName::BuiltIn),
-			TextureFile::fromName(TextureName::IntroTitle),
-			secondsToDisplay,
-			changeToQuote);
+		const std::string &textureName = TextureFile::fromName(TextureName::IntroTitle);
+		const std::string &paletteName = textureName;
+		return std::make_unique<ImagePanel>(game, paletteName, textureName,
+			secondsToDisplay, changeToQuote);
 	};
 
 	// Decide how the game starts up. If only the floppy disk data is available,
@@ -253,10 +250,13 @@ TextureID Panel::getTextureID(const std::string &textureName,
 	auto &textureManager = game.getTextureManager();
 	auto &renderer = game.getRenderer();
 
+	const std::string &paletteFilename =
+		PaletteUtils::isBuiltIn(paletteName) ? textureName : paletteName;
+
 	PaletteID paletteID;
-	if (!textureManager.tryGetPaletteID(paletteName.c_str(), &paletteID))
+	if (!textureManager.tryGetPaletteID(paletteFilename.c_str(), &paletteID))
 	{
-		DebugCrash("Couldn't get palette ID for \"" + paletteName + "\".");
+		DebugCrash("Couldn't get palette ID for \"" + paletteFilename + "\".");
 	}
 
 	TextureID textureID;
@@ -271,8 +271,7 @@ TextureID Panel::getTextureID(const std::string &textureName,
 TextureID Panel::getTextureID(TextureName textureName, PaletteName paletteName) const
 {
 	const std::string &textureFilename = TextureFile::fromName(textureName);
-	const std::string &paletteFilename = (paletteName == PaletteName::BuiltIn) ?
-		textureFilename : PaletteFile::fromName(paletteName);
+	const std::string &paletteFilename = PaletteFile::fromName(paletteName);
 	return this->getTextureID(textureFilename, paletteFilename);
 }
 
@@ -282,10 +281,13 @@ TextureManager::IdGroup<TextureID> Panel::getTextureIDs(const std::string &textu
 	auto &textureManager = game.getTextureManager();
 	auto &renderer = game.getRenderer();
 
+	const std::string &paletteFilename =
+		PaletteUtils::isBuiltIn(paletteName) ? textureName : paletteName;
+
 	PaletteID paletteID;
-	if (!textureManager.tryGetPaletteID(paletteName.c_str(), &paletteID))
+	if (!textureManager.tryGetPaletteID(paletteFilename.c_str(), &paletteID))
 	{
-		DebugCrash("Couldn't get palette ID for \"" + paletteName + "\".");
+		DebugCrash("Couldn't get palette ID for \"" + paletteFilename + "\".");
 	}
 
 	TextureManager::IdGroup<TextureID> textureIDs;
@@ -301,8 +303,7 @@ TextureManager::IdGroup<TextureID> Panel::getTextureIDs(TextureName textureName,
 	PaletteName paletteName) const
 {
 	const std::string &textureFilename = TextureFile::fromName(textureName);
-	const std::string &paletteFilename = (paletteName == PaletteName::BuiltIn) ?
-		textureFilename : PaletteFile::fromName(paletteName);
+	const std::string &paletteFilename = PaletteFile::fromName(paletteName);
 	return this->getTextureIDs(textureFilename, paletteFilename);
 }
 

--- a/OpenTESArena/src/Interface/Panel.cpp
+++ b/OpenTESArena/src/Interface/Panel.cpp
@@ -27,6 +27,8 @@
 
 #include "components/vfs/manager.hpp"
 
+const Panel::CursorData Panel::CursorData::EMPTY(nullptr, CursorAlignment::TopLeft);
+
 Panel::CursorData::CursorData(const Texture *texture, CursorAlignment alignment)
 {
 	this->texture = texture;
@@ -217,6 +219,91 @@ void Panel::resize(int windowWidth, int windowHeight)
 Game &Panel::getGame() const
 {
 	return this->game;
+}
+
+Panel::CursorData Panel::getDefaultCursor() const
+{
+	auto &game = this->getGame();
+	auto &renderer = game.getRenderer();
+	auto &textureManager = game.getTextureManager();
+
+	const std::string &paletteFilename = PaletteFile::fromName(PaletteName::Default);
+	PaletteID paletteID;
+	if (!textureManager.tryGetPaletteID(paletteFilename.c_str(), &paletteID))
+	{
+		DebugLogWarning("Couldn't get palette ID for \"" + paletteFilename + "\".");
+		return CursorData::EMPTY;
+	}
+
+	const std::string &textureFilename = TextureFile::fromName(TextureName::SwordCursor);
+	TextureID textureID;
+	if (!textureManager.tryGetTextureID(textureFilename.c_str(), paletteID, renderer, &textureID))
+	{
+		DebugLogWarning("Couldn't get texture ID for \"" + textureFilename + "\".");
+		return CursorData::EMPTY;
+	}
+
+	const Texture &texture = textureManager.getTexture(textureID);
+	return CursorData(&texture, CursorAlignment::TopLeft);
+}
+
+TextureID Panel::getTextureID(const std::string &textureName,
+	const std::string &paletteName) const
+{
+	auto &textureManager = game.getTextureManager();
+	auto &renderer = game.getRenderer();
+
+	PaletteID paletteID;
+	if (!textureManager.tryGetPaletteID(paletteName.c_str(), &paletteID))
+	{
+		DebugCrash("Couldn't get palette ID for \"" + paletteName + "\".");
+	}
+
+	TextureID textureID;
+	if (!textureManager.tryGetTextureID(textureName.c_str(), paletteID, renderer, &textureID))
+	{
+		DebugCrash("Couldn't get texture ID for \"" + textureName + "\".");
+	}
+
+	return textureID;
+}
+
+TextureID Panel::getTextureID(TextureName textureName, PaletteName paletteName) const
+{
+	const std::string &textureFilename = TextureFile::fromName(textureName);
+	const std::string &paletteFilename = (paletteName == PaletteName::BuiltIn) ?
+		textureFilename : PaletteFile::fromName(paletteName);
+	return this->getTextureID(textureFilename, paletteFilename);
+}
+
+TextureManager::IdGroup<TextureID> Panel::getTextureIDs(const std::string &textureName,
+	const std::string &paletteName) const
+{
+	auto &textureManager = game.getTextureManager();
+	auto &renderer = game.getRenderer();
+
+	PaletteID paletteID;
+	if (!textureManager.tryGetPaletteID(paletteName.c_str(), &paletteID))
+	{
+		DebugCrash("Couldn't get palette ID for \"" + paletteName + "\".");
+	}
+
+	TextureManager::IdGroup<TextureID> textureIDs;
+	if (!textureManager.tryGetTextureIDs(textureName.c_str(), paletteID, renderer, &textureIDs))
+	{
+		DebugCrash("Couldn't get texture IDs for \"" + textureName + "\".");
+	}
+
+	return textureIDs;
+}
+
+TextureManager::IdGroup<TextureID> Panel::getTextureIDs(TextureName textureName,
+	PaletteName paletteName) const
+{
+	const std::string &textureFilename = TextureFile::fromName(textureName);
+	const std::string &paletteFilename = (paletteName == PaletteName::BuiltIn) ?
+		textureFilename : PaletteFile::fromName(paletteName);
+	return this->getTextureIDs(textureFilename, paletteFilename);
 }
 
 void Panel::tick(double dt)

--- a/OpenTESArena/src/Interface/Panel.h
+++ b/OpenTESArena/src/Interface/Panel.h
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "../Math/Vector2.h"
+#include "../Media/TextureManager.h"
 #include "../Media/TextureUtils.h"
 
 // Each panel interprets user input and draws to the screen. There is only one panel 

--- a/OpenTESArena/src/Interface/Panel.h
+++ b/OpenTESArena/src/Interface/Panel.h
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "../Math/Vector2.h"
+#include "../Media/TextureUtils.h"
 
 // Each panel interprets user input and draws to the screen. There is only one panel 
 // active at a time, and it is owned by the Game.
@@ -22,6 +23,8 @@ class Texture;
 
 enum class CursorAlignment;
 enum class FontName;
+enum class PaletteName;
+enum class TextureName;
 
 struct SDL_Texture;
 
@@ -36,6 +39,8 @@ public:
 		const Texture *texture;
 		CursorAlignment alignment;
 	public:
+		static const CursorData EMPTY;
+
 		CursorData(const Texture *texture, CursorAlignment alignment);
 
 		const Texture *getTexture() const;
@@ -50,6 +55,18 @@ protected:
 		FontName fontName, FontManager &fontManager, Renderer &renderer);
 
 	Game &getGame() const;
+
+	// Default cursor used by most panels.
+	CursorData getDefaultCursor() const;
+
+	// Helper functions for accessing common UI textures. These functions assume that the
+	// textures exist.
+	TextureID getTextureID(const std::string &textureName, const std::string &paletteName) const;
+	TextureID getTextureID(TextureName textureName, PaletteName paletteName) const;
+	TextureManager::IdGroup<TextureID> getTextureIDs(const std::string &textureName,
+		const std::string &paletteName) const;
+	TextureManager::IdGroup<TextureID> getTextureIDs(TextureName textureName,
+		PaletteName paletteName) const;
 public:
 	Panel(Game &game);
 	virtual ~Panel() = default;

--- a/OpenTESArena/src/Interface/PauseMenuPanel.cpp
+++ b/OpenTESArena/src/Interface/PauseMenuPanel.cpp
@@ -311,13 +311,7 @@ void PauseMenuPanel::updateSoundText(double volume)
 
 Panel::CursorData PauseMenuPanel::getCurrentCursor() const
 {
-	auto &game = this->getGame();
-	auto &renderer = game.getRenderer();
-	auto &textureManager = game.getTextureManager();
-	const auto &texture = textureManager.getTexture(
-		TextureFile::fromName(TextureName::SwordCursor),
-		PaletteFile::fromName(PaletteName::Default), renderer);
-	return CursorData(&texture, CursorAlignment::TopLeft);
+	return this->getDefaultCursor();
 }
 
 void PauseMenuPanel::handleEvent(const SDL_Event &e)

--- a/OpenTESArena/src/Interface/PauseMenuPanel.cpp
+++ b/OpenTESArena/src/Interface/PauseMenuPanel.cpp
@@ -385,38 +385,51 @@ void PauseMenuPanel::render(Renderer &renderer)
 	// Clear full screen.
 	renderer.clear();
 
-	// Set palette.
-	auto &textureManager = this->getGame().getTextureManager();
-	textureManager.setPalette(PaletteFile::fromName(PaletteName::Default));
-
 	// Draw pause background.
-	const auto &pauseBackground = textureManager.getTexture(
-		TextureFile::fromName(TextureName::PauseBackground), renderer);
-	renderer.drawOriginal(pauseBackground);
+	auto &textureManager = this->getGame().getTextureManager();
+	const TextureID pauseBackgroundTextureID = this->getTextureID(
+		TextureName::PauseBackground, PaletteName::Default);
+	const Texture &pauseBackgroundTexture = textureManager.getTexture(pauseBackgroundTextureID);
+	renderer.drawOriginal(pauseBackgroundTexture);
 
 	// Draw game world interface below the pause menu.
-	const auto &gameInterface = textureManager.getTexture(
-		TextureFile::fromName(TextureName::GameWorldInterface), renderer);
-	renderer.drawOriginal(gameInterface, 0,
-		Renderer::ORIGINAL_HEIGHT - gameInterface.getHeight());
+	const TextureID gameInterfaceTextureID = this->getTextureID(
+		TextureName::GameWorldInterface, PaletteName::Default);
+	const Texture &gameInterfaceTexture = textureManager.getTexture(gameInterfaceTextureID);
+	renderer.drawOriginal(gameInterfaceTexture, 0,
+		Renderer::ORIGINAL_HEIGHT - gameInterfaceTexture.getHeight());
 
 	// Draw player portrait.
 	const auto &player = this->getGame().getGameData().getPlayer();
 	const auto &headsFilename = PortraitFile::getHeads(
 		player.isMale(), player.getRaceID(), true);
-	const auto &portrait = textureManager.getTextures(
-		headsFilename, renderer).at(player.getPortraitID());
-	const auto &status = textureManager.getTextures(
-		TextureFile::fromName(TextureName::StatusGradients), renderer).at(0);
-	renderer.drawOriginal(status, 14, 166);
-	renderer.drawOriginal(portrait, 14, 166);
+	const Texture &portraitTexture = [this, &textureManager, &headsFilename, &player]() -> const Texture&
+	{
+		const TextureManager::IdGroup<TextureID> portraitTextureIDs = this->getTextureIDs(
+			headsFilename, PaletteFile::fromName(PaletteName::Default));
+		const TextureID portraitTextureID = portraitTextureIDs.startID + player.getPortraitID();
+		return textureManager.getTexture(portraitTextureID);
+	}();
+
+	const Texture &statusTexture = [this, &textureManager]() -> const Texture&
+	{
+		const TextureManager::IdGroup<TextureID> statusTextureIDs = this->getTextureIDs(
+			TextureFile::fromName(TextureName::StatusGradients),
+			PaletteFile::fromName(PaletteName::Default));
+		const TextureID statusTextureID = statusTextureIDs.startID;
+		return textureManager.getTexture(statusTextureID);
+	}();
+
+	renderer.drawOriginal(statusTexture, 14, 166);
+	renderer.drawOriginal(portraitTexture, 14, 166);
 
 	// If the player's class can't use magic, show the darkened spell icon.
 	if (!player.getCharacterClass().canCastMagic())
 	{
-		const auto &nonMagicIcon = textureManager.getTexture(
-			TextureFile::fromName(TextureName::NoSpell), renderer);
-		renderer.drawOriginal(nonMagicIcon, 91, 177);
+		const TextureID nonMagicIconTextureID = this->getTextureID(
+			TextureName::NoSpell, PaletteName::Default);
+		const Texture &nonMagicIconTexture = textureManager.getTexture(nonMagicIconTextureID);
+		renderer.drawOriginal(nonMagicIconTexture, 91, 177);
 	}
 
 	// Cover up the detail slider with a new options background.

--- a/OpenTESArena/src/Interface/ProvinceMapPanel.cpp
+++ b/OpenTESArena/src/Interface/ProvinceMapPanel.cpp
@@ -252,13 +252,7 @@ void ProvinceMapPanel::trySelectLocation(int selectedLocationID)
 
 Panel::CursorData ProvinceMapPanel::getCurrentCursor() const
 {
-	auto &game = this->getGame();
-	auto &renderer = game.getRenderer();
-	auto &textureManager = game.getTextureManager();
-	const auto &texture = textureManager.getTexture(
-		TextureFile::fromName(TextureName::SwordCursor),
-		PaletteFile::fromName(PaletteName::Default), renderer);
-	return CursorData(&texture, CursorAlignment::TopLeft);
+	return this->getDefaultCursor();
 }
 
 void ProvinceMapPanel::handleEvent(const SDL_Event &e)

--- a/OpenTESArena/src/Interface/ProvinceMapPanel.cpp
+++ b/OpenTESArena/src/Interface/ProvinceMapPanel.cpp
@@ -932,8 +932,9 @@ void ProvinceMapPanel::render(Renderer &renderer)
 	// Draw province map background.
 	auto &textureManager = this->getGame().getTextureManager();
 	const std::string backgroundFilename = this->getBackgroundFilename();
+	const std::string &backgroundPaletteName = backgroundFilename;
 	const TextureID mapBackgroundTextureID = this->getTextureID(
-		backgroundFilename, PaletteFile::fromName(PaletteName::BuiltIn));
+		backgroundFilename, backgroundPaletteName);
 	const Texture &mapBackgroundTexture = textureManager.getTexture(mapBackgroundTextureID);
 	renderer.drawOriginal(mapBackgroundTexture);
 

--- a/OpenTESArena/src/Interface/ProvinceSearchSubPanel.cpp
+++ b/OpenTESArena/src/Interface/ProvinceSearchSubPanel.cpp
@@ -164,13 +164,7 @@ Panel::CursorData ProvinceSearchSubPanel::getCurrentCursor() const
 	}
 	else
 	{
-		auto &game = this->getGame();
-		auto &renderer = game.getRenderer();
-		auto &textureManager = game.getTextureManager();
-		const auto &texture = textureManager.getTexture(
-			TextureFile::fromName(TextureName::SwordCursor),
-			PaletteFile::fromName(PaletteName::Default), renderer);
-		return CursorData(&texture, CursorAlignment::TopLeft);
+		return this->getDefaultCursor();
 	}
 }
 

--- a/OpenTESArena/src/Interface/ProvinceSearchSubPanel.cpp
+++ b/OpenTESArena/src/Interface/ProvinceSearchSubPanel.cpp
@@ -480,12 +480,13 @@ void ProvinceSearchSubPanel::renderList(Renderer &renderer)
 	// Draw list background.
 	auto &game = this->getGame();
 	auto &textureManager = game.getTextureManager();
-	const auto &listBackground = textureManager.getTexture(
-		TextureFile::fromName(TextureName::PopUp8), this->getBackgroundFilename(), renderer);
+	const TextureID listBackgroundTextureID = this->getTextureID(
+		TextureFile::fromName(TextureName::PopUp8), this->getBackgroundFilename());
+	const Texture &listBackgroundTexture = textureManager.getTexture(listBackgroundTextureID);
 
 	const int listBackgroundX = 57;
 	const int listBackgroundY = 11;
-	renderer.drawOriginal(listBackground, listBackgroundX, listBackgroundY);
+	renderer.drawOriginal(listBackgroundTexture, listBackgroundX, listBackgroundY);
 
 	// Draw list box text.
 	renderer.drawOriginal(this->locationsListBox->getTexture(),

--- a/OpenTESArena/src/Interface/TextCinematicPanel.cpp
+++ b/OpenTESArena/src/Interface/TextCinematicPanel.cpp
@@ -136,15 +136,12 @@ void TextCinematicPanel::tick(double dt)
 		this->currentImageSeconds -= this->secondsPerImage;
 		this->imageIndex++;
 
-		auto &game = this->getGame();
-		auto &renderer = game.getRenderer();
-		auto &textureManager = game.getTextureManager();
-
 		// If at the end of the sequence, go back to the first image. The cinematic 
 		// ends at the end of the last text box.
-		const auto &textures = textureManager.getTextures(this->sequenceName, renderer);
-		const int textureCount = static_cast<int>(textures.size());
-		if (this->imageIndex == textureCount)
+		const TextureManager::IdGroup<TextureID> textureIDs = this->getTextureIDs(
+			this->sequenceName, PaletteFile::fromName(PaletteName::Default));
+
+		if (this->imageIndex == textureIDs.count)
 		{
 			this->imageIndex = 0;
 		}
@@ -156,20 +153,16 @@ void TextCinematicPanel::render(Renderer &renderer)
 	// Clear full screen.
 	renderer.clear();
 
-	// Set palette.
+	// Draw current frame in animation.
 	auto &textureManager = this->getGame().getTextureManager();
-	textureManager.setPalette(PaletteFile::fromName(PaletteName::Default));
-
-	// Get a reference to all relevant textures.
-	const auto &textures = textureManager.getTextures(this->sequenceName, renderer);
-
-	// Draw animation.
-	const auto &texture = textures.at(this->imageIndex);
+	const TextureManager::IdGroup<TextureID> textureIDs = this->getTextureIDs(
+		this->sequenceName, PaletteFile::fromName(PaletteName::Default));
+	const TextureID textureID = textureIDs.startID + this->imageIndex;
+	const Texture &texture = textureManager.getTexture(textureID);
 	renderer.drawOriginal(texture);
 
-	// Get the relevant text box.
-	const auto &textBox = this->textBoxes.at(this->textIndex);
-
-	// Draw text.
+	// Draw the relevant text box.
+	DebugAssertIndex(this->textBoxes, this->textIndex);
+	const auto &textBox = this->textBoxes[this->textIndex];
 	renderer.drawOriginal(textBox->getTexture(), textBox->getX(), textBox->getY());
 }

--- a/OpenTESArena/src/Interface/TextCinematicPanel.cpp
+++ b/OpenTESArena/src/Interface/TextCinematicPanel.cpp
@@ -139,7 +139,7 @@ void TextCinematicPanel::tick(double dt)
 		// If at the end of the sequence, go back to the first image. The cinematic 
 		// ends at the end of the last text box.
 		const TextureManager::IdGroup<TextureID> textureIDs = this->getTextureIDs(
-			this->sequenceName, PaletteFile::fromName(PaletteName::Default));
+			this->sequenceName, PaletteFile::fromName(PaletteName::BuiltIn));
 
 		if (this->imageIndex == textureIDs.count)
 		{
@@ -153,11 +153,13 @@ void TextCinematicPanel::render(Renderer &renderer)
 	// Clear full screen.
 	renderer.clear();
 
+	// Get texture IDs in advance of any texture references.
+	const TextureManager::IdGroup<TextureID> textureIDs = this->getTextureIDs(
+		this->sequenceName, PaletteFile::fromName(PaletteName::BuiltIn));
+	const TextureID textureID = textureIDs.startID + this->imageIndex;
+
 	// Draw current frame in animation.
 	auto &textureManager = this->getGame().getTextureManager();
-	const TextureManager::IdGroup<TextureID> textureIDs = this->getTextureIDs(
-		this->sequenceName, PaletteFile::fromName(PaletteName::Default));
-	const TextureID textureID = textureIDs.startID + this->imageIndex;
 	const Texture &texture = textureManager.getTexture(textureID);
 	renderer.drawOriginal(texture);
 

--- a/OpenTESArena/src/Interface/TextSubPanel.cpp
+++ b/OpenTESArena/src/Interface/TextSubPanel.cpp
@@ -32,9 +32,24 @@ Panel::CursorData TextSubPanel::getCurrentCursor() const
 	auto &game = this->getGame();
 	auto &renderer = game.getRenderer();
 	auto &textureManager = game.getTextureManager();
-	const auto &texture = textureManager.getTexture(
-		TextureFile::fromName(TextureName::SwordCursor),
-		PaletteFile::fromName(PaletteName::Default), renderer);
+	
+	const std::string &paletteFilename = PaletteFile::fromName(PaletteName::Default);
+	PaletteID paletteID;
+	if (!textureManager.tryGetPaletteID(paletteFilename.c_str(), &paletteID))
+	{
+		DebugLogWarning("Couldn't get palette ID for \"" + paletteFilename + "\".");
+		return CursorData::EMPTY;
+	}
+
+	const std::string &textureFilename = TextureFile::fromName(TextureName::SwordCursor);
+	TextureID textureID;
+	if (!textureManager.tryGetTextureID(textureFilename.c_str(), paletteID, renderer, &textureID))
+	{
+		DebugLogWarning("Couldn't get texture ID for \"" + textureFilename + "\".");
+		return CursorData::EMPTY;
+	}
+
+	const Texture &texture = textureManager.getTexture(textureID);
 	return CursorData(&texture, CursorAlignment::TopLeft);
 }
 

--- a/OpenTESArena/src/Interface/WorldMapPanel.cpp
+++ b/OpenTESArena/src/Interface/WorldMapPanel.cpp
@@ -126,23 +126,22 @@ void WorldMapPanel::render(Renderer &renderer)
 
 	// Clear full screen.
 	renderer.clear();
-
-	// Set palette.
-	auto &textureManager = this->getGame().getTextureManager();
-	textureManager.setPalette(PaletteFile::fromName(PaletteName::Default));
-
+	
 	// Draw world map background. This one has "Exit" at the bottom right.
-	const std::string &backgroundFilename = TextureFile::fromName(TextureName::WorldMap);
-	const auto &mapBackground = textureManager.getTexture(
-		backgroundFilename, PaletteFile::fromName(PaletteName::BuiltIn), renderer);
-	renderer.drawOriginal(mapBackground);
+	auto &textureManager = this->getGame().getTextureManager();
+	const TextureID mapBackgroundTextureID = this->getTextureID(
+		TextureName::WorldMap, PaletteName::BuiltIn);
+	const Texture &mapBackgroundTexture = textureManager.getTexture(mapBackgroundTextureID);
+	renderer.drawOriginal(mapBackgroundTexture);
 
 	// Draw yellow text over current province name.
 	const auto &gameData = this->getGame().getGameData();
 	const int provinceID = gameData.getProvinceDefinition().getRaceID();
-	const auto &provinceText = textureManager.getTextures(
+	const TextureManager::IdGroup<TextureID> provinceTextTextureIDs = this->getTextureIDs(
 		TextureFile::fromName(TextureName::ProvinceNames),
-		backgroundFilename, renderer).at(provinceID);
+		TextureFile::fromName(TextureName::WorldMap));
+	const TextureID provinceTextTextureID = provinceTextTextureIDs.startID + provinceID;
+	const Texture &provinceTextTexture = textureManager.getTexture(provinceTextTextureID);
 	const Int2 &nameOffset = this->provinceNameOffsets.at(provinceID);
-	renderer.drawOriginal(provinceText, nameOffset.x, nameOffset.y);
+	renderer.drawOriginal(provinceTextTexture, nameOffset.x, nameOffset.y);
 }

--- a/OpenTESArena/src/Interface/WorldMapPanel.cpp
+++ b/OpenTESArena/src/Interface/WorldMapPanel.cpp
@@ -126,21 +126,27 @@ void WorldMapPanel::render(Renderer &renderer)
 
 	// Clear full screen.
 	renderer.clear();
+
+	// Get texture IDs in advance of any texture references.
+	const auto &gameData = this->getGame().getGameData();
+	const int provinceID = gameData.getProvinceDefinition().getRaceID();
+	const TextureID provinceTextTextureID = [this, provinceID]()
+	{
+		const TextureManager::IdGroup<TextureID> provinceTextTextureIDs = this->getTextureIDs(
+			TextureFile::fromName(TextureName::ProvinceNames),
+			TextureFile::fromName(TextureName::WorldMap));
+		return provinceTextTextureIDs.startID + provinceID;
+	}();
+
+	const TextureID mapBackgroundTextureID = this->getTextureID(
+		TextureName::WorldMap, PaletteName::BuiltIn);
 	
 	// Draw world map background. This one has "Exit" at the bottom right.
 	auto &textureManager = this->getGame().getTextureManager();
-	const TextureID mapBackgroundTextureID = this->getTextureID(
-		TextureName::WorldMap, PaletteName::BuiltIn);
 	const Texture &mapBackgroundTexture = textureManager.getTexture(mapBackgroundTextureID);
 	renderer.drawOriginal(mapBackgroundTexture);
 
 	// Draw yellow text over current province name.
-	const auto &gameData = this->getGame().getGameData();
-	const int provinceID = gameData.getProvinceDefinition().getRaceID();
-	const TextureManager::IdGroup<TextureID> provinceTextTextureIDs = this->getTextureIDs(
-		TextureFile::fromName(TextureName::ProvinceNames),
-		TextureFile::fromName(TextureName::WorldMap));
-	const TextureID provinceTextTextureID = provinceTextTextureIDs.startID + provinceID;
 	const Texture &provinceTextTexture = textureManager.getTexture(provinceTextTextureID);
 	const Int2 &nameOffset = this->provinceNameOffsets.at(provinceID);
 	renderer.drawOriginal(provinceTextTexture, nameOffset.x, nameOffset.y);

--- a/OpenTESArena/src/Interface/WorldMapPanel.cpp
+++ b/OpenTESArena/src/Interface/WorldMapPanel.cpp
@@ -63,13 +63,7 @@ WorldMapPanel::WorldMapPanel(Game &game, std::unique_ptr<ProvinceMapPanel::Trave
 
 Panel::CursorData WorldMapPanel::getCurrentCursor() const
 {
-	auto &game = this->getGame();
-	auto &renderer = game.getRenderer();
-	auto &textureManager = game.getTextureManager();
-	const auto &texture = textureManager.getTexture(
-		TextureFile::fromName(TextureName::SwordCursor),
-		PaletteFile::fromName(PaletteName::Default), renderer);
-	return CursorData(&texture, CursorAlignment::TopLeft);
+	return this->getDefaultCursor();
 }
 
 void WorldMapPanel::handleEvent(const SDL_Event &e)

--- a/OpenTESArena/src/Media/TextureManager.h
+++ b/OpenTESArena/src/Media/TextureManager.h
@@ -99,6 +99,9 @@ public:
 	bool tryGetTextureID(const char *filename, PaletteID paletteID, Renderer &renderer, TextureID *outID);
 
 	// Texture getter functions, fast look-up.
+	// Note! The ID getter functions may resize the internal texture buffer causing
+	// dangling texture references, so get all IDs in advance of calling these functions,
+	// and store these references in as small of a scope as possible!
 	const Palette &getPalette(PaletteID id) const;
 	const Image &getImage(ImageID id) const;
 	const Surface &getSurface(SurfaceID id) const;

--- a/OpenTESArena/src/Rendering/Renderer.cpp
+++ b/OpenTESArena/src/Rendering/Renderer.cpp
@@ -627,10 +627,11 @@ void Renderer::addChasmTexture(VoxelDefinition::ChasmData::Type chasmType, const
 	this->softwareRenderer.addChasmTexture(chasmType, colors, width, height, palette);
 }
 
-void Renderer::setDistantSky(const DistantSky &distantSky, const Palette &palette)
+void Renderer::setDistantSky(const DistantSky &distantSky, const Palette &palette,
+	TextureManager &textureManager)
 {
 	DebugAssert(this->softwareRenderer.isInited());
-	this->softwareRenderer.setDistantSky(distantSky, palette);
+	this->softwareRenderer.setDistantSky(distantSky, palette, textureManager);
 }
 
 void Renderer::setSkyPalette(const uint32_t *colors, int count)

--- a/OpenTESArena/src/Rendering/Renderer.h
+++ b/OpenTESArena/src/Rendering/Renderer.h
@@ -199,7 +199,8 @@ public:
 		const Palette &palette);
 	void addChasmTexture(VoxelDefinition::ChasmData::Type chasmType, const uint8_t *colors,
 		int width, int height, const Palette &palette);
-	void setDistantSky(const DistantSky &distantSky, const Palette &palette);
+	void setDistantSky(const DistantSky &distantSky, const Palette &palette,
+		TextureManager &textureManager);
 	void setSkyPalette(const uint32_t *colors, int count);
 	void setNightLightsActive(bool active);
 	void removeLight(int id);

--- a/OpenTESArena/src/Rendering/SoftwareRenderer.h
+++ b/OpenTESArena/src/Rendering/SoftwareRenderer.h
@@ -365,7 +365,7 @@ private:
 		DistantObjects();
 
 		void init(const DistantSky &distantSky, std::vector<SkyTexture> &skyTextures,
-			const Palette &palette);
+			const Palette &palette, TextureManager &textureManager);
 
 		void clear();
 	};
@@ -1000,7 +1000,8 @@ public:
 	void setFogDistance(double fogDistance);
 
 	// Sets textures for the distant sky (mountains, clouds, etc.).
-	void setDistantSky(const DistantSky &distantSky, const Palette &palette);
+	void setDistantSky(const DistantSky &distantSky, const Palette &palette,
+		TextureManager &textureManager);
 
 	// Sets the sky palette to use with sky colors based on the time of day.
 	// For dungeons, this would probably just be one black pixel.

--- a/OpenTESArena/src/Rendering/Texture.cpp
+++ b/OpenTESArena/src/Rendering/Texture.cpp
@@ -61,23 +61,34 @@ Texture Texture::generate(Texture::PatternType type, int width, int height,
 		DebugAssert(height >= 40);
 
 		// Get the nine parchment tiles.
-		const auto &tiles = textureManager.getSurfaces(
-			TextureFile::fromName(TextureName::Parchment), "STARTGAM.MNU");
+		const std::string tilesPaletteFilename = "STARTGAM.MNU";
+		PaletteID tilesPaletteID;
+		if (!textureManager.tryGetPaletteID(tilesPaletteFilename.c_str(), &tilesPaletteID))
+		{
+			DebugCrash("Couldn't get palette ID for \"" + tilesPaletteFilename + "\".");
+		}
+
+		const std::string &tilesFilename = TextureFile::fromName(TextureName::Parchment);
+		TextureManager::IdGroup<SurfaceID> tileIDs;
+		if (!textureManager.tryGetSurfaceIDs(tilesFilename.c_str(), tilesPaletteID, &tileIDs))
+		{
+			DebugCrash("Couldn't get surface IDs for \"" + tilesFilename + "\".");
+		}
 
 		// Four corner tiles.
-		SDL_Surface *topLeft = tiles.at(0).get();
-		SDL_Surface *topRight = tiles.at(2).get();
-		SDL_Surface *bottomLeft = tiles.at(6).get();
-		SDL_Surface *bottomRight = tiles.at(8).get();
+		SDL_Surface *topLeft = textureManager.getSurface(tileIDs.startID).get();
+		SDL_Surface *topRight = textureManager.getSurface(tileIDs.startID + 2).get();
+		SDL_Surface *bottomLeft = textureManager.getSurface(tileIDs.startID + 6).get();
+		SDL_Surface *bottomRight = textureManager.getSurface(tileIDs.startID + 8).get();
 
 		// Four side tiles.
-		SDL_Surface *top = tiles.at(1).get();
-		SDL_Surface *left = tiles.at(3).get();
-		SDL_Surface *right = tiles.at(5).get();
-		SDL_Surface *bottom = tiles.at(7).get();
+		SDL_Surface *top = textureManager.getSurface(tileIDs.startID + 1).get();
+		SDL_Surface *left = textureManager.getSurface(tileIDs.startID + 3).get();
+		SDL_Surface *right = textureManager.getSurface(tileIDs.startID + 5).get();
+		SDL_Surface *bottom = textureManager.getSurface(tileIDs.startID + 7).get();
 
 		// One body tile.
-		SDL_Surface *body = tiles.at(4).get();
+		SDL_Surface *body = textureManager.getSurface(tileIDs.startID + 4).get();
 
 		// Draw body tiles.
 		for (int y = topLeft->h; y < (surface.getHeight() - topRight->h); y += body->h)

--- a/OpenTESArena/src/World/DistantSky.h
+++ b/OpenTESArena/src/World/DistantSky.h
@@ -7,11 +7,10 @@
 
 #include "../Math/MathUtils.h"
 #include "../Math/Vector3.h"
+#include "../Media/TextureManager.h"
+#include "../Media/TextureUtils.h"
 
 #include "components/utilities/Buffer.h"
-#include "components/utilities/BufferView.h"
-#include "components/utilities/Buffer2D.h"
-#include "components/utilities/BufferView2D.h"
 
 // Contains data for distant objects (mountains, clouds, stars). Each distant object's image
 // is owned by the texture manager.
@@ -137,23 +136,23 @@ private:
 	// Number of unique directions in 360 degrees.
 	static const int UNIQUE_ANGLES;
 
-	// Each texture entry holds its filename and 8-bit texture.
+	// Each texture entry holds its filename and 8-bit texture handle.
 	struct TextureEntry
 	{
 		std::string filename;
-		Buffer2D<uint8_t> texture;
+		ImageID imageID;
 
-		TextureEntry(std::string &&filename, Buffer2D<uint8_t> &&texture);
+		TextureEntry(std::string &&filename, ImageID imageID);
 	};
 
-	// Each texture set entry holds its filename and 8-bit textures. Intended only for
+	// Each texture set entry holds its filename and 8-bit texture handles. Intended only for
 	// animated distant objects.
 	struct TextureSetEntry
 	{
 		std::string filename;
-		Buffer<Buffer2D<uint8_t>> textures;
+		TextureManager::IdGroup<ImageID> imageIDs;
 
-		TextureSetEntry(std::string &&filename, Buffer<Buffer2D<uint8_t>> &&textures);
+		TextureSetEntry(std::string &&filename, TextureManager::IdGroup<ImageID> &&imageIDs);
 	};
 
 	// Each object's texture index points into here.
@@ -198,13 +197,13 @@ public:
 	const StarObject &getStarObject(int index) const;
 	int getSunEntryIndex() const;
 
-	BufferView2D<const uint8_t> getTexture(int index) const;
+	ImageID getImageID(int index) const;
 
 	// Gets the number of textures in the texture set at the given index.
 	int getTextureSetCount(int index) const;
 
-	// Gets the texture at the given element index in the given texture set.
-	BufferView2D<const uint8_t> getTextureSetElement(int index, int elementIndex) const;
+	// Gets the image ID at the given element index in the given texture set.
+	ImageID getTextureSetImageID(int index, int elementIndex) const;
 
 	// Added in the new engine for fun. Gets the number of stars for some density.
 	static int getStarCountFromDensity(int starDensity);

--- a/OpenTESArena/src/World/ExteriorLevelData.cpp
+++ b/OpenTESArena/src/World/ExteriorLevelData.cpp
@@ -1114,7 +1114,7 @@ void ExteriorLevelData::setActive(bool nightLightsAreActive, const WorldData &wo
 	}
 
 	// Give distant sky data to the renderer.
-	renderer.setDistantSky(this->distantSky, col.getPalette());
+	renderer.setDistantSky(this->distantSky, col.getPalette(), textureManager);
 }
 
 void ExteriorLevelData::tick(Game &game, double dt)

--- a/OpenTESArena/src/World/WeatherUtils.cpp
+++ b/OpenTESArena/src/World/WeatherUtils.cpp
@@ -44,21 +44,26 @@ Buffer<uint32_t> WeatherUtils::makeExteriorSkyPalette(WeatherType weatherType,
 	TextureManager &textureManager)
 {
 	// Get the palette name for the given weather.
-	const std::string paletteName = (weatherType == WeatherType::Clear) ? "DAYTIME.COL" : "DREARY.COL";
+	const char *paletteName = (weatherType == WeatherType::Clear) ? "DAYTIME.COL" : "DREARY.COL";
 
 	// The palettes in the data files only cover half of the day, so some added
 	// darkness is needed for the other half.
-	const Surface &palette = textureManager.getSurface(paletteName);
-	const uint32_t *pixels = static_cast<const uint32_t*>(palette.getPixels());
-	const int pixelCount = palette.getWidth() * palette.getHeight();
+	PaletteID paletteID;
+	if (!textureManager.tryGetPaletteID(paletteName, &paletteID))
+	{
+		DebugCrash("Couldn't get palette ID for \"" + std::string(paletteName) + "\".");
+	}
 
-	// Fill palette with darkness (the first color in the palette is the closest to night).
-	const uint32_t darkness = pixels[0];
-	Buffer<uint32_t> fullPalette(pixelCount * 2);
+	const Palette &palette = textureManager.getPalette(paletteID);
+
+	// Fill sky palette with darkness (the first color in the palette is the closest to night).
+	const uint32_t darkness = palette[0].toARGB();
+	Buffer<uint32_t> fullPalette(static_cast<int>(palette.size()) * 2);
 	fullPalette.fill(darkness);
 
 	// Copy the sky palette over the center of the full palette.
-	std::copy(pixels, pixels + pixelCount, fullPalette.get() + (fullPalette.getCount() / 4));
+	std::transform(palette.begin(), palette.end(), fullPalette.get() + (fullPalette.getCount() / 4),
+		[](const Color &color) { return color.toARGB(); });
 
 	return fullPalette;
 }


### PR DESCRIPTION
Re-designed the texture manager so it can fail to look-up a texture. Added native support for storing/handling 8-bit images and started using a new ID-based system for fast texture look-up.

Ran into some issues with dangling texture references if texture IDs are obtained after a texture reference look-up because the internal texture buffer in the texture manager might get resized, so just need to be careful by getting all texture IDs ahead of time. At least the texture look-up functions are const now.