### PR TITLE
Add buffer ref class for texture reference safety

### DIFF
--- a/OpenTESArena/src/Interface/AutomapPanel.cpp
+++ b/OpenTESArena/src/Interface/AutomapPanel.cpp
@@ -595,7 +595,7 @@ Panel::CursorData AutomapPanel::getCurrentCursor() const
 		return CursorData::EMPTY;
 	}
 
-	const Texture &texture = textureManager.getTexture(textureID);
+	const Texture &texture = textureManager.getTextureHandle(textureID);
 	return CursorData(&texture, CursorAlignment::BottomLeft);
 }
 
@@ -692,9 +692,9 @@ void AutomapPanel::render(Renderer &renderer)
 	renderer.clear();
 
 	// Draw automap background.
-	auto &textureManager = this->getGame().getTextureManager();
-	const Texture &backgroundTexture = textureManager.getTexture(this->backgroundTextureID);
-	renderer.drawOriginal(backgroundTexture);
+	const auto &textureManager = this->getGame().getTextureManager();
+	const TextureRef backgroundTexture = textureManager.getTextureRef(this->backgroundTextureID);
+	renderer.drawOriginal(backgroundTexture.get());
 
 	// Only draw the part of the automap within the drawing area.
 	const Rect nativeDrawingArea = renderer.originalToNative(DrawingArea);

--- a/OpenTESArena/src/Interface/CharacterEquipmentPanel.cpp
+++ b/OpenTESArena/src/Interface/CharacterEquipmentPanel.cpp
@@ -299,21 +299,21 @@ void CharacterEquipmentPanel::render(Renderer &renderer)
 		TextureName::CharacterEquipment, PaletteName::CharSheet);
 
 	// Draw the current portrait and clothes.
-	auto &textureManager = game.getTextureManager();
-	const Texture &headTexture = textureManager.getTexture(headTextureID);
-	const Texture &bodyTexture = textureManager.getTexture(bodyTextureID);
-	const Texture &shirtTexture = textureManager.getTexture(shirtTextureID);
-	const Texture &pantsTexture = textureManager.getTexture(pantsTextureID);
+	const auto &textureManager = game.getTextureManager();
+	TextureRef headTexture = textureManager.getTextureRef(headTextureID);
+	TextureRef bodyTexture = textureManager.getTextureRef(bodyTextureID);
+	TextureRef shirtTexture = textureManager.getTextureRef(shirtTextureID);
+	TextureRef pantsTexture = textureManager.getTextureRef(pantsTextureID);
 
 	const Int2 &headOffset = this->headOffsets.at(player.getPortraitID());
-	renderer.drawOriginal(bodyTexture, Renderer::ORIGINAL_WIDTH - bodyTexture.getWidth(), 0);
-	renderer.drawOriginal(pantsTexture, pantsOffset.x, pantsOffset.y);
-	renderer.drawOriginal(headTexture, headOffset.x, headOffset.y);
-	renderer.drawOriginal(shirtTexture, shirtOffset.x, shirtOffset.y);
+	renderer.drawOriginal(bodyTexture.get(), Renderer::ORIGINAL_WIDTH - bodyTexture.getWidth(), 0);
+	renderer.drawOriginal(pantsTexture.get(), pantsOffset.x, pantsOffset.y);
+	renderer.drawOriginal(headTexture.get(), headOffset.x, headOffset.y);
+	renderer.drawOriginal(shirtTexture.get(), shirtOffset.x, shirtOffset.y);
 
 	// Draw character equipment background.
-	const Texture &equipmentBackgroundTexture = textureManager.getTexture(equipmentBackgroundTextureID);
-	renderer.drawOriginal(equipmentBackgroundTexture);
+	TextureRef equipmentBackgroundTexture = textureManager.getTextureRef(equipmentBackgroundTextureID);
+	renderer.drawOriginal(equipmentBackgroundTexture.get());
 
 	// Draw text boxes: player name, race, class.
 	renderer.drawOriginal(this->playerNameTextBox->getTexture(),

--- a/OpenTESArena/src/Interface/CharacterPanel.cpp
+++ b/OpenTESArena/src/Interface/CharacterPanel.cpp
@@ -201,25 +201,25 @@ void CharacterPanel::render(Renderer &renderer)
 		TextureName::NextPage, PaletteName::CharSheet);
 
 	// Draw the current portrait and clothes.
-	auto &textureManager = game.getTextureManager();
-	const Texture &headTexture = textureManager.getTexture(headTextureID);
-	const Texture &bodyTexture = textureManager.getTexture(bodyTextureID);
-	const Texture &shirtTexture = textureManager.getTexture(shirtTextureID);
-	const Texture &pantsTexture = textureManager.getTexture(pantsTextureID);
+	const auto &textureManager = game.getTextureManager();
+	const TextureRef headTexture = textureManager.getTextureRef(headTextureID);
+	const TextureRef bodyTexture = textureManager.getTextureRef(bodyTextureID);
+	const TextureRef shirtTexture = textureManager.getTextureRef(shirtTextureID);
+	const TextureRef pantsTexture = textureManager.getTextureRef(pantsTextureID);
 
 	const Int2 &headOffset = this->headOffsets.at(player.getPortraitID());
-	renderer.drawOriginal(bodyTexture, Renderer::ORIGINAL_WIDTH - bodyTexture.getWidth(), 0);
-	renderer.drawOriginal(pantsTexture, pantsOffset.x, pantsOffset.y);
-	renderer.drawOriginal(headTexture, headOffset.x, headOffset.y);
-	renderer.drawOriginal(shirtTexture, shirtOffset.x, shirtOffset.y);
+	renderer.drawOriginal(bodyTexture.get(), Renderer::ORIGINAL_WIDTH - bodyTexture.getWidth(), 0);
+	renderer.drawOriginal(pantsTexture.get(), pantsOffset.x, pantsOffset.y);
+	renderer.drawOriginal(headTexture.get(), headOffset.x, headOffset.y);
+	renderer.drawOriginal(shirtTexture.get(), shirtOffset.x, shirtOffset.y);
 
 	// Draw character stats background.
-	const Texture &statsBackgroundTexture = textureManager.getTexture(statsBackgroundTextureID);
-	renderer.drawOriginal(statsBackgroundTexture);
+	const TextureRef statsBackgroundTexture = textureManager.getTextureRef(statsBackgroundTextureID);
+	renderer.drawOriginal(statsBackgroundTexture.get());
 
 	// Draw "Next Page" texture.
-	const Texture &nextPageTexture = textureManager.getTexture(nextPageTextureID);
-	renderer.drawOriginal(nextPageTexture, 108, 179);
+	const TextureRef nextPageTexture = textureManager.getTextureRef(nextPageTextureID);
+	renderer.drawOriginal(nextPageTexture.get(), 108, 179);
 
 	// Draw text boxes: player name, race, class.
 	renderer.drawOriginal(this->playerNameTextBox->getTexture(),

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
@@ -725,49 +725,49 @@ void ChooseAttributesPanel::render(Renderer &renderer)
 	// Draw the current portrait and clothes.
 	auto &textureManager = game.getTextureManager();
 	const Int2 &headOffset = this->headOffsets.at(portraitIndex);
-	const Texture &headTexture = [this, &textureManager, portraitIndex, &headsFilename]() -> const Texture&
+	const TextureRef headTexture = [this, &textureManager, portraitIndex, &headsFilename]() -> TextureRef
 	{
 		const TextureManager::IdGroup<TextureID> headTextureIDs =
 			this->getTextureIDs(headsFilename, PaletteFile::fromName(PaletteName::CharSheet));
 		const TextureID headTextureID = headTextureIDs.startID + portraitIndex;
-		return textureManager.getTexture(headTextureID);
+		return textureManager.getTextureRef(headTextureID);
 	}();
 
-	const Texture &bodyTexture = [this, &textureManager, &bodyFilename]() -> const Texture&
+	const TextureRef bodyTexture = [this, &textureManager, &bodyFilename]() -> TextureRef
 	{
 		const TextureID bodyTextureID = this->getTextureID(
 			bodyFilename, PaletteFile::fromName(PaletteName::CharSheet));
-		return textureManager.getTexture(bodyTextureID);
+		return textureManager.getTextureRef(bodyTextureID);
 	}();
 
-	const Texture &shirtTexture = [this, &textureManager, &shirtFilename]() -> const Texture&
+	const TextureRef shirtTexture = [this, &textureManager, &shirtFilename]() -> TextureRef
 	{
 		const TextureID shirtTextureID = this->getTextureID(
 			shirtFilename, PaletteFile::fromName(PaletteName::CharSheet));
-		return textureManager.getTexture(shirtTextureID);
+		return textureManager.getTextureRef(shirtTextureID);
 	}();
 
-	const Texture &pantsTexture = [this, &textureManager, &pantsFilename]() -> const Texture&
+	const TextureRef pantsTexture = [this, &textureManager, &pantsFilename]() -> TextureRef
 	{
 		const TextureID pantsTextureID = this->getTextureID(
 			pantsFilename, PaletteFile::fromName(PaletteName::CharSheet));
-		return textureManager.getTexture(pantsTextureID);
+		return textureManager.getTextureRef(pantsTextureID);
 	}();
 
-	renderer.drawOriginal(bodyTexture, Renderer::ORIGINAL_WIDTH - bodyTexture.getWidth(), 0);
-	renderer.drawOriginal(pantsTexture, pantsOffset.x, pantsOffset.y);
-	renderer.drawOriginal(headTexture, headOffset.x, headOffset.y);
-	renderer.drawOriginal(shirtTexture, shirtOffset.x, shirtOffset.y);
+	renderer.drawOriginal(bodyTexture.get(), Renderer::ORIGINAL_WIDTH - bodyTexture.getWidth(), 0);
+	renderer.drawOriginal(pantsTexture.get(), pantsOffset.x, pantsOffset.y);
+	renderer.drawOriginal(headTexture.get(), headOffset.x, headOffset.y);
+	renderer.drawOriginal(shirtTexture.get(), shirtOffset.x, shirtOffset.y);
 
 	// Draw attributes texture.
-	const Texture &attributesBackgroundTexture = [this, &textureManager]() -> const Texture&
+	const TextureRef attributesBackgroundTexture = [this, &textureManager]() -> TextureRef
 	{
 		const TextureID attributesBackgroundTextureID = this->getTextureID(
 			TextureName::CharacterStats, PaletteName::CharSheet);
-		return textureManager.getTexture(attributesBackgroundTextureID);
+		return textureManager.getTextureRef(attributesBackgroundTextureID);
 	}();
 
-	renderer.drawOriginal(attributesBackgroundTexture);
+	renderer.drawOriginal(attributesBackgroundTexture.get());
 
 	// Draw text boxes: player name, race, class.
 	renderer.drawOriginal(this->nameTextBox->getTexture(),

--- a/OpenTESArena/src/Interface/ChooseClassCreationPanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseClassCreationPanel.cpp
@@ -187,11 +187,11 @@ void ChooseClassCreationPanel::render(Renderer &renderer)
 	renderer.clear();
 
 	// Draw background.
-	auto &textureManager = this->getGame().getTextureManager();
+	const auto &textureManager = this->getGame().getTextureManager();
 	const TextureID backgroundTextureID = this->getTextureID(
 		TextureName::CharacterCreation, PaletteName::BuiltIn);
-	const Texture &backgroundTexture = textureManager.getTexture(backgroundTextureID);
-	renderer.drawOriginal(backgroundTexture);
+	const TextureRef backgroundTexture = textureManager.getTextureRef(backgroundTextureID);
+	renderer.drawOriginal(backgroundTexture.get());
 
 	// Draw parchments: title, generate, select.
 	const int parchmentX = (Renderer::ORIGINAL_WIDTH / 2) - 

--- a/OpenTESArena/src/Interface/ChooseClassPanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseClassPanel.cpp
@@ -434,18 +434,18 @@ void ChooseClassPanel::render(Renderer &renderer)
 
 	// Draw background.
 	auto &game = this->getGame();
-	auto &textureManager = game.getTextureManager();
+	const auto &textureManager = game.getTextureManager();
 	const TextureID backgroundTextureID = this->getTextureID(
 		TextureName::CharacterCreation, PaletteName::BuiltIn);
-	const Texture &backgroundTexture = textureManager.getTexture(backgroundTextureID);
-	renderer.drawOriginal(backgroundTexture);
+	const TextureRef backgroundTexture = textureManager.getTextureRef(backgroundTextureID);
+	renderer.drawOriginal(backgroundTexture.get());
 
 	// Draw list pop-up.
 	const TextureID listPopUpTextureID = this->getTextureID(
 		TextureFile::fromName(TextureName::PopUp2),
 		TextureFile::fromName(TextureName::CharacterCreation));
-	const Texture &listPopUpTexture = textureManager.getTexture(listPopUpTextureID);
-	renderer.drawOriginal(listPopUpTexture, 55, 9,
+	const TextureRef listPopUpTexture = textureManager.getTextureRef(listPopUpTextureID);
+	renderer.drawOriginal(listPopUpTexture.get(), 55, 9,
 		listPopUpTexture.getWidth(), listPopUpTexture.getHeight());
 
 	// Draw text: title, list.

--- a/OpenTESArena/src/Interface/ChooseGenderPanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseGenderPanel.cpp
@@ -161,11 +161,11 @@ void ChooseGenderPanel::render(Renderer &renderer)
 	renderer.clear();
 
 	// Draw background.
-	auto &textureManager = this->getGame().getTextureManager();
+	const auto &textureManager = this->getGame().getTextureManager();
 	const TextureID backgroundTextureID = this->getTextureID(
 		TextureName::CharacterCreation, PaletteName::BuiltIn);
-	const Texture &backgroundTexture = textureManager.getTexture(backgroundTextureID);
-	renderer.drawOriginal(backgroundTexture);
+	const TextureRef backgroundTexture = textureManager.getTextureRef(backgroundTextureID);
+	renderer.drawOriginal(backgroundTexture.get());
 
 	// Draw parchments: title, male, and female.
 	const int parchmentX = (Renderer::ORIGINAL_WIDTH / 2) -

--- a/OpenTESArena/src/Interface/ChooseNamePanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseNamePanel.cpp
@@ -178,8 +178,8 @@ void ChooseNamePanel::render(Renderer &renderer)
 	auto &textureManager = this->getGame().getTextureManager();
 	const TextureID backgroundTextureID = this->getTextureID(
 		TextureName::CharacterCreation, PaletteName::BuiltIn);
-	const Texture &backgroundTexture = textureManager.getTexture(backgroundTextureID);
-	renderer.drawOriginal(backgroundTexture);
+	const TextureRef backgroundTexture = textureManager.getTextureRef(backgroundTextureID);
+	renderer.drawOriginal(backgroundTexture.get());
 
 	// Draw parchment: title.
 	renderer.drawOriginal(this->parchment,

--- a/OpenTESArena/src/Interface/ChooseRacePanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseRacePanel.cpp
@@ -606,18 +606,18 @@ void ChooseRacePanel::render(Renderer &renderer)
 	renderer.clear();
 
 	// Draw background map.
-	auto &textureManager = this->getGame().getTextureManager();
+	const auto &textureManager = this->getGame().getTextureManager();
 	const TextureID raceSelectMapTextureID = this->getTextureID(
 		TextureName::RaceSelect, PaletteName::BuiltIn);
-	const Texture &raceSelectMapTexture = textureManager.getTexture(raceSelectMapTextureID);
-	renderer.drawOriginal(raceSelectMapTexture);
+	const TextureRef raceSelectMapTexture = textureManager.getTextureRef(raceSelectMapTextureID);
+	renderer.drawOriginal(raceSelectMapTexture.get());
 
 	// Arena just covers up the "exit" text at the bottom right.
 	const TextureID exitCoverTextureID = this->getTextureID(
 		TextureFile::fromName(TextureName::NoExit),
 		TextureFile::fromName(TextureName::RaceSelect));
-	const Texture &exitCoverTexture = textureManager.getTexture(exitCoverTextureID);
-	renderer.drawOriginal(exitCoverTexture,
+	const TextureRef exitCoverTexture = textureManager.getTextureRef(exitCoverTextureID);
+	renderer.drawOriginal(exitCoverTexture.get(),
 		Renderer::ORIGINAL_WIDTH - exitCoverTexture.getWidth(),
 		Renderer::ORIGINAL_HEIGHT - exitCoverTexture.getHeight());
 }

--- a/OpenTESArena/src/Interface/CinematicPanel.cpp
+++ b/OpenTESArena/src/Interface/CinematicPanel.cpp
@@ -73,7 +73,7 @@ void CinematicPanel::render(Renderer &renderer)
 	const TextureID textureID = textureIDs.startID + this->imageIndex;
 
 	// Draw current frame of the cinematic.
-	auto &textureManager = this->getGame().getTextureManager();
-	const Texture &texture = textureManager.getTexture(textureID);
-	renderer.drawOriginal(texture);
+	const auto &textureManager = this->getGame().getTextureManager();
+	const TextureRef texture = textureManager.getTextureRef(textureID);
+	renderer.drawOriginal(texture.get());
 }

--- a/OpenTESArena/src/Interface/FastTravelSubPanel.cpp
+++ b/OpenTESArena/src/Interface/FastTravelSubPanel.cpp
@@ -568,9 +568,9 @@ void FastTravelSubPanel::render(Renderer &renderer)
 	const TextureManager::IdGroup<TextureID> animationTextureIDs = this->getAnimationTextureIDs();
 	const TextureID animationTextureID =
 		animationTextureIDs.startID + static_cast<int>(this->frameIndex);
-	const Texture &animFrame = textureManager.getTexture(animationTextureID);
+	const TextureRef animFrame = textureManager.getTextureRef(animationTextureID);
 
 	const int x = (Renderer::ORIGINAL_WIDTH / 2) - (animFrame.getWidth() / 2);
 	const int y = (Renderer::ORIGINAL_HEIGHT / 2) - (animFrame.getHeight() / 2);
-	renderer.drawOriginal(animFrame, x, y);
+	renderer.drawOriginal(animFrame.get(), x, y);
 }

--- a/OpenTESArena/src/Interface/GameWorldPanel.cpp
+++ b/OpenTESArena/src/Interface/GameWorldPanel.cpp
@@ -673,7 +673,7 @@ Int2 GameWorldPanel::getInterfaceCenter(bool modernInterface, TextureManager &te
 	{
 		const TextureID gameInterfaceTextureID =
 			GameWorldPanel::getGameWorldInterfaceTextureID(textureManager, renderer);
-		const Texture &gameInterfaceTexture = textureManager.getTexture(gameInterfaceTextureID);
+		const TextureRef gameInterfaceTexture = textureManager.getTextureRef(gameInterfaceTextureID);
 
 		return Int2(Renderer::ORIGINAL_WIDTH / 2,
 			(Renderer::ORIGINAL_HEIGHT - gameInterfaceTexture.getHeight()) / 2);
@@ -718,7 +718,7 @@ Panel::CursorData GameWorldPanel::getCurrentCursor() const
 				}
 
 				const TextureID textureID = textureIDs.startID + i;
-				const Texture &texture = textureManager.getTexture(textureID);
+				const Texture &texture = textureManager.getTextureHandle(textureID);
 				return CursorData(&texture, ArrowCursorAlignments.at(i));
 			}
 		}
@@ -1567,8 +1567,8 @@ void GameWorldPanel::handlePlayerAttack(const Int2 &mouseDelta)
 					auto &renderer = game.getRenderer();
 					const TextureID gameWorldInterfaceTextureID =
 						GameWorldPanel::getGameWorldInterfaceTextureID(textureManager, renderer);
-					const Texture &gameWorldInterfaceTexture =
-						textureManager.getTexture(gameWorldInterfaceTextureID);
+					const TextureRef gameWorldInterfaceTexture =
+						textureManager.getTextureRef(gameWorldInterfaceTextureID);
 					const int originalCursorY = renderer.nativeToOriginal(inputManager.getMousePosition()).y;
 					return rightClick && (originalCursorY <
 						(Renderer::ORIGINAL_HEIGHT - gameWorldInterfaceTexture.getHeight()));
@@ -2569,7 +2569,8 @@ void GameWorldPanel::drawTooltip(const std::string &text, Renderer &renderer)
 	auto &textureManager = this->getGame().getTextureManager();
 	const TextureID gameWorldInterfaceTextureID =
 		GameWorldPanel::getGameWorldInterfaceTextureID(textureManager, renderer);
-	const Texture &gameWorldInterfaceTexture = textureManager.getTexture(gameWorldInterfaceTextureID);
+	const TextureRef gameWorldInterfaceTexture =
+		textureManager.getTextureRef(gameWorldInterfaceTextureID);
 
 	const int x = 0;
 	const int y = Renderer::ORIGINAL_HEIGHT -
@@ -2584,7 +2585,7 @@ void GameWorldPanel::drawCompass(const NewDouble2 &direction,
 	const TextureID compassFrameTextureID = this->getCompassFrameTextureID();
 
 	// Draw compass slider based on player direction.
-	const Texture &compassSlider = textureManager.getTexture(compassSliderTextureID);
+	const TextureRef compassSlider = textureManager.getTextureRef(compassSliderTextureID);
 
 	// Angle between 0 and 2 pi.
 	const double angle = std::atan2(-direction.y, -direction.x);
@@ -2607,11 +2608,11 @@ void GameWorldPanel::drawCompass(const NewDouble2 &direction,
 	renderer.fillOriginalRect(Color::Black, sliderX - 1, sliderY - 1,
 		clipRect.getWidth() + 2, clipRect.getHeight() + 2);
 
-	renderer.drawOriginalClipped(compassSlider, clipRect, sliderX, sliderY);
+	renderer.drawOriginalClipped(compassSlider.get(), clipRect, sliderX, sliderY);
 
 	// Draw the compass frame over the slider.
-	const Texture &compassFrame = textureManager.getTexture(compassFrameTextureID);
-	renderer.drawOriginal(compassFrame,
+	const TextureRef compassFrame = textureManager.getTextureRef(compassFrameTextureID);
+	renderer.drawOriginal(compassFrame.get(),
 		(Renderer::ORIGINAL_WIDTH / 2) - (compassFrame.getWidth() / 2), 0);
 }
 
@@ -3021,21 +3022,22 @@ void GameWorldPanel::render(Renderer &renderer)
 	if (!modernInterface)
 	{
 		// Draw game world interface.
-		const Texture &gameWorldInterfaceTexture = textureManager.getTexture(gameWorldInterfaceTextureID);
-		renderer.drawOriginal(gameWorldInterfaceTexture, 0,
+		const TextureRef gameWorldInterfaceTexture =
+			textureManager.getTextureRef(gameWorldInterfaceTextureID);
+		renderer.drawOriginal(gameWorldInterfaceTexture.get(), 0,
 			Renderer::ORIGINAL_HEIGHT - gameWorldInterfaceTexture.getHeight());
 
 		// Draw player portrait.
-		const Texture &statusGradientTexture = textureManager.getTexture(statusGradientTextureID);
-		const Texture &playerPortraitTexture = textureManager.getTexture(playerPortraitTextureID);
-		renderer.drawOriginal(statusGradientTexture, 14, 166);
-		renderer.drawOriginal(playerPortraitTexture, 14, 166);
+		const TextureRef statusGradientTexture = textureManager.getTextureRef(statusGradientTextureID);
+		const TextureRef playerPortraitTexture = textureManager.getTextureRef(playerPortraitTextureID);
+		renderer.drawOriginal(statusGradientTexture.get(), 14, 166);
+		renderer.drawOriginal(playerPortraitTexture.get(), 14, 166);
 
 		// If the player's class can't use magic, show the darkened spell icon.
 		if (!player.getCharacterClass().canCastMagic())
 		{
-			const Texture &noSpellTexture = textureManager.getTexture(noSpellTextureID);
-			renderer.drawOriginal(noSpellTexture, 91, 177);
+			const TextureRef noSpellTexture = textureManager.getTextureRef(noSpellTextureID);
+			renderer.drawOriginal(noSpellTexture.get(), 91, 177);
 		}
 
 		// Draw text: player name.
@@ -3071,9 +3073,9 @@ void GameWorldPanel::renderSecondary(Renderer &renderer)
 			return this->getWeaponTextureID(weaponFilename, weaponAnimIndex);
 		}();
 
-		const Texture &gameWorldInterfaceTexture =
-			textureManager.getTexture(gameWorldInterfaceTextureID);
-		const Texture &weaponTexture = textureManager.getTexture(weaponTextureID);
+		const TextureRef gameWorldInterfaceTexture =
+			textureManager.getTextureRef(gameWorldInterfaceTextureID);
+		const TextureRef weaponTexture = textureManager.getTextureRef(weaponTextureID);
 
 		DebugAssertIndex(this->weaponOffsets, weaponAnimIndex);
 		const Int2 &weaponOffset = this->weaponOffsets[weaponAnimIndex];
@@ -3110,7 +3112,7 @@ void GameWorldPanel::renderSecondary(Renderer &renderer)
 				static_cast<double>(std::min(weaponTexture.getHeight() + 1,
 					std::max(Renderer::ORIGINAL_HEIGHT - weaponY, 0))) * weaponScaleY));
 
-			renderer.drawOriginal(weaponTexture,
+			renderer.drawOriginal(weaponTexture.get(),
 				weaponX, weaponY, weaponWidth, weaponHeight);
 
 			// Reset letterbox mode back to what it was.
@@ -3126,7 +3128,7 @@ void GameWorldPanel::renderSecondary(Renderer &renderer)
 			// Add 1 to the height because Arena's renderer has an off-by-one bug, and a 1 pixel
 			// gap appears unless a small change is added.
 			const int weaponHeight = std::clamp(weaponTexture.getHeight() + 1, 0, maxWeaponHeight);
-			renderer.drawOriginal(weaponTexture,
+			renderer.drawOriginal(weaponTexture.get(),
 				weaponOffset.x, weaponOffset.y, weaponTexture.getWidth(), weaponHeight);
 		}
 	}
@@ -3145,7 +3147,7 @@ void GameWorldPanel::renderSecondary(Renderer &renderer)
 		const Texture *triggerTextTexture;
 		gameData.getTriggerTextRenderInfo(&triggerTextTexture);
 
-		const Texture &gameWorldInterfaceTexture = textureManager.getTexture(gameWorldInterfaceTextureID);
+		const TextureRef gameWorldInterfaceTexture = textureManager.getTextureRef(gameWorldInterfaceTextureID);
 		const int centerX = (Renderer::ORIGINAL_WIDTH / 2) - (triggerTextTexture->getWidth() / 2) - 1;
 		const int centerY = [modernInterface, &gameWorldInterfaceTexture, triggerTextTexture]()
 		{

--- a/OpenTESArena/src/Interface/ImagePanel.cpp
+++ b/OpenTESArena/src/Interface/ImagePanel.cpp
@@ -58,6 +58,6 @@ void ImagePanel::render(Renderer &renderer)
 	// Draw image.
 	auto &textureManager = this->getGame().getTextureManager();
 	const TextureID textureID = this->getTextureID(this->textureName, this->paletteName);
-	const Texture &texture = textureManager.getTexture(textureID);
-	renderer.drawOriginal(texture);
+	const TextureRef texture = textureManager.getTextureRef(textureID);
+	renderer.drawOriginal(texture.get());
 }

--- a/OpenTESArena/src/Interface/ImageSequencePanel.cpp
+++ b/OpenTESArena/src/Interface/ImageSequencePanel.cpp
@@ -101,6 +101,6 @@ void ImageSequencePanel::render(Renderer &renderer)
 	const std::string &textureName = this->textureNames[this->imageIndex];
 	const std::string &paletteName = this->paletteNames[this->imageIndex];
 	const TextureID textureID = this->getTextureID(textureName, paletteName);
-	const Texture &texture = textureManager.getTexture(textureID);
-	renderer.drawOriginal(texture);
+	const TextureRef texture = textureManager.getTextureRef(textureID);
+	renderer.drawOriginal(texture.get());
 }

--- a/OpenTESArena/src/Interface/LoadSavePanel.cpp
+++ b/OpenTESArena/src/Interface/LoadSavePanel.cpp
@@ -183,11 +183,12 @@ void LoadSavePanel::render(Renderer &renderer)
 	renderer.clear();
 
 	// Draw slots background.
-	auto &textureManager = this->getGame().getTextureManager();
+	const auto &textureManager = this->getGame().getTextureManager();
 	const TextureID slotsBackgroundTextureID = this->getTextureID(
 		TextureName::LoadSave, PaletteName::Default);
-	const Texture &slotsBackgroundTexture = textureManager.getTexture(slotsBackgroundTextureID);
-	renderer.drawOriginal(slotsBackgroundTexture);
+	const TextureRef slotsBackgroundTexture =
+		textureManager.getTextureRef(slotsBackgroundTextureID);
+	renderer.drawOriginal(slotsBackgroundTexture.get());
 
 	// Draw save text.
 	for (const auto &textBox : this->saveTextBoxes)

--- a/OpenTESArena/src/Interface/LogbookPanel.cpp
+++ b/OpenTESArena/src/Interface/LogbookPanel.cpp
@@ -112,9 +112,9 @@ void LogbookPanel::render(Renderer &renderer)
 	renderer.clear();
 
 	// Logbook background.
-	auto &textureManager = this->getGame().getTextureManager();
-	const Texture &backgroundTexture = textureManager.getTexture(this->backgroundTextureID);
-	renderer.drawOriginal(backgroundTexture);
+	const auto &textureManager = this->getGame().getTextureManager();
+	const TextureRef backgroundTexture = textureManager.getTextureRef(this->backgroundTextureID);
+	renderer.drawOriginal(backgroundTexture.get());
 
 	// Draw text: title.
 	renderer.drawOriginal(this->titleTextBox->getTexture(),

--- a/OpenTESArena/src/Interface/MainMenuPanel.cpp
+++ b/OpenTESArena/src/Interface/MainMenuPanel.cpp
@@ -1153,25 +1153,25 @@ void MainMenuPanel::render(Renderer &renderer)
 	// Draw main menu.
 	auto &textureManager = this->getGame().getTextureManager();
 	const TextureID mainMenuTextureID = this->getTextureID(TextureName::MainMenu, PaletteName::BuiltIn);
-	const Texture &mainMenuTexture = textureManager.getTexture(mainMenuTextureID);
-	renderer.drawOriginal(mainMenuTexture);
+	const TextureRef mainMenuTexture = textureManager.getTextureRef(mainMenuTextureID);
+	renderer.drawOriginal(mainMenuTexture.get());
 
 	// Draw test buttons.
 	const TextureID arrowsTextureID = this->getTextureID(TextureName::UpDown, PaletteName::CharSheet);
-	const Texture &arrowsTexture = textureManager.getTexture(arrowsTextureID);
-	renderer.drawOriginal(arrowsTexture, this->testTypeUpButton.getX(),
+	const TextureRef arrowsTexture = textureManager.getTextureRef(arrowsTextureID);
+	renderer.drawOriginal(arrowsTexture.get(), this->testTypeUpButton.getX(),
 		this->testTypeUpButton.getY());
-	renderer.drawOriginal(arrowsTexture, this->testIndexUpButton.getX(),
+	renderer.drawOriginal(arrowsTexture.get(), this->testIndexUpButton.getX(),
 		this->testIndexUpButton.getY());
 
 	if (this->testType == TestType_Interior)
 	{
-		renderer.drawOriginal(arrowsTexture, this->testIndex2UpButton.getX(),
+		renderer.drawOriginal(arrowsTexture.get(), this->testIndex2UpButton.getX(),
 			this->testIndex2UpButton.getY());
 	}
 	else if ((this->testType == TestType_City) || (this->testType == TestType_Wilderness))
 	{
-		renderer.drawOriginal(arrowsTexture, this->testWeatherUpButton.getX(),
+		renderer.drawOriginal(arrowsTexture.get(), this->testWeatherUpButton.getX(),
 			this->testWeatherUpButton.getY());
 	}
 

--- a/OpenTESArena/src/Interface/MainQuestSplashPanel.cpp
+++ b/OpenTESArena/src/Interface/MainQuestSplashPanel.cpp
@@ -119,12 +119,12 @@ void MainQuestSplashPanel::render(Renderer &renderer)
 	renderer.clear();
 
 	// Draw staff dungeon splash image.
-	auto &textureManager = this->getGame().getTextureManager();
+	const auto &textureManager = this->getGame().getTextureManager();
 	const std::string &textureName = this->splashFilename;
 	const std::string &paletteName = textureName;
 	const TextureID splashImageTextureID = this->getTextureID(textureName, paletteName);
-	const Texture &splashImageTexture = textureManager.getTexture(splashImageTextureID);
-	renderer.drawOriginal(splashImageTexture);
+	const TextureRef splashImageTexture = textureManager.getTextureRef(splashImageTextureID);
+	renderer.drawOriginal(splashImageTexture.get());
 
 	// Draw text.
 	renderer.drawOriginal(this->textBox->getTexture(),

--- a/OpenTESArena/src/Interface/MessageBoxSubPanel.cpp
+++ b/OpenTESArena/src/Interface/MessageBoxSubPanel.cpp
@@ -43,7 +43,7 @@ Panel::CursorData MessageBoxSubPanel::getCurrentCursor() const
 		return CursorData::EMPTY;
 	}
 
-	const Texture &texture = textureManager.getTexture(textureID);
+	const Texture &texture = textureManager.getTextureHandle(textureID);
 	return CursorData(&texture, CursorAlignment::TopLeft);
 }
 

--- a/OpenTESArena/src/Interface/Panel.cpp
+++ b/OpenTESArena/src/Interface/Panel.cpp
@@ -240,7 +240,7 @@ Panel::CursorData Panel::getDefaultCursor() const
 		return CursorData::EMPTY;
 	}
 
-	const Texture &texture = textureManager.getTexture(textureID);
+	const Texture &texture = textureManager.getTextureHandle(textureID);
 	return CursorData(&texture, CursorAlignment::TopLeft);
 }
 

--- a/OpenTESArena/src/Interface/PauseMenuPanel.cpp
+++ b/OpenTESArena/src/Interface/PauseMenuPanel.cpp
@@ -389,47 +389,47 @@ void PauseMenuPanel::render(Renderer &renderer)
 	auto &textureManager = this->getGame().getTextureManager();
 	const TextureID pauseBackgroundTextureID = this->getTextureID(
 		TextureName::PauseBackground, PaletteName::Default);
-	const Texture &pauseBackgroundTexture = textureManager.getTexture(pauseBackgroundTextureID);
-	renderer.drawOriginal(pauseBackgroundTexture);
+	const TextureRef pauseBackgroundTexture = textureManager.getTextureRef(pauseBackgroundTextureID);
+	renderer.drawOriginal(pauseBackgroundTexture.get());
 
 	// Draw game world interface below the pause menu.
 	const TextureID gameInterfaceTextureID = this->getTextureID(
 		TextureName::GameWorldInterface, PaletteName::Default);
-	const Texture &gameInterfaceTexture = textureManager.getTexture(gameInterfaceTextureID);
-	renderer.drawOriginal(gameInterfaceTexture, 0,
+	const TextureRef gameInterfaceTexture = textureManager.getTextureRef(gameInterfaceTextureID);
+	renderer.drawOriginal(gameInterfaceTexture.get(), 0,
 		Renderer::ORIGINAL_HEIGHT - gameInterfaceTexture.getHeight());
 
 	// Draw player portrait.
 	const auto &player = this->getGame().getGameData().getPlayer();
 	const auto &headsFilename = PortraitFile::getHeads(
 		player.isMale(), player.getRaceID(), true);
-	const Texture &portraitTexture = [this, &textureManager, &headsFilename, &player]() -> const Texture&
+	const TextureRef portraitTexture = [this, &textureManager, &headsFilename, &player]() -> TextureRef
 	{
 		const TextureManager::IdGroup<TextureID> portraitTextureIDs = this->getTextureIDs(
 			headsFilename, PaletteFile::fromName(PaletteName::Default));
 		const TextureID portraitTextureID = portraitTextureIDs.startID + player.getPortraitID();
-		return textureManager.getTexture(portraitTextureID);
+		return textureManager.getTextureRef(portraitTextureID);
 	}();
 
-	const Texture &statusTexture = [this, &textureManager]() -> const Texture&
+	const TextureRef statusTexture = [this, &textureManager]() -> TextureRef
 	{
 		const TextureManager::IdGroup<TextureID> statusTextureIDs = this->getTextureIDs(
 			TextureFile::fromName(TextureName::StatusGradients),
 			PaletteFile::fromName(PaletteName::Default));
 		const TextureID statusTextureID = statusTextureIDs.startID;
-		return textureManager.getTexture(statusTextureID);
+		return textureManager.getTextureRef(statusTextureID);
 	}();
 
-	renderer.drawOriginal(statusTexture, 14, 166);
-	renderer.drawOriginal(portraitTexture, 14, 166);
+	renderer.drawOriginal(statusTexture.get(), 14, 166);
+	renderer.drawOriginal(portraitTexture.get(), 14, 166);
 
 	// If the player's class can't use magic, show the darkened spell icon.
 	if (!player.getCharacterClass().canCastMagic())
 	{
 		const TextureID nonMagicIconTextureID = this->getTextureID(
 			TextureName::NoSpell, PaletteName::Default);
-		const Texture &nonMagicIconTexture = textureManager.getTexture(nonMagicIconTextureID);
-		renderer.drawOriginal(nonMagicIconTexture, 91, 177);
+		const TextureRef nonMagicIconTexture = textureManager.getTextureRef(nonMagicIconTextureID);
+		renderer.drawOriginal(nonMagicIconTexture.get(), 91, 177);
 	}
 
 	// Cover up the detail slider with a new options background.

--- a/OpenTESArena/src/Interface/ProvinceMapPanel.cpp
+++ b/OpenTESArena/src/Interface/ProvinceMapPanel.cpp
@@ -710,8 +710,8 @@ void ProvinceMapPanel::drawVisibleLocations(const std::string &backgroundFilenam
 			const LocationDefinition &locationDef = provinceDef.getLocationDef(locationDefIndex);
 			const Int2 point(locationDef.getScreenX(), locationDef.getScreenY());
 			const TextureID iconTextureID = getLocationIconTextureID(locationDef);
-			const Texture &iconTexture = textureManager.getTexture(iconTextureID);
-			this->drawCenteredIcon(iconTexture, point, renderer);
+			const TextureRef iconTexture = textureManager.getTextureRef(iconTextureID);
+			this->drawCenteredIcon(iconTexture.get(), point, renderer);
 		}
 	};
 
@@ -764,8 +764,8 @@ void ProvinceMapPanel::drawLocationHighlight(const LocationDefinition &locationD
 		DebugAssert(highlightIndex >= 0);
 		DebugAssert(highlightIndex < highlightTextureIDs.count);
 		const TextureID highlightTextureID = highlightTextureIDs.startID + highlightIndex;
-		const Texture &highlightTexture = textureManager.getTexture(highlightTextureID);
-		drawHighlight(highlightTexture);
+		const TextureRef highlightTexture = textureManager.getTextureRef(highlightTextureID);
+		drawHighlight(highlightTexture.get());
 	};
 
 	auto handleDungeonHighlight = [this, &textureManager, &drawHighlight, &highlightTextureIDs]()
@@ -774,8 +774,8 @@ void ProvinceMapPanel::drawLocationHighlight(const LocationDefinition &locationD
 		const int highlightIndex = 3;
 		DebugAssert(highlightIndex < highlightTextureIDs.count);
 		const TextureID highlightTextureID = highlightTextureIDs.startID + highlightIndex;
-		const Texture &highlightTexture = textureManager.getTexture(highlightTextureID);
-		drawHighlight(highlightTexture);
+		const TextureRef highlightTexture = textureManager.getTextureRef(highlightTextureID);
+		drawHighlight(highlightTexture.get());
 	};
 
 	auto handleMainQuestDungeonHighlight = [this, &locationDef, highlightType, &backgroundFilename,
@@ -794,8 +794,8 @@ void ProvinceMapPanel::drawLocationHighlight(const LocationDefinition &locationD
 			const int highlightIndex = 3;
 			DebugAssert(highlightIndex < highlightTextureIDs.count);
 			const TextureID highlightTextureID = highlightTextureIDs.startID + highlightIndex;
-			const Texture &highlightTexture = textureManager.getTexture(highlightTextureID);
-			drawHighlight(highlightTexture);
+			const TextureRef highlightTexture = textureManager.getTextureRef(highlightTextureID);
+			drawHighlight(highlightTexture.get());
 		}
 		else if (mainQuestDungeonDef.type == LocationDefinition::MainQuestDungeonDefinition::Type::Staff)
 		{
@@ -935,8 +935,8 @@ void ProvinceMapPanel::render(Renderer &renderer)
 	const std::string &backgroundPaletteName = backgroundFilename;
 	const TextureID mapBackgroundTextureID = this->getTextureID(
 		backgroundFilename, backgroundPaletteName);
-	const Texture &mapBackgroundTexture = textureManager.getTexture(mapBackgroundTextureID);
-	renderer.drawOriginal(mapBackgroundTexture);
+	const TextureRef mapBackgroundTexture = textureManager.getTextureRef(mapBackgroundTextureID);
+	renderer.drawOriginal(mapBackgroundTexture.get());
 
 	// Draw visible location icons.
 	this->drawVisibleLocations(backgroundFilename, textureManager, renderer);

--- a/OpenTESArena/src/Interface/ProvinceSearchSubPanel.cpp
+++ b/OpenTESArena/src/Interface/ProvinceSearchSubPanel.cpp
@@ -482,11 +482,11 @@ void ProvinceSearchSubPanel::renderList(Renderer &renderer)
 	auto &textureManager = game.getTextureManager();
 	const TextureID listBackgroundTextureID = this->getTextureID(
 		TextureFile::fromName(TextureName::PopUp8), this->getBackgroundFilename());
-	const Texture &listBackgroundTexture = textureManager.getTexture(listBackgroundTextureID);
+	const TextureRef listBackgroundTexture = textureManager.getTextureRef(listBackgroundTextureID);
 
 	const int listBackgroundX = 57;
 	const int listBackgroundY = 11;
-	renderer.drawOriginal(listBackgroundTexture, listBackgroundX, listBackgroundY);
+	renderer.drawOriginal(listBackgroundTexture.get(), listBackgroundX, listBackgroundY);
 
 	// Draw list box text.
 	renderer.drawOriginal(this->locationsListBox->getTexture(),

--- a/OpenTESArena/src/Interface/TextCinematicPanel.cpp
+++ b/OpenTESArena/src/Interface/TextCinematicPanel.cpp
@@ -159,9 +159,9 @@ void TextCinematicPanel::render(Renderer &renderer)
 	const TextureID textureID = textureIDs.startID + this->imageIndex;
 
 	// Draw current frame in animation.
-	auto &textureManager = this->getGame().getTextureManager();
-	const Texture &texture = textureManager.getTexture(textureID);
-	renderer.drawOriginal(texture);
+	const auto &textureManager = this->getGame().getTextureManager();
+	const TextureRef texture = textureManager.getTextureRef(textureID);
+	renderer.drawOriginal(texture.get());
 
 	// Draw the relevant text box.
 	DebugAssertIndex(this->textBoxes, this->textIndex);

--- a/OpenTESArena/src/Interface/TextSubPanel.cpp
+++ b/OpenTESArena/src/Interface/TextSubPanel.cpp
@@ -49,7 +49,7 @@ Panel::CursorData TextSubPanel::getCurrentCursor() const
 		return CursorData::EMPTY;
 	}
 
-	const Texture &texture = textureManager.getTexture(textureID);
+	const Texture &texture = textureManager.getTextureHandle(textureID);
 	return CursorData(&texture, CursorAlignment::TopLeft);
 }
 

--- a/OpenTESArena/src/Interface/WorldMapPanel.cpp
+++ b/OpenTESArena/src/Interface/WorldMapPanel.cpp
@@ -142,12 +142,12 @@ void WorldMapPanel::render(Renderer &renderer)
 		TextureName::WorldMap, PaletteName::BuiltIn);
 	
 	// Draw world map background. This one has "Exit" at the bottom right.
-	auto &textureManager = this->getGame().getTextureManager();
-	const Texture &mapBackgroundTexture = textureManager.getTexture(mapBackgroundTextureID);
-	renderer.drawOriginal(mapBackgroundTexture);
+	const auto &textureManager = this->getGame().getTextureManager();
+	const TextureRef mapBackgroundTexture = textureManager.getTextureRef(mapBackgroundTextureID);
+	renderer.drawOriginal(mapBackgroundTexture.get());
 
 	// Draw yellow text over current province name.
-	const Texture &provinceTextTexture = textureManager.getTexture(provinceTextTextureID);
+	const TextureRef provinceTextTexture = textureManager.getTextureRef(provinceTextTextureID);
 	const Int2 &nameOffset = this->provinceNameOffsets.at(provinceID);
-	renderer.drawOriginal(provinceTextTexture, nameOffset.x, nameOffset.y);
+	renderer.drawOriginal(provinceTextTexture.get(), nameOffset.x, nameOffset.y);
 }

--- a/OpenTESArena/src/Media/TextureManager.cpp
+++ b/OpenTESArena/src/Media/TextureManager.cpp
@@ -441,11 +441,11 @@ bool TextureManager::tryGetSurfaceIDs(const char *filename, PaletteID paletteID,
 	auto iter = this->surfaceIDs.find(mappingName);
 	if (iter == this->surfaceIDs.end())
 	{
-		const Palette &palette = this->getPalette(paletteID);
+		PaletteRef palette = this->getPaletteRef(paletteID);
 
 		// Load surface(s) from file.
 		Buffer<Surface> surfaces;
-		if (TextureManager::tryLoadSurfaces(filename, palette, &surfaces))
+		if (TextureManager::tryLoadSurfaces(filename, palette.get(), &surfaces))
 		{
 			const SurfaceID startID = static_cast<SurfaceID>(this->surfaces.size());
 			IdGroup<SurfaceID> ids(startID, surfaces.getCount());
@@ -482,11 +482,11 @@ bool TextureManager::tryGetTextureIDs(const char *filename, PaletteID paletteID,
 	auto iter = this->textureIDs.find(mappingName);
 	if (iter == this->textureIDs.end())
 	{
-		const Palette &palette = this->getPalette(paletteID);
+		PaletteRef palette = this->getPaletteRef(paletteID);
 
 		// Load texture(s) from file.
 		Buffer<Texture> textures;
-		if (TextureManager::tryLoadTextures(filename, palette, renderer, &textures))
+		if (TextureManager::tryLoadTextures(filename, palette.get(), renderer, &textures))
 		{
 			const TextureID startID = static_cast<TextureID>(this->textures.size());
 			IdGroup<TextureID> ids(startID, textures.getCount());
@@ -573,25 +573,45 @@ bool TextureManager::tryGetTextureID(const char *filename, PaletteID paletteID,
 	}
 }
 
-const Palette &TextureManager::getPalette(PaletteID id) const
+PaletteRef TextureManager::getPaletteRef(PaletteID id) const
+{
+	return PaletteRef(&this->palettes, static_cast<int>(id));
+}
+
+ImageRef TextureManager::getImageRef(ImageID id) const
+{
+	return ImageRef(&this->images, static_cast<int>(id));
+}
+
+SurfaceRef TextureManager::getSurfaceRef(SurfaceID id) const
+{
+	return SurfaceRef(&this->surfaces, static_cast<int>(id));
+}
+
+TextureRef TextureManager::getTextureRef(TextureID id) const
+{
+	return TextureRef(&this->textures, static_cast<int>(id));
+}
+
+const Palette &TextureManager::getPaletteHandle(PaletteID id) const
 {
 	DebugAssertIndex(this->palettes, id);
 	return this->palettes[id];
 }
 
-const Image &TextureManager::getImage(ImageID id) const
+const Image &TextureManager::getImageHandle(ImageID id) const
 {
 	DebugAssertIndex(this->images, id);
 	return this->images[id];
 }
 
-const Surface &TextureManager::getSurface(SurfaceID id) const
+const Surface &TextureManager::getSurfaceHandle(SurfaceID id) const
 {
 	DebugAssertIndex(this->surfaces, id);
 	return this->surfaces[id];
 }
 
-const Texture &TextureManager::getTexture(TextureID id) const
+const Texture &TextureManager::getTextureHandle(TextureID id) const
 {
 	DebugAssertIndex(this->textures, id);
 	return this->textures[id];

--- a/OpenTESArena/src/Media/TextureManager.h
+++ b/OpenTESArena/src/Media/TextureManager.h
@@ -14,15 +14,17 @@
 #include "../Rendering/Texture.h"
 
 #include "components/utilities/Buffer.h"
+#include "components/utilities/BufferRef.h"
 #include "components/utilities/BufferRef2D.h"
 
 class Renderer;
 
 // BufferRef variations for avoiding returning easily-stale handles from texture manager.
-using PaletteRef = BufferRef2D<std::vector<Palette>, Palette>;
-using ImageRef = BufferRef2D<std::vector<Image>, Image>;
-using SurfaceRef = BufferRef2D<std::vector<Surface>, Surface>;
-using TextureRef = BufferRef2D<std::vector<Texture>, Texture>;
+// All references are read-only interfaces.
+using PaletteRef = BufferRef<const std::vector<Palette>, const Palette>;
+using ImageRef = BufferRef2D<const std::vector<Image>, const Image>;
+using SurfaceRef = BufferRef2D<const std::vector<Surface>, const Surface>;
+using TextureRef = BufferRef2D<const std::vector<Texture>, const Texture>;
 
 class TextureManager
 {
@@ -104,14 +106,18 @@ public:
 	bool tryGetSurfaceID(const char *filename, PaletteID paletteID, SurfaceID *outID);
 	bool tryGetTextureID(const char *filename, PaletteID paletteID, Renderer &renderer, TextureID *outID);
 
-	// Texture getter functions, fast look-up.
-	// Note! The ID getter functions may resize the internal texture buffer causing
-	// dangling texture references, so get all IDs in advance of calling these functions,
-	// and store these references in as small of a scope as possible!
-	const Palette &getPalette(PaletteID id) const;
-	const Image &getImage(ImageID id) const;
-	const Surface &getSurface(SurfaceID id) const;
-	const Texture &getTexture(TextureID id) const;
+	// Texture getter functions, fast look-up. These return reference wrappers to avoid
+	// dangling pointer issues with internal buffer resizing.
+	PaletteRef getPaletteRef(PaletteID id) const;
+	ImageRef getImageRef(ImageID id) const;
+	SurfaceRef getSurfaceRef(SurfaceID id) const;
+	TextureRef getTextureRef(TextureID id) const;
+
+	// Texture getter functions, fast look-up. These do not protect against dangling pointers.
+	const Palette &getPaletteHandle(PaletteID id) const;
+	const Image &getImageHandle(ImageID id) const;
+	const Surface &getSurfaceHandle(SurfaceID id) const;
+	const Texture &getTextureHandle(TextureID id) const;
 };
 
 #endif

--- a/OpenTESArena/src/Media/TextureManager.h
+++ b/OpenTESArena/src/Media/TextureManager.h
@@ -14,9 +14,15 @@
 #include "../Rendering/Texture.h"
 
 #include "components/utilities/Buffer.h"
-#include "components/utilities/Buffer2D.h"
+#include "components/utilities/BufferRef2D.h"
 
 class Renderer;
+
+// BufferRef variations for avoiding returning easily-stale handles from texture manager.
+using PaletteRef = BufferRef2D<std::vector<Palette>, Palette>;
+using ImageRef = BufferRef2D<std::vector<Image>, Image>;
+using SurfaceRef = BufferRef2D<std::vector<Surface>, Surface>;
+using TextureRef = BufferRef2D<std::vector<Texture>, Texture>;
 
 class TextureManager
 {

--- a/OpenTESArena/src/Rendering/Renderer.h
+++ b/OpenTESArena/src/Rendering/Renderer.h
@@ -9,6 +9,7 @@
 #include "Texture.h"
 #include "../Math/Vector2.h"
 #include "../Math/Vector3.h"
+#include "../Media/TextureManager.h"
 #include "../World/LevelData.h"
 
 // Acts as a wrapper for SDL_Renderer operations as well as 3D rendering operations.

--- a/OpenTESArena/src/Rendering/SoftwareRenderer.cpp
+++ b/OpenTESArena/src/Rendering/SoftwareRenderer.cpp
@@ -589,7 +589,7 @@ void SoftwareRenderer::DistantObjects::init(const DistantSky &distantSky,
 	// and returns its index in the sky textures list.
 	auto addSkyTexture = [&skyTextures, &palette, &textureManager](ImageID imageID)
 	{
-		const Image &image = textureManager.getImage(imageID);
+		const Image &image = textureManager.getImageHandle(imageID);
 		const int width = image.getWidth();
 		const int height = image.getHeight();
 		const int texelCount = width * height;

--- a/OpenTESArena/src/Rendering/Texture.cpp
+++ b/OpenTESArena/src/Rendering/Texture.cpp
@@ -76,19 +76,19 @@ Texture Texture::generate(Texture::PatternType type, int width, int height,
 		}
 
 		// Four corner tiles.
-		SDL_Surface *topLeft = textureManager.getSurface(tileIDs.startID).get();
-		SDL_Surface *topRight = textureManager.getSurface(tileIDs.startID + 2).get();
-		SDL_Surface *bottomLeft = textureManager.getSurface(tileIDs.startID + 6).get();
-		SDL_Surface *bottomRight = textureManager.getSurface(tileIDs.startID + 8).get();
+		SDL_Surface *topLeft = textureManager.getSurfaceHandle(tileIDs.startID).get();
+		SDL_Surface *topRight = textureManager.getSurfaceHandle(tileIDs.startID + 2).get();
+		SDL_Surface *bottomLeft = textureManager.getSurfaceHandle(tileIDs.startID + 6).get();
+		SDL_Surface *bottomRight = textureManager.getSurfaceHandle(tileIDs.startID + 8).get();
 
 		// Four side tiles.
-		SDL_Surface *top = textureManager.getSurface(tileIDs.startID + 1).get();
-		SDL_Surface *left = textureManager.getSurface(tileIDs.startID + 3).get();
-		SDL_Surface *right = textureManager.getSurface(tileIDs.startID + 5).get();
-		SDL_Surface *bottom = textureManager.getSurface(tileIDs.startID + 7).get();
+		SDL_Surface *top = textureManager.getSurfaceHandle(tileIDs.startID + 1).get();
+		SDL_Surface *left = textureManager.getSurfaceHandle(tileIDs.startID + 3).get();
+		SDL_Surface *right = textureManager.getSurfaceHandle(tileIDs.startID + 5).get();
+		SDL_Surface *bottom = textureManager.getSurfaceHandle(tileIDs.startID + 7).get();
 
 		// One body tile.
-		SDL_Surface *body = textureManager.getSurface(tileIDs.startID + 4).get();
+		SDL_Surface *body = textureManager.getSurfaceHandle(tileIDs.startID + 4).get();
 
 		// Draw body tiles.
 		for (int y = topLeft->h; y < (surface.getHeight() - topRight->h); y += body->h)

--- a/OpenTESArena/src/World/WeatherUtils.cpp
+++ b/OpenTESArena/src/World/WeatherUtils.cpp
@@ -54,7 +54,7 @@ Buffer<uint32_t> WeatherUtils::makeExteriorSkyPalette(WeatherType weatherType,
 		DebugCrash("Couldn't get palette ID for \"" + std::string(paletteName) + "\".");
 	}
 
-	const Palette &palette = textureManager.getPalette(paletteID);
+	const Palette &palette = textureManager.getPaletteHandle(paletteID);
 
 	// Fill sky palette with darkness (the first color in the palette is the closest to night).
 	const uint32_t darkness = palette[0].toARGB();

--- a/components/utilities/BufferRef.h
+++ b/components/utilities/BufferRef.h
@@ -1,0 +1,39 @@
+#ifndef BUFFER_REF_H
+#define BUFFER_REF_H
+
+#include "../debug/Debug.h"
+
+template <typename ContainerT, typename T>
+class BufferRef
+{
+private:
+	ContainerT *container;
+	int index;
+public:
+	BufferRef(ContainerT *container, int index)
+	{
+		this->container = container;
+		this->index = index;
+	}
+
+	T &get()
+	{
+		ContainerT &containerRef = *this->container;
+		DebugAssertIndex(containerRef, this->index);
+		return containerRef[this->index];
+	}
+
+	const T &get() const
+	{
+		const ContainerT &containerRef = *this->container;
+		DebugAssertIndex(containerRef, this->index);
+		return containerRef[this->index];
+	}
+
+	int getCount() const
+	{
+		return static_cast<int>(std::size(this->get()));
+	}
+};
+
+#endif

--- a/components/utilities/BufferRef2D.h
+++ b/components/utilities/BufferRef2D.h
@@ -1,0 +1,48 @@
+#ifndef BUFFER_REF_2D_H
+#define BUFFER_REF_2D_H
+
+#include <type_traits>
+
+#include "../debug/Debug.h"
+
+// This only exists because dangling pointers are bad and classes like the texture manager
+// shouldn't return raw texture references when it knows that the reference could become
+// invalidated by a call to one of the manager's other functions.
+
+// Intended for 2D image-like buffers.
+
+template <typename ContainerT, typename T>
+class BufferRef2D
+{
+private:
+	static_assert(std::is_integral_v<T>);
+
+	ContainerT *container;
+	int index;
+public:
+	BufferRef2D(ContainerT *container, int index)
+	{
+		this->container = container;
+		this->index = index;
+	}
+
+	// NOTE: for privileged use only. Only public to avoid friend keyword.
+	T &get()
+	{
+		ContainerT &containerRef = *this->container;
+		DebugAssertIndex(containerRef, this->index);
+		return containerRef[this->index];
+	}
+
+	int getWidth() const
+	{
+		return this->get().getWidth();
+	}
+
+	int getHeight() const
+	{
+		return this->get().getHeight();
+	}
+};
+
+#endif

--- a/components/utilities/BufferRef2D.h
+++ b/components/utilities/BufferRef2D.h
@@ -1,8 +1,6 @@
 #ifndef BUFFER_REF_2D_H
 #define BUFFER_REF_2D_H
 
-#include <type_traits>
-
 #include "../debug/Debug.h"
 
 // This only exists because dangling pointers are bad and classes like the texture manager
@@ -15,8 +13,6 @@ template <typename ContainerT, typename T>
 class BufferRef2D
 {
 private:
-	static_assert(std::is_integral_v<T>);
-
 	ContainerT *container;
 	int index;
 public:
@@ -26,10 +22,16 @@ public:
 		this->index = index;
 	}
 
-	// NOTE: for privileged use only. Only public to avoid friend keyword.
 	T &get()
 	{
 		ContainerT &containerRef = *this->container;
+		DebugAssertIndex(containerRef, this->index);
+		return containerRef[this->index];
+	}
+
+	const T &get() const
+	{
+		const ContainerT &containerRef = *this->container;
 		DebugAssertIndex(containerRef, this->index);
 		return containerRef[this->index];
 	}


### PR DESCRIPTION
I noticed during the texture manager refactor that it had been allowing dangling texture references to happen, so I figured that adding a templated buffer ref class for each texture type would help prevent dangling texture references in the future.