### PR TITLE
Use TextureAssetReference with VoxelDefinitions for more flexible renderer texture handling

### DIFF
--- a/OpenTESArena/src/Assets/TextureAssetReference.cpp
+++ b/OpenTESArena/src/Assets/TextureAssetReference.cpp
@@ -7,3 +7,8 @@ TextureAssetReference::TextureAssetReference(std::string &&filename)
 	: filename(std::move(filename)), index(std::nullopt) { }
 
 TextureAssetReference::TextureAssetReference() { }
+
+bool TextureAssetReference::operator==(const TextureAssetReference &other) const
+{
+	return (this->filename == other.filename) && (this->index == other.index);
+}

--- a/OpenTESArena/src/Assets/TextureAssetReference.cpp
+++ b/OpenTESArena/src/Assets/TextureAssetReference.cpp
@@ -1,6 +1,6 @@
 #include "TextureAssetReference.h"
 
-TextureAssetReference::TextureAssetReference(std::string &&filename, int index)
+TextureAssetReference::TextureAssetReference(std::string &&filename, const std::optional<int> &index)
 	: filename(std::move(filename)), index(index) { }
 
 TextureAssetReference::TextureAssetReference(std::string &&filename)

--- a/OpenTESArena/src/Assets/TextureAssetReference.h
+++ b/OpenTESArena/src/Assets/TextureAssetReference.h
@@ -15,6 +15,8 @@ struct TextureAssetReference
 	TextureAssetReference(std::string &&filename, int index);
 	TextureAssetReference(std::string &&filename);
 	TextureAssetReference();
+
+	bool operator==(const TextureAssetReference &other) const;
 };
 
 #endif

--- a/OpenTESArena/src/Assets/TextureAssetReference.h
+++ b/OpenTESArena/src/Assets/TextureAssetReference.h
@@ -12,7 +12,7 @@ struct TextureAssetReference
 	std::string filename;
 	std::optional<int> index; // Points into sequential texture file.
 
-	TextureAssetReference(std::string &&filename, int index);
+	TextureAssetReference(std::string &&filename, const std::optional<int> &index);
 	TextureAssetReference(std::string &&filename);
 	TextureAssetReference();
 

--- a/OpenTESArena/src/Rendering/ArenaRenderUtils.h
+++ b/OpenTESArena/src/Rendering/ArenaRenderUtils.h
@@ -9,6 +9,16 @@ namespace ArenaRenderUtils
 	constexpr int SCREEN_HEIGHT = 200;
 	constexpr int BITS_PER_PIXEL = 8;
 
+	// Texture limits.
+	static constexpr int DEFAULT_VOXEL_TEXTURE_COUNT = 64;
+	static constexpr int DEFAULT_FLAT_TEXTURE_COUNT = 256;
+
+	// Height ratio between normal pixels and tall pixels.
+	static constexpr double TALL_PIXEL_RATIO = 1.20;
+
+	// Amount of a sliding/raising door that is visible when fully open.
+	static constexpr double DOOR_MIN_VISIBLE = 0.10;
+
 	// Hardcoded palette indices with special behavior in the original game's renderer.
 	constexpr uint8_t PALETTE_INDEX_LIGHT_LEVEL_LOWEST = 1;
 	constexpr uint8_t PALETTE_INDEX_LIGHT_LEVEL_HIGHEST = 13;

--- a/OpenTESArena/src/Rendering/ArenaRenderUtils.h
+++ b/OpenTESArena/src/Rendering/ArenaRenderUtils.h
@@ -10,14 +10,14 @@ namespace ArenaRenderUtils
 	constexpr int BITS_PER_PIXEL = 8;
 
 	// Texture limits.
-	static constexpr int DEFAULT_VOXEL_TEXTURE_COUNT = 64;
-	static constexpr int DEFAULT_FLAT_TEXTURE_COUNT = 256;
+	constexpr int DEFAULT_VOXEL_TEXTURE_COUNT = 64;
+	constexpr int DEFAULT_FLAT_TEXTURE_COUNT = 256;
 
 	// Height ratio between normal pixels and tall pixels.
-	static constexpr double TALL_PIXEL_RATIO = 1.20;
+	constexpr double TALL_PIXEL_RATIO = 1.20;
 
 	// Amount of a sliding/raising door that is visible when fully open.
-	static constexpr double DOOR_MIN_VISIBLE = 0.10;
+	constexpr double DOOR_MIN_VISIBLE = 0.10;
 
 	// Hardcoded palette indices with special behavior in the original game's renderer.
 	constexpr uint8_t PALETTE_INDEX_LIGHT_LEVEL_LOWEST = 1;

--- a/OpenTESArena/src/Rendering/ArenaRenderUtils.h
+++ b/OpenTESArena/src/Rendering/ArenaRenderUtils.h
@@ -35,6 +35,7 @@ namespace ArenaRenderUtils
 	constexpr uint8_t PALETTE_INDEX_NIGHT_LIGHT_INACTIVE = 112;
 	constexpr uint8_t PALETTE_INDEX_PUDDLE_EVEN_ROW = 30;
 	constexpr uint8_t PALETTE_INDEX_PUDDLE_ODD_ROW = 103;
+	constexpr uint8_t PALETTE_INDEX_DRY_CHASM_COLOR = 112; // @todo: might not be correct, need to check with light tables
 
 	// Various functions for determining the type of palette index.
 	bool IsGhostTexel(uint8_t texel);

--- a/OpenTESArena/src/Rendering/RenderTextureUtils.cpp
+++ b/OpenTESArena/src/Rendering/RenderTextureUtils.cpp
@@ -4,7 +4,7 @@
 
 #include "components/debug/Debug.h"
 
-ScopedVoxelTextureRef::ScopedVoxelTextureRef(VoxelTextureID id, RendererSystem3D &rendererSystem)
+/*ScopedVoxelTextureRef::ScopedVoxelTextureRef(VoxelTextureID id, RendererSystem3D &rendererSystem)
 {
 	this->id = id;
 	this->rendererSystem = &rendererSystem;
@@ -66,4 +66,4 @@ ScopedUiTextureRef::~ScopedUiTextureRef()
 UiTextureID ScopedUiTextureRef::get() const
 {
 	return this->id;
-}
+}*/

--- a/OpenTESArena/src/Rendering/RenderTextureUtils.h
+++ b/OpenTESArena/src/Rendering/RenderTextureUtils.h
@@ -13,7 +13,9 @@ class RendererSystem2D;
 class RendererSystem3D;
 
 // Convenience classes for creating and automatically destroying a texture.
-class ScopedVoxelTextureRef
+// @temp: commented out until the renderers are working with texture builders and texture IDs instead of
+// TextureAssetReferences for texture handle creation/destruction.
+/*class ScopedVoxelTextureRef
 {
 private:
 	VoxelTextureID id;
@@ -59,6 +61,6 @@ public:
 	~ScopedUiTextureRef();
 
 	UiTextureID get() const;
-};
+};*/
 
 #endif

--- a/OpenTESArena/src/Rendering/Renderer.cpp
+++ b/OpenTESArena/src/Rendering/Renderer.cpp
@@ -731,55 +731,49 @@ void Renderer::setRenderThreadsMode(int mode)
 	this->renderer3D->setRenderThreadsMode(mode);
 }
 
-std::optional<VoxelTextureID> Renderer::tryCreateVoxelTexture(const TextureBuilder &textureBuilder)
+bool Renderer::tryCreateVoxelTexture(const TextureAssetReference &textureAssetRef, TextureManager &textureManager)
 {
-	return this->renderer3D->tryCreateVoxelTexture(textureBuilder);
+	return this->renderer3D->tryCreateVoxelTexture(textureAssetRef, textureManager);
 }
 
-std::optional<EntityTextureID> Renderer::tryCreateEntityTexture(const TextureBuilder &textureBuilder)
+bool Renderer::tryCreateEntityTexture(const TextureAssetReference &textureAssetRef, TextureManager &textureManager)
 {
-	return this->renderer3D->tryCreateEntityTexture(textureBuilder);
+	return this->renderer3D->tryCreateEntityTexture(textureAssetRef, textureManager);
 }
 
-std::optional<SkyTextureID> Renderer::tryCreateSkyTexture(const TextureBuilder &textureBuilder)
+bool Renderer::tryCreateSkyTexture(const TextureAssetReference &textureAssetRef, TextureManager &textureManager)
 {
-	return this->renderer3D->tryCreateSkyTexture(textureBuilder);
+	return this->renderer3D->tryCreateSkyTexture(textureAssetRef, textureManager);
 }
 
-std::optional<UiTextureID> Renderer::tryCreateUiTexture(const TextureBuilder &textureBuilder)
+bool Renderer::tryCreateUiTexture(const TextureAssetReference &textureAssetRef, TextureManager &textureManager)
 {
-	return this->renderer2D->tryCreateUiTexture(textureBuilder);
+	return this->renderer2D->tryCreateUiTexture(textureAssetRef, textureManager);
 }
 
-void Renderer::freeVoxelTexture(VoxelTextureID id)
+void Renderer::freeVoxelTexture(const TextureAssetReference &textureAssetRef)
 {
-	this->renderer3D->freeVoxelTexture(id);
+	this->renderer3D->freeVoxelTexture(textureAssetRef);
 }
 
-void Renderer::freeEntityTexture(EntityTextureID id)
+void Renderer::freeEntityTexture(const TextureAssetReference &textureAssetRef)
 {
-	this->renderer3D->freeEntityTexture(id);
+	this->renderer3D->freeEntityTexture(textureAssetRef);
 }
 
-void Renderer::freeSkyTexture(SkyTextureID id)
+void Renderer::freeSkyTexture(const TextureAssetReference &textureAssetRef)
 {
-	this->renderer3D->freeSkyTexture(id);
+	this->renderer3D->freeSkyTexture(textureAssetRef);
 }
 
-void Renderer::freeUiTexture(UiTextureID id)
+void Renderer::freeUiTexture(const TextureAssetReference &textureAssetRef)
 {
-	this->renderer2D->freeUiTexture(id);
+	this->renderer2D->freeUiTexture(textureAssetRef);
 }
 
 void Renderer::setFogDistance(double fogDistance)
 {
 	this->renderer3D->setFogDistance(fogDistance);
-}
-
-void Renderer::setVoxelTexture(int id, const uint8_t *srcTexels, const Palette &palette)
-{
-	DebugAssert(this->renderer3D->isInited());
-	this->renderer3D->setVoxelTexture(id, srcTexels, palette);
 }
 
 EntityRenderID Renderer::makeEntityRenderID()

--- a/OpenTESArena/src/Rendering/Renderer.h
+++ b/OpenTESArena/src/Rendering/Renderer.h
@@ -205,20 +205,21 @@ public:
 	void setRenderThreadsMode(int mode);
 
 	// Texture handle allocation functions.
-	std::optional<VoxelTextureID> tryCreateVoxelTexture(const TextureBuilder &textureBuilder);
-	std::optional<EntityTextureID> tryCreateEntityTexture(const TextureBuilder &textureBuilder);
-	std::optional<SkyTextureID> tryCreateSkyTexture(const TextureBuilder &textureBuilder);
-	std::optional<UiTextureID> tryCreateUiTexture(const TextureBuilder &textureBuilder);
+	// @todo: see RendererSystem3D -- these should take TextureBuilders instead and return optional handles.
+	bool tryCreateVoxelTexture(const TextureAssetReference &textureAssetRef, TextureManager &textureManager);
+	bool tryCreateEntityTexture(const TextureAssetReference &textureAssetRef, TextureManager &textureManager);
+	bool tryCreateSkyTexture(const TextureAssetReference &textureAssetRef, TextureManager &textureManager);
+	bool tryCreateUiTexture(const TextureAssetReference &textureAssetRef, TextureManager &textureManager);
 
 	// Texture handle freeing functions.
-	void freeVoxelTexture(VoxelTextureID id);
-	void freeEntityTexture(EntityTextureID id);
-	void freeSkyTexture(SkyTextureID id);
-	void freeUiTexture(UiTextureID id);
+	// @todo: see RendererSystem3D -- these should take texture IDs instead.
+	void freeVoxelTexture(const TextureAssetReference &textureAssetRef);
+	void freeEntityTexture(const TextureAssetReference &textureAssetRef);
+	void freeSkyTexture(const TextureAssetReference &textureAssetRef);
+	void freeUiTexture(const TextureAssetReference &textureAssetRef);
 
 	// Helper methods for changing data in the 3D renderer.
 	void setFogDistance(double fogDistance);
-	void setVoxelTexture(int id, const uint8_t *srcTexels, const Palette &palette);
 	EntityRenderID makeEntityRenderID();
 	void setFlatTextures(EntityRenderID entityRenderID, const EntityAnimationDefinition &animDef,
 		const EntityAnimationInstance &animInst, bool isPuddle, const Palette &palette,

--- a/OpenTESArena/src/Rendering/RendererSystem2D.h
+++ b/OpenTESArena/src/Rendering/RendererSystem2D.h
@@ -19,8 +19,10 @@
 // if it's the same backend.
 
 class TextureBuilder;
+class TextureManager;
 
 struct SDL_Window;
+struct TextureAssetReference;
 
 class RendererSystem2D
 {
@@ -45,10 +47,13 @@ public:
 	virtual void shutdown() = 0;
 
 	// Texture handle allocation function for a UI texture.
-	virtual std::optional<UiTextureID> tryCreateUiTexture(const TextureBuilder &textureBuilder) = 0;
+	// @todo: this should take a TextureBuilder and return optional<UiTextureID>.
+	virtual bool tryCreateUiTexture(const TextureAssetReference &textureAssetRef,
+		TextureManager &textureManager) = 0;
 
 	// Texture handle freeing function for a UI texture.
-	virtual void freeUiTexture(UiTextureID id) = 0;
+	// @todo: this should eventually take a UiTextureID.
+	virtual void freeUiTexture(const TextureAssetReference &textureAssetRef) = 0;
 
 	// Returns the texture's dimensions, if it exists.
 	virtual std::optional<Int2> tryGetTextureDims(UiTextureID id) const = 0;

--- a/OpenTESArena/src/Rendering/RendererSystem3D.h
+++ b/OpenTESArena/src/Rendering/RendererSystem3D.h
@@ -31,6 +31,8 @@ class TextureManager;
 class TextureInstanceManager;
 class VoxelGrid;
 
+struct TextureAssetReference;
+
 class RendererSystem3D
 {
 public:
@@ -49,14 +51,21 @@ public:
 	virtual bool isInited() const = 0;
 
 	// Texture handle allocation functions for each texture type.
-	virtual std::optional<VoxelTextureID> tryCreateVoxelTexture(const TextureBuilder &textureBuilder) = 0;
-	virtual std::optional<EntityTextureID> tryCreateEntityTexture(const TextureBuilder &textureBuilder) = 0;
-	virtual std::optional<SkyTextureID> tryCreateSkyTexture(const TextureBuilder &textureBuilder) = 0;
+	// @todo: ideally these would take a TextureBuilder and return optional<VoxelTextureID/etc.>, but that
+	// would require a lot of renderer decoupling, such as binding VoxelTextureIDs/etc. to instance voxel
+	// geometry instead of relying on VoxelDefinition/etc. for texture look-ups.
+	virtual bool tryCreateVoxelTexture(const TextureAssetReference &textureAssetRef,
+		TextureManager &textureManager) = 0;
+	virtual bool tryCreateEntityTexture(const TextureAssetReference &textureAssetRef,
+		TextureManager &textureManager) = 0;
+	virtual bool tryCreateSkyTexture(const TextureAssetReference &textureAssetRef,
+		TextureManager &textureManager) = 0;
 
 	// Texture handle freeing functions for each texture type.
-	virtual void freeVoxelTexture(VoxelTextureID id) = 0;
-	virtual void freeEntityTexture(EntityTextureID id) = 0;
-	virtual void freeSkyTexture(SkyTextureID id) = 0;
+	// @todo: ideally these would take VoxelTextureID/etc..
+	virtual void freeVoxelTexture(const TextureAssetReference &textureAssetRef) = 0;
+	virtual void freeEntityTexture(const TextureAssetReference &textureAssetRef) = 0;
+	virtual void freeSkyTexture(const TextureAssetReference &textureAssetRef) = 0;
 
 	virtual void resize(int width, int height) = 0;
 
@@ -75,7 +84,6 @@ public:
 	// Legacy functions (remove these eventually).
 	virtual void setRenderThreadsMode(int mode) = 0;
 	virtual void setFogDistance(double fogDistance) = 0;
-	virtual void setVoxelTexture(int id, const uint8_t *srcTexels, const Palette &palette) = 0;
 	virtual EntityRenderID makeEntityRenderID() = 0;
 	virtual void setFlatTextures(EntityRenderID entityRenderID, const EntityAnimationDefinition &animDef,
 		const EntityAnimationInstance &animInst, bool isPuddle, const Palette &palette,

--- a/OpenTESArena/src/Rendering/SdlUiRenderer.cpp
+++ b/OpenTESArena/src/Rendering/SdlUiRenderer.cpp
@@ -1,7 +1,9 @@
 #include "SDL.h"
 
 #include "SdlUiRenderer.h"
+#include "../Assets/TextureAssetReference.h"
 #include "../Media/TextureBuilder.h"
+#include "../Media/TextureManager.h"
 
 #include "components/debug/Debug.h"
 
@@ -21,27 +23,39 @@ void SdlUiRenderer::shutdown()
 	this->textures.clear();
 }
 
-std::optional<UiTextureID> SdlUiRenderer::tryCreateUiTexture(const TextureBuilder &textureBuilder)
+bool SdlUiRenderer::tryCreateUiTexture(const TextureAssetReference &textureAssetRef,
+	TextureManager &textureManager)
 {
+	const std::string &filename = textureAssetRef.filename;
+	const std::optional<TextureBuilderIdGroup> textureBuilderIDs =
+		textureManager.tryGetTextureBuilderIDs(filename.c_str());
+	if (!textureBuilderIDs.has_value())
+	{
+		DebugLogError("Couldn't get UI texture builder IDs for \"" + filename + "\".");
+		return false;
+	}
+
+	const int textureIndex = textureAssetRef.index.has_value() ? *textureAssetRef.index : 0;
+	const TextureBuilderID textureBuilderID = textureBuilderIDs->getID(textureIndex);
+	const TextureBuilder &textureBuilder = textureManager.getTextureBuilderHandle(textureBuilderID);
 	const TextureBuilder::Type textureBuilderType = textureBuilder.getType();
 	if (textureBuilderType == TextureBuilder::Type::Paletted)
 	{
 		DebugNotImplemented();
-		return std::nullopt;
+		return true;
 	}
 	else if (textureBuilderType == TextureBuilder::Type::TrueColor)
 	{
 		DebugNotImplemented();
-		return std::nullopt;
+		return true;
 	}
 	else
 	{
-		DebugUnhandledReturnMsg(std::optional<UiTextureID>,
-			std::to_string(static_cast<int>(textureBuilderType)));
+		DebugUnhandledReturnMsg(bool, std::to_string(static_cast<int>(textureBuilderType)));
 	}
 }
 
-void SdlUiRenderer::freeUiTexture(UiTextureID id)
+void SdlUiRenderer::freeUiTexture(const TextureAssetReference &textureAssetRef)
 {
 	DebugNotImplemented();
 }

--- a/OpenTESArena/src/Rendering/SdlUiRenderer.h
+++ b/OpenTESArena/src/Rendering/SdlUiRenderer.h
@@ -17,8 +17,8 @@ public:
 	void init(SDL_Window *window) override; // @todo: might also need target SDL_Texture*
 	void shutdown() override;
 
-	std::optional<UiTextureID> tryCreateUiTexture(const TextureBuilder &textureBuilder) override;
-	void freeUiTexture(UiTextureID id) override;
+	bool tryCreateUiTexture(const TextureAssetReference &textureAssetRef, TextureManager &textureManager) override;
+	void freeUiTexture(const TextureAssetReference &textureAssetRef) override;
 	std::optional<Int2> tryGetTextureDims(UiTextureID id) const override;
 
 	void draw(const RenderElement *elements, int count, RenderSpace renderSpace) override;

--- a/OpenTESArena/src/Rendering/SoftwareRenderer.cpp
+++ b/OpenTESArena/src/Rendering/SoftwareRenderer.cpp
@@ -1016,7 +1016,7 @@ Double3 SoftwareRenderer::screenPointToRay(double xPercent, double yPercent,
 	const Radians yAngleRadians = cameraDirection.getYAngleRadians();
 	const double zoom = MathUtils::verticalFovToZoom(fovY);
 	const double yShear = RendererUtils::getYShear(yAngleRadians, zoom);
-	const double upPercent = (((yPercent - yShear) * 2.0) - 1.0) / SoftwareRenderer::TALL_PIXEL_RATIO;
+	const double upPercent = (((yPercent - yShear) * 2.0) - 1.0) / ArenaRenderUtils::TALL_PIXEL_RATIO;
 
 	// Combine the various components to get the final vector
 	const Double3 forwardComponent = forward * zoom;
@@ -1040,7 +1040,7 @@ void SoftwareRenderer::init(const RenderInitSettings &settings)
 	this->skyGradientRowCache.fill(Double3::Zero);
 
 	// Initialize texture vectors to default sizes.
-	this->voxelTextures = std::vector<VoxelTexture>(SoftwareRenderer::DEFAULT_VOXEL_TEXTURE_COUNT);
+	this->voxelTextures = std::vector<VoxelTexture>(ArenaRenderUtils::DEFAULT_VOXEL_TEXTURE_COUNT);
 	this->flatTextureGroups = FlatTextureGroups();
 
 	this->width = settings.getWidth();
@@ -1438,7 +1438,7 @@ void SoftwareRenderer::updateVisibleDistantObjects(const ShadingInfo &shadingInf
 		// Calculate the projected width of the object so we can get the left and right X
 		// coordinates on-screen.
 		const double objProjWidth = (objWidth * camera.zoom) /
-			(camera.aspect * SoftwareRenderer::TALL_PIXEL_RATIO);
+			(camera.aspect * ArenaRenderUtils::TALL_PIXEL_RATIO);
 		const double objProjHalfWidth = objProjWidth * 0.50;
 
 		// Left and right coordinates of the object in screen space.
@@ -2875,7 +2875,7 @@ bool SoftwareRenderer::findInitialDoorIntersection(SNInt voxelX, WEInt voxelZ,
 			{
 				// If far U coordinate is within percent closed, it's a hit. At 100% open,
 				// a sliding door is still partially visible.
-				const double minVisible = SoftwareRenderer::DOOR_MIN_VISIBLE;
+				const double minVisible = ArenaRenderUtils::DOOR_MIN_VISIBLE;
 				const double visibleAmount = 1.0 - ((1.0 - minVisible) * percentOpen);
 				if (visibleAmount > farU)
 				{
@@ -2904,7 +2904,7 @@ bool SoftwareRenderer::findInitialDoorIntersection(SNInt voxelX, WEInt voxelZ,
 			{
 				// If far U coordinate is within percent closed on left or right half, it's a hit.
 				// At 100% open, a splitting door is still partially visible.
-				const double minVisible = SoftwareRenderer::DOOR_MIN_VISIBLE;
+				const double minVisible = ArenaRenderUtils::DOOR_MIN_VISIBLE;
 				const bool leftHalf = farU < 0.50;
 				const bool rightHalf = farU > 0.50;
 				double leftVisAmount, rightVisAmount;
@@ -3110,7 +3110,7 @@ bool SoftwareRenderer::findDoorIntersection(SNInt voxelX, WEInt voxelZ,
 	{
 		// If near U coordinate is within percent closed, it's a hit. At 100% open,
 		// a sliding door is still partially visible.
-		const double minVisible = SoftwareRenderer::DOOR_MIN_VISIBLE;
+		const double minVisible = ArenaRenderUtils::DOOR_MIN_VISIBLE;
 		const double visibleAmount = 1.0 - ((1.0 - minVisible) * percentOpen);
 		if (visibleAmount > nearU)
 		{
@@ -3139,7 +3139,7 @@ bool SoftwareRenderer::findDoorIntersection(SNInt voxelX, WEInt voxelZ,
 	{
 		// If near U coordinate is within percent closed on left or right half, it's a hit.
 		// At 100% open, a splitting door is still partially visible.
-		const double minVisible = SoftwareRenderer::DOOR_MIN_VISIBLE;
+		const double minVisible = ArenaRenderUtils::DOOR_MIN_VISIBLE;
 		const bool leftHalf = nearU < 0.50;
 		const bool rightHalf = nearU > 0.50;
 		double leftVisAmount, rightVisAmount;
@@ -4925,7 +4925,7 @@ void SoftwareRenderer::drawInitialVoxelSameFloor(int x, SNInt voxelX, int voxelY
 			else if (doorData.type == VoxelDefinition::DoorData::Type::Raising)
 			{
 				// Top point is fixed, bottom point depends on percent open.
-				const double minVisible = SoftwareRenderer::DOOR_MIN_VISIBLE;
+				const double minVisible = ArenaRenderUtils::DOOR_MIN_VISIBLE;
 				const double raisedAmount = (voxelHeight * (1.0 - minVisible)) * percentOpen;
 
 				const Double3 doorTopPoint(
@@ -5255,7 +5255,7 @@ void SoftwareRenderer::drawInitialVoxelAbove(int x, SNInt voxelX, int voxelY, WE
 			else if (doorData.type == VoxelDefinition::DoorData::Type::Raising)
 			{
 				// Top point is fixed, bottom point depends on percent open.
-				const double minVisible = SoftwareRenderer::DOOR_MIN_VISIBLE;
+				const double minVisible = ArenaRenderUtils::DOOR_MIN_VISIBLE;
 				const double raisedAmount = (voxelHeight * (1.0 - minVisible)) * percentOpen;
 
 				const Double3 doorTopPoint(
@@ -5665,7 +5665,7 @@ void SoftwareRenderer::drawInitialVoxelBelow(int x, SNInt voxelX, int voxelY, WE
 			else if (doorData.type == VoxelDefinition::DoorData::Type::Raising)
 			{
 				// Top point is fixed, bottom point depends on percent open.
-				const double minVisible = SoftwareRenderer::DOOR_MIN_VISIBLE;
+				const double minVisible = ArenaRenderUtils::DOOR_MIN_VISIBLE;
 				const double raisedAmount = (voxelHeight * (1.0 - minVisible)) * percentOpen;
 
 				const Double3 doorTopPoint(
@@ -6183,7 +6183,7 @@ void SoftwareRenderer::drawVoxelSameFloor(int x, SNInt voxelX, int voxelY, WEInt
 			else if (doorData.type == VoxelDefinition::DoorData::Type::Raising)
 			{
 				// Top point is fixed, bottom point depends on percent open.
-				const double minVisible = SoftwareRenderer::DOOR_MIN_VISIBLE;
+				const double minVisible = ArenaRenderUtils::DOOR_MIN_VISIBLE;
 				const double raisedAmount = (voxelHeight * (1.0 - minVisible)) * percentOpen;
 
 				const Double3 doorTopPoint(
@@ -6533,7 +6533,7 @@ void SoftwareRenderer::drawVoxelAbove(int x, SNInt voxelX, int voxelY, WEInt vox
 			else if (doorData.type == VoxelDefinition::DoorData::Type::Raising)
 			{
 				// Top point is fixed, bottom point depends on percent open.
-				const double minVisible = SoftwareRenderer::DOOR_MIN_VISIBLE;
+				const double minVisible = ArenaRenderUtils::DOOR_MIN_VISIBLE;
 				const double raisedAmount = (voxelHeight * (1.0 - minVisible)) * percentOpen;
 
 				const Double3 doorTopPoint(
@@ -6983,7 +6983,7 @@ void SoftwareRenderer::drawVoxelBelow(int x, SNInt voxelX, int voxelY, WEInt vox
 			else if (doorData.type == VoxelDefinition::DoorData::Type::Raising)
 			{
 				// Top point is fixed, bottom point depends on percent open.
-				const double minVisible = SoftwareRenderer::DOOR_MIN_VISIBLE;
+				const double minVisible = ArenaRenderUtils::DOOR_MIN_VISIBLE;
 				const double raisedAmount = (voxelHeight * (1.0 - minVisible)) * percentOpen;
 
 				const Double3 doorTopPoint(
@@ -7842,7 +7842,7 @@ void SoftwareRenderer::render(const Double3 &eye, const Double3 &direction, doub
 	const double aspect = widthReal / heightReal;
 
 	// To account for tall pixels.
-	const double projectionModifier = SoftwareRenderer::TALL_PIXEL_RATIO;
+	const double projectionModifier = ArenaRenderUtils::TALL_PIXEL_RATIO;
 
 	// 2.5D camera definition.
 	const Camera camera(eye, direction, fovY, aspect, projectionModifier);

--- a/OpenTESArena/src/Rendering/SoftwareRenderer.h
+++ b/OpenTESArena/src/Rendering/SoftwareRenderer.h
@@ -115,6 +115,29 @@ private:
 		void init(int width, int height, const uint8_t *srcTexels, const Palette &palette);
 	};
 
+	// @temp: this is a temporary solution to voxel texture allocation management -- ideally the renderer
+	// would take texture builders and return texture handles and those would be bound to instance voxel
+	// geometry.
+	struct VoxelTextureMapping
+	{
+		TextureAssetReference textureAssetRef;
+		int textureIndex; // Index in voxel textures list.
+
+		VoxelTextureMapping(TextureAssetReference &&textureAssetRef, int textureIndex);
+	};
+
+	struct VoxelTextures
+	{
+		std::vector<VoxelTexture> textures;
+		std::vector<VoxelTextureMapping> mappings;
+
+		void addTexture(VoxelTexture &&texture, TextureAssetReference &&textureAssetRef);
+
+		const VoxelTexture &getTexture(const TextureAssetReference &textureAssetRef) const;
+
+		void clear();
+	};
+
 	// Camera for 2.5D ray casting (with some pre-calculated values to avoid duplicating work).
 	struct Camera
 	{
@@ -465,7 +488,7 @@ private:
 			const std::vector<VisibleLight> *visLights;
 			const Buffer2D<VisibleLightList> *visLightLists;
 			const VoxelGrid *voxelGrid;
-			const std::vector<VoxelTexture> *voxelTextures;
+			const VoxelTextures *voxelTextures;
 			const ChasmTextureGroups *chasmTextureGroups;
 			Buffer<OcclusionData> *occlusion;
 			double ceilingHeight;
@@ -478,8 +501,8 @@ private:
 				const LevelData::ChasmStates &chasmStates,
 				const std::vector<VisibleLight> &visLights,
 				const Buffer2D<VisibleLightList> &visLightLists, const VoxelGrid &voxelGrid,
-				const std::vector<VoxelTexture> &voxelTextures,
-				const ChasmTextureGroups &chasmTextureGroups, Buffer<OcclusionData> &occlusion);
+				const VoxelTextures &voxelTextures, const ChasmTextureGroups &chasmTextureGroups,
+				Buffer<OcclusionData> &occlusion);
 		};
 
 		struct Flats
@@ -536,7 +559,7 @@ private:
 	VisDistantObjects visDistantObjs; // Visible distant sky objects.
 	Buffer2D<VisibleLightList> visLightLists; // Potentially-visible voxel column references to visible lights.
 	std::vector<VisibleLight> visibleLights; // Lights that contribute to the current frame.
-	std::vector<VoxelTexture> voxelTextures; // Max 64 voxel textures in original engine.
+	VoxelTextures voxelTextures; // Voxel textures and their mappings.
 	FlatTextureGroups flatTextureGroups; // Entity anim textures accessed by entity render ID.
 	ChasmTextureGroups chasmTextureGroups; // Mappings from chasm ID to textures.
 	std::vector<SkyTexture> skyTextures; // Distant object textures. Size is managed internally.
@@ -797,7 +820,7 @@ private:
 		const LevelData::ChasmStates &chasmStates,
 		const BufferView<const VisibleLight> &visLights,
 		const BufferView2D<const VisibleLightList> &visLightLists, const VoxelGrid &voxelGrid,
-		const std::vector<VoxelTexture> &textures, const ChasmTextureGroups &chasmTextureGroups,
+		const VoxelTextures &textures, const ChasmTextureGroups &chasmTextureGroups,
 		OcclusionData &occlusion, const FrameView &frame);
 	static void drawInitialVoxelAbove(int x, SNInt voxelX, int voxelY, WEInt voxelZ,
 		const Camera &camera, const Ray &ray, VoxelFacing2D facing, const NewDouble2 &nearPoint,
@@ -808,7 +831,7 @@ private:
 		const LevelData::ChasmStates &chasmStates,
 		const BufferView<const VisibleLight> &visLights,
 		const BufferView2D<const VisibleLightList> &visLightLists, const VoxelGrid &voxelGrid,
-		const std::vector<VoxelTexture> &textures, const ChasmTextureGroups &chasmTextureGroups,
+		const VoxelTextures &textures, const ChasmTextureGroups &chasmTextureGroups,
 		OcclusionData &occlusion, const FrameView &frame);
 	static void drawInitialVoxelBelow(int x, SNInt voxelX, int voxelY, WEInt voxelZ,
 		const Camera &camera, const Ray &ray, VoxelFacing2D facing, const NewDouble2 &nearPoint,
@@ -819,7 +842,7 @@ private:
 		const LevelData::ChasmStates &chasmStates,
 		const BufferView<const VisibleLight> &visLights,
 		const BufferView2D<const VisibleLightList> &visLightLists, const VoxelGrid &voxelGrid,
-		const std::vector<VoxelTexture> &textures, const ChasmTextureGroups &chasmTextureGroups,
+		const VoxelTextures &textures, const ChasmTextureGroups &chasmTextureGroups,
 		OcclusionData &occlusion, const FrameView &frame);
 
 	// Manages drawing voxels in the column that the player is in.
@@ -831,7 +854,7 @@ private:
 		const LevelData::ChasmStates &chasmStates,
 		const BufferView<const VisibleLight> &visLights,
 		const BufferView2D<const VisibleLightList> &visLightLists, const VoxelGrid &voxelGrid,
-		const std::vector<VoxelTexture> &textures, const ChasmTextureGroups &chasmTextureGroups,
+		const VoxelTextures &textures, const ChasmTextureGroups &chasmTextureGroups,
 		OcclusionData &occlusion, const FrameView &frame);
 
 	// Helper functions for drawing a voxel column.
@@ -843,7 +866,7 @@ private:
 		const LevelData::ChasmStates &chasmStates,
 		const BufferView<const VisibleLight> &visLights,
 		const BufferView2D<const VisibleLightList> &visLightLists, const VoxelGrid &voxelGrid,
-		const std::vector<VoxelTexture> &textures, const ChasmTextureGroups &chasmTextureGroups,
+		const VoxelTextures &textures, const ChasmTextureGroups &chasmTextureGroups,
 		OcclusionData &occlusion, const FrameView &frame);
 	static void drawVoxelAbove(int x, SNInt voxelX, int voxelY, WEInt voxelZ, const Camera &camera,
 		const Ray &ray, VoxelFacing2D facing, const NewDouble2 &nearPoint, const NewDouble2 &farPoint,
@@ -853,7 +876,7 @@ private:
 		const LevelData::ChasmStates &chasmStates,
 		const BufferView<const VisibleLight> &visLights,
 		const BufferView2D<const VisibleLightList> &visLightLists, const VoxelGrid &voxelGrid,
-		const std::vector<VoxelTexture> &textures, const ChasmTextureGroups &chasmTextureGroups,
+		const VoxelTextures &textures, const ChasmTextureGroups &chasmTextureGroups,
 		OcclusionData &occlusion, const FrameView &frame);
 	static void drawVoxelBelow(int x, SNInt voxelX, int voxelY, WEInt voxelZ, const Camera &camera,
 		const Ray &ray, VoxelFacing2D facing, const NewDouble2 &nearPoint, const NewDouble2 &farPoint,
@@ -863,7 +886,7 @@ private:
 		const LevelData::ChasmStates &chasmStates,
 		const BufferView<const VisibleLight> &visLights,
 		const BufferView2D<const VisibleLightList> &visLightLists, const VoxelGrid &voxelGrid,
-		const std::vector<VoxelTexture> &textures, const ChasmTextureGroups &chasmTextureGroups,
+		const VoxelTextures &textures, const ChasmTextureGroups &chasmTextureGroups,
 		OcclusionData &occlusion, const FrameView &frame);
 
 	// Manages drawing voxels in the column of the given XZ coordinate in the voxel grid.
@@ -875,7 +898,7 @@ private:
 		const LevelData::ChasmStates &chasmStates,
 		const BufferView<const VisibleLight> &visLights,
 		const BufferView2D<const VisibleLightList> &visLightLists, const VoxelGrid &voxelGrid,
-		const std::vector<VoxelTexture> &textures, const ChasmTextureGroups &chasmTextureGroups,
+		const VoxelTextures &textures, const ChasmTextureGroups &chasmTextureGroups,
 		OcclusionData &occlusion, const FrameView &frame);
 
 	// Draws the portion of a flat contained within the given X range of the screen. The end
@@ -896,7 +919,7 @@ private:
 		const LevelData::ChasmStates &chasmStates,
 		const BufferView<const VisibleLight> &visLights,
 		const BufferView2D<const VisibleLightList> &visLightLists, const VoxelGrid &voxelGrid,
-		const std::vector<VoxelTexture> &textures, const ChasmTextureGroups &chasmTextureGroups,
+		const VoxelTextures &textures, const ChasmTextureGroups &chasmTextureGroups,
 		OcclusionData &occlusion, const FrameView &frame);
 
 	// Helper method for internal ray casting function that takes template parameters for better
@@ -908,7 +931,7 @@ private:
 		const LevelData::ChasmStates &chasmStates,
 		const BufferView<const VisibleLight> &visLights,
 		const BufferView2D<const VisibleLightList> &visLightLists, const VoxelGrid &voxelGrid,
-		const std::vector<VoxelTexture> &textures, const ChasmTextureGroups &chasmTextureGroups,
+		const VoxelTextures &textures, const ChasmTextureGroups &chasmTextureGroups,
 		OcclusionData &occlusion, const FrameView &frame);
 
 	// Draws a portion of the sky gradient. The start and end Y are determined from current
@@ -931,7 +954,7 @@ private:
 		const LevelData::ChasmStates &chasmStates,
 		const BufferView<const VisibleLight> &visLights,
 		const BufferView2D<const VisibleLightList> &visLightLists, const VoxelGrid &voxelGrid,
-		const std::vector<VoxelTexture> &voxelTextures, const ChasmTextureGroups &chasmTextureGroups,
+		const VoxelTextures &voxelTextures, const ChasmTextureGroups &chasmTextureGroups,
 		Buffer<OcclusionData> &occlusion, const ShadingInfo &shadingInfo, const FrameView &frame);
 
 	// Handles drawing all flats for the current frame.
@@ -987,9 +1010,6 @@ public:
 	void addChasmTexture(VoxelDefinition::ChasmData::Type chasmType, const uint8_t *colors,
 		int width, int height, const Palette &palette) override;
 
-	// Overwrites the selected voxel texture's data with the given 64x64 set of texels.
-	void setVoxelTexture(int id, const uint8_t *srcTexels, const Palette &palette) override;
-
 	// Gets the next available entity render ID to be assigned to entities in the engine.
 	EntityRenderID makeEntityRenderID() override;
 
@@ -1014,14 +1034,16 @@ public:
 	void shutdown() override;
 	void resize(int width, int height) override;
 
-	std::optional<VoxelTextureID> tryCreateVoxelTexture(const TextureBuilder &textureBuilder) override;
-	std::optional<EntityTextureID> tryCreateEntityTexture(const TextureBuilder &textureBuilder) override;
-	std::optional<SkyTextureID> tryCreateSkyTexture(const TextureBuilder &textureBuilder) override;
+	bool tryCreateVoxelTexture(const TextureAssetReference &textureAssetRef,
+		TextureManager &textureManager) override;
+	bool tryCreateEntityTexture(const TextureAssetReference &textureAssetRef,
+		TextureManager &textureManager) override;
+	bool tryCreateSkyTexture(const TextureAssetReference &textureAssetRef,
+		TextureManager &textureManager) override;
 
-	// Texture handle freeing functions for each texture type.
-	void freeVoxelTexture(VoxelTextureID id) override;
-	void freeEntityTexture(EntityTextureID id) override;
-	void freeSkyTexture(SkyTextureID id) override;
+	void freeVoxelTexture(const TextureAssetReference &textureAssetRef) override;
+	void freeEntityTexture(const TextureAssetReference &textureAssetRef) override;
+	void freeSkyTexture(const TextureAssetReference &textureAssetRef) override;
 
 	// Draws the scene to the output color buffer in ARGB8888 format.
 	// @todo: move everything to RenderCamera and RenderFrameSettings temporarily until design is finished.

--- a/OpenTESArena/src/Rendering/SoftwareRenderer.h
+++ b/OpenTESArena/src/Rendering/SoftwareRenderer.h
@@ -972,7 +972,7 @@ private:
 		int endX, int startY, int endY);
 public:
 	SoftwareRenderer();
-	~SoftwareRenderer();
+	virtual ~SoftwareRenderer();
 
 	bool isInited() const override;
 

--- a/OpenTESArena/src/Rendering/SoftwareRenderer.h
+++ b/OpenTESArena/src/Rendering/SoftwareRenderer.h
@@ -522,16 +522,6 @@ private:
 	static constexpr double NEAR_PLANE = 0.0001;
 	static constexpr double FAR_PLANE = 1000.0;
 
-	// Default texture array sizes (using vector instead of array to avoid stack overflow).
-	static constexpr int DEFAULT_VOXEL_TEXTURE_COUNT = 64;
-	//static const int DEFAULT_FLAT_TEXTURE_COUNT = 256; // Not used with flat texture groups.
-
-	// Height ratio between normal pixels and tall pixels.
-	static constexpr double TALL_PIXEL_RATIO = 1.20;
-
-	// Amount of a sliding/raising door that is visible when fully open.
-	static constexpr double DOOR_MIN_VISIBLE = 0.10;
-
 	// Angle of the sky gradient above the horizon, in degrees.
 	static constexpr double SKY_GRADIENT_ANGLE = 30.0;
 

--- a/OpenTESArena/src/World/ArenaVoxelUtils.cpp
+++ b/OpenTESArena/src/World/ArenaVoxelUtils.cpp
@@ -1,9 +1,11 @@
 #include <algorithm>
+#include <vector>
 
 #include "ArenaVoxelUtils.h"
 #include "MapType.h"
 
 #include "components/debug/Debug.h"
+#include "components/utilities/String.h"
 
 ArenaTypes::MenuType ArenaVoxelUtils::getMenuType(int menuID, MapType mapType)
 {
@@ -131,6 +133,20 @@ int ArenaVoxelUtils::clampVoxelTextureID(int id)
 	}
 
 	return id;
+}
+
+std::string ArenaVoxelUtils::getVoxelTextureFilename(int id, const INFFile &inf)
+{
+	const std::vector<INFFile::VoxelTextureData> &voxelTextures = inf.getVoxelTextures();
+	if ((id < 0) || (id >= static_cast<int>(voxelTextures.size())))
+	{
+		DebugLogError("Couldn't get .INF voxel texture filename for ID \"" + std::to_string(id) + "\".");
+		return std::string();
+	}
+
+	const INFFile::VoxelTextureData &textureData = voxelTextures[id];
+	const char *filename = textureData.filename.data();
+	return String::toUppercase(filename);
 }
 
 bool ArenaVoxelUtils::isFloorWildWallColored(int floorID, MapType mapType)

--- a/OpenTESArena/src/World/ArenaVoxelUtils.cpp
+++ b/OpenTESArena/src/World/ArenaVoxelUtils.cpp
@@ -149,6 +149,19 @@ std::string ArenaVoxelUtils::getVoxelTextureFilename(int id, const INFFile &inf)
 	return String::toUppercase(filename);
 }
 
+std::optional<int> ArenaVoxelUtils::getVoxelTextureSetIndex(int id, const INFFile &inf)
+{
+	const std::vector<INFFile::VoxelTextureData> &voxelTextures = inf.getVoxelTextures();
+	if ((id < 0) || (id >= static_cast<int>(voxelTextures.size())))
+	{
+		DebugLogError("Couldn't get .INF voxel texture set index for ID \"" + std::to_string(id) + "\".");
+		return std::nullopt;
+	}
+
+	const INFFile::VoxelTextureData &textureData = voxelTextures[id];
+	return textureData.setIndex;
+}
+
 bool ArenaVoxelUtils::isFloorWildWallColored(int floorID, MapType mapType)
 {
 	if (mapType != MapType::Wilderness)

--- a/OpenTESArena/src/World/ArenaVoxelUtils.h
+++ b/OpenTESArena/src/World/ArenaVoxelUtils.h
@@ -1,6 +1,8 @@
 #ifndef ARENA_VOXEL_UTILS_H
 #define ARENA_VOXEL_UTILS_H
 
+#include <string>
+
 #include "../Assets/ArenaTypes.h"
 #include "../Assets/INFFile.h"
 #include "../Assets/MIFUtils.h"
@@ -31,6 +33,9 @@ namespace ArenaVoxelUtils
 
 	// Validates a voxel texture ID to make sure it's in the proper range and clamps if necessary.
 	int clampVoxelTextureID(int id);
+
+	// Gets the texture filename for the given voxel texture ID.
+	std::string getVoxelTextureFilename(int id, const INFFile &inf);
 
 	// Returns whether the floor would be colored like a wall on the wild automap, to make it easier
 	// to see roads, etc..

--- a/OpenTESArena/src/World/ArenaVoxelUtils.h
+++ b/OpenTESArena/src/World/ArenaVoxelUtils.h
@@ -37,6 +37,10 @@ namespace ArenaVoxelUtils
 	// Gets the texture filename for the given voxel texture ID.
 	std::string getVoxelTextureFilename(int id, const INFFile &inf);
 
+	// Gets the index into a texture set for the given voxel texture ID, if any. For example, it may
+	// return 2 in a 4-image .SET file, or none if not a .SET file.
+	std::optional<int> getVoxelTextureSetIndex(int id, const INFFile &inf);
+
 	// Returns whether the floor would be colored like a wall on the wild automap, to make it easier
 	// to see roads, etc..
 	bool isFloorWildWallColored(int floorID, MapType mapType);

--- a/OpenTESArena/src/World/LevelData.cpp
+++ b/OpenTESArena/src/World/LevelData.cpp
@@ -38,6 +38,7 @@
 #include "../Math/Constants.h"
 #include "../Math/Random.h"
 #include "../Media/TextureManager.h"
+#include "../Rendering/ArenaRenderUtils.h"
 #include "../Rendering/Renderer.h"
 
 #include "components/debug/Debug.h"
@@ -1587,7 +1588,7 @@ void LevelData::setActive(bool nightLightsAreActive, const WorldData &worldData,
 		for (int i = 0; i < voxelDefCount; i++)
 		{
 			const VoxelDefinition &voxelDef = this->voxelGrid.getVoxelDef(i);
-			Buffer<TextureAssetReference> textureAssetRefs = voxelDef.getTextureAssetReferences();
+			const Buffer<TextureAssetReference> textureAssetRefs = voxelDef.getTextureAssetReferences();
 			for (int j = 0; j < textureAssetRefs.getCount(); j++)
 			{
 				const TextureAssetReference &textureAssetRef = textureAssetRefs.get(j);
@@ -1607,8 +1608,7 @@ void LevelData::setActive(bool nightLightsAreActive, const WorldData &worldData,
 		Buffer<uint8_t> chasmBuffer(chasmWidth * chasmHeight);
 
 		// Dry chasm (just a single color).
-		constexpr uint8_t dryChasmColor = 112; // Matches the original game.
-		chasmBuffer.fill(dryChasmColor);
+		chasmBuffer.fill(ArenaRenderUtils::PALETTE_INDEX_DRY_CHASM_COLOR);
 		renderer.addChasmTexture(VoxelDefinition::ChasmData::Type::Dry, chasmBuffer.get(),
 			chasmWidth, chasmHeight, palette);
 

--- a/OpenTESArena/src/World/LevelData.cpp
+++ b/OpenTESArena/src/World/LevelData.cpp
@@ -454,7 +454,7 @@ void LevelData::readFLOR(const BufferView2D<const ArenaTypes::VoxelID> &flor, co
 	};
 
 	// Lambda for obtaining the voxel data index of a typical (non-chasm) FLOR voxel.
-	auto getFlorDataIndex = [this, mapType](uint16_t florVoxel, int floorTextureID)
+	auto getFlorDataIndex = [this, &inf, mapType](uint16_t florVoxel, int floorTextureID)
 	{
 		// See if the voxel already has a mapping.
 		const auto floorIter = std::find_if(
@@ -471,9 +471,13 @@ void LevelData::readFLOR(const BufferView2D<const ArenaTypes::VoxelID> &flor, co
 		else
 		{
 			// Insert new mapping.
+			const int clampedTextureID = ArenaVoxelUtils::clampVoxelTextureID(floorTextureID);
+			TextureAssetReference textureAssetRef(
+				ArenaVoxelUtils::getVoxelTextureFilename(clampedTextureID, inf),
+				ArenaVoxelUtils::getVoxelTextureSetIndex(clampedTextureID, inf));
 			const bool isWildWallColored = ArenaVoxelUtils::isFloorWildWallColored(floorTextureID, mapType);
 			const int index = this->voxelGrid.addVoxelDef(
-				VoxelDefinition::makeFloor(ArenaVoxelUtils::clampVoxelTextureID(floorTextureID), isWildWallColored));
+				VoxelDefinition::makeFloor(std::move(textureAssetRef), isWildWallColored));
 			this->floorDataMappings.push_back(std::make_pair(florVoxel, index));
 			return index;
 		}
@@ -522,8 +526,11 @@ void LevelData::readFLOR(const BufferView2D<const ArenaTypes::VoxelID> &flor, co
 			}
 		}();
 
-		return VoxelDefinition::makeChasm(
-			ArenaVoxelUtils::clampVoxelTextureID(dryChasmID), VoxelDefinition::ChasmData::Type::Dry);
+		const int clampedTextureID = ArenaVoxelUtils::clampVoxelTextureID(dryChasmID);
+		TextureAssetReference textureAssetRef(
+			ArenaVoxelUtils::getVoxelTextureFilename(clampedTextureID, inf),
+			ArenaVoxelUtils::getVoxelTextureSetIndex(clampedTextureID, inf));
+		return VoxelDefinition::makeChasm(std::move(textureAssetRef), VoxelDefinition::ChasmData::Type::Dry);
 	};
 
 	auto makeLavaChasmVoxelDef = [](const INFFile &inf)
@@ -542,8 +549,11 @@ void LevelData::readFLOR(const BufferView2D<const ArenaTypes::VoxelID> &flor, co
 			}
 		}();
 
-		return VoxelDefinition::makeChasm(
-			ArenaVoxelUtils::clampVoxelTextureID(lavaChasmID), VoxelDefinition::ChasmData::Type::Lava);
+		const int clampedTextureID = ArenaVoxelUtils::clampVoxelTextureID(lavaChasmID);
+		TextureAssetReference textureAssetRef(
+			ArenaVoxelUtils::getVoxelTextureFilename(clampedTextureID, inf),
+			ArenaVoxelUtils::getVoxelTextureSetIndex(clampedTextureID, inf));
+		return VoxelDefinition::makeChasm(std::move(textureAssetRef), VoxelDefinition::ChasmData::Type::Lava);
 	};
 
 	auto makeWetChasmVoxelDef = [](const INFFile &inf)
@@ -562,8 +572,11 @@ void LevelData::readFLOR(const BufferView2D<const ArenaTypes::VoxelID> &flor, co
 			}
 		}();
 
-		return VoxelDefinition::makeChasm(
-			ArenaVoxelUtils::clampVoxelTextureID(wetChasmID), VoxelDefinition::ChasmData::Type::Wet);
+		const int clampedTextureID = ArenaVoxelUtils::clampVoxelTextureID(wetChasmID);
+		TextureAssetReference textureAssetRef(
+			ArenaVoxelUtils::getVoxelTextureFilename(clampedTextureID, inf),
+			ArenaVoxelUtils::getVoxelTextureSetIndex(clampedTextureID, inf));
+		return VoxelDefinition::makeChasm(std::move(textureAssetRef), VoxelDefinition::ChasmData::Type::Wet);
 	};
 
 	// Write the voxel IDs into the voxel grid.
@@ -775,9 +788,13 @@ void LevelData::readMAP1(const BufferView2D<const ArenaTypes::VoxelID> &map1, co
 		}
 		else
 		{
-			const int clampedTextureIndex = ArenaVoxelUtils::clampVoxelTextureID(textureIndex);
+			const int clampedTextureID = ArenaVoxelUtils::clampVoxelTextureID(textureIndex);
+			const TextureAssetReference textureAssetRef(
+				ArenaVoxelUtils::getVoxelTextureFilename(clampedTextureID, inf),
+				ArenaVoxelUtils::getVoxelTextureSetIndex(clampedTextureID, inf));
 			const int index = this->voxelGrid.addVoxelDef(VoxelDefinition::makeWall(
-				clampedTextureIndex, clampedTextureIndex, clampedTextureIndex));
+				TextureAssetReference(textureAssetRef), TextureAssetReference(textureAssetRef),
+				TextureAssetReference(textureAssetRef)));
 			this->wallDataMappings.push_back(std::make_pair(map1Voxel, index));
 			return index;
 		}
@@ -891,11 +908,20 @@ void LevelData::readMAP1(const BufferView2D<const ArenaTypes::VoxelID> &map1, co
 					0.0, 1.0 - yOffsetNormalized - ySizeNormalized);
 				const double vBottom = std::min(vTop + ySizeNormalized, 1.0);
 
-				return VoxelDefinition::makeRaised(
-					ArenaVoxelUtils::clampVoxelTextureID(sideID),
-					ArenaVoxelUtils::clampVoxelTextureID(floorID),
-					ArenaVoxelUtils::clampVoxelTextureID(ceilingID),
-					yOffsetNormalized, ySizeNormalized, vTop, vBottom);
+				const int clampedSideID = ArenaVoxelUtils::clampVoxelTextureID(sideID);
+				const int clampedFloorID = ArenaVoxelUtils::clampVoxelTextureID(floorID);
+				const int clampedCeilingID = ArenaVoxelUtils::clampVoxelTextureID(ceilingID);
+				TextureAssetReference sideTextureAssetRef(
+					ArenaVoxelUtils::getVoxelTextureFilename(clampedSideID, inf),
+					ArenaVoxelUtils::getVoxelTextureSetIndex(clampedSideID, inf));
+				TextureAssetReference floorTextureAssetRef(
+					ArenaVoxelUtils::getVoxelTextureFilename(clampedFloorID, inf),
+					ArenaVoxelUtils::getVoxelTextureSetIndex(clampedFloorID, inf));
+				TextureAssetReference ceilingTextureAssetRef(
+					ArenaVoxelUtils::getVoxelTextureFilename(clampedCeilingID, inf),
+					ArenaVoxelUtils::getVoxelTextureSetIndex(clampedCeilingID, inf));
+				return VoxelDefinition::makeRaised(std::move(sideTextureAssetRef), std::move(floorTextureAssetRef),
+					std::move(ceilingTextureAssetRef), yOffsetNormalized, ySizeNormalized, vTop, vBottom);
 			};
 
 			const int index = this->voxelGrid.addVoxelDef(makeRaisedVoxelData());
@@ -904,18 +930,36 @@ void LevelData::readMAP1(const BufferView2D<const ArenaTypes::VoxelID> &map1, co
 		}
 	};
 
-	// Lambda for creating type 0x9 voxel data.
-	auto makeType9VoxelData = [](uint16_t map1Voxel)
+	// Lambda for obtaining the voxel data index of a type 0x9 voxel.
+	auto getType9DataIndex = [this, &inf, &findWallMapping](uint16_t map1Voxel)
 	{
-		const int textureIndex = (map1Voxel & 0x00FF) - 1;
-		const bool collider = (map1Voxel & 0x0100) == 0;
-		return VoxelDefinition::makeTransparentWall(
-			ArenaVoxelUtils::clampVoxelTextureID(textureIndex), collider);
+		const auto wallIter = findWallMapping(map1Voxel);
+		if (wallIter != this->wallDataMappings.end())
+		{
+			return wallIter->second;
+		}
+		else
+		{
+			// Lambda for creating type 0x9 voxel data.
+			auto makeType9VoxelData = [&inf, map1Voxel]()
+			{
+				const int textureIndex = (map1Voxel & 0x00FF) - 1;
+				const int clampedTextureID = ArenaVoxelUtils::clampVoxelTextureID(textureIndex);
+				TextureAssetReference textureAssetRef(
+					ArenaVoxelUtils::getVoxelTextureFilename(clampedTextureID, inf),
+					ArenaVoxelUtils::getVoxelTextureSetIndex(clampedTextureID, inf));
+				const bool collider = (map1Voxel & 0x0100) == 0;
+				return VoxelDefinition::makeTransparentWall(std::move(textureAssetRef), collider);
+			};
+
+			const int index = this->voxelGrid.addVoxelDef(makeType9VoxelData());
+			this->wallDataMappings.push_back(std::make_pair(map1Voxel, index));
+			return index;
+		}
 	};
 
 	// Lambda for obtaining the voxel data index of a type 0xA voxel.
-	auto getTypeADataIndex = [this, mapType, &findWallMapping](
-		uint16_t map1Voxel, int textureIndex)
+	auto getTypeADataIndex = [this, &inf, mapType, &findWallMapping](uint16_t map1Voxel, int textureIndex)
 	{
 		const auto wallIter = findWallMapping(map1Voxel);
 		if (wallIter != this->wallDataMappings.end())
@@ -925,7 +969,7 @@ void LevelData::readMAP1(const BufferView2D<const ArenaTypes::VoxelID> &map1, co
 		else
 		{
 			// Lambda for creating type 0xA voxel data.
-			auto makeTypeAVoxelData = [mapType, map1Voxel, textureIndex]()
+			auto makeTypeAVoxelData = [&inf, mapType, map1Voxel, textureIndex]()
 			{
 				const double yOffset = [mapType, map1Voxel]()
 				{
@@ -967,8 +1011,11 @@ void LevelData::readMAP1(const BufferView2D<const ArenaTypes::VoxelID> &map1, co
 					}
 				}();
 
-				return VoxelDefinition::makeEdge(ArenaVoxelUtils::clampVoxelTextureID(textureIndex),
-					yOffset, collider, flipped, facing);
+				const int clampedTextureID = ArenaVoxelUtils::clampVoxelTextureID(textureIndex);
+				TextureAssetReference textureAssetRef(
+					ArenaVoxelUtils::getVoxelTextureFilename(clampedTextureID, inf),
+					ArenaVoxelUtils::getVoxelTextureSetIndex(clampedTextureID, inf));
+				return VoxelDefinition::makeEdge(std::move(textureAssetRef), yOffset, collider, flipped, facing);
 			};
 
 			const int index = this->voxelGrid.addVoxelDef(makeTypeAVoxelData());
@@ -977,45 +1024,83 @@ void LevelData::readMAP1(const BufferView2D<const ArenaTypes::VoxelID> &map1, co
 		}
 	};
 
-	// Lambda for creating type 0xB voxel data.
-	auto makeTypeBVoxelData = [](uint16_t map1Voxel)
+	// Lambda for obtaining the voxel data index of a type 0xB voxel.
+	auto getTypeBDataIndex = [this, &inf, &findWallMapping](uint16_t map1Voxel)
 	{
-		const int textureIndex = (map1Voxel & 0x003F) - 1;
-		const VoxelDefinition::DoorData::Type doorType = [map1Voxel]()
+		const auto wallIter = findWallMapping(map1Voxel);
+		if (wallIter != this->wallDataMappings.end())
 		{
-			const int type = (map1Voxel & 0x00C0) >> 4;
-			if (type == 0x0)
+			return wallIter->second;
+		}
+		else
+		{
+			// Lambda for creating type 0xB voxel data.
+			auto makeTypeBVoxelData = [&inf, map1Voxel]()
 			{
-				return VoxelDefinition::DoorData::Type::Swinging;
-			}
-			else if (type == 0x4)
-			{
-				return VoxelDefinition::DoorData::Type::Sliding;
-			}
-			else if (type == 0x8)
-			{
-				return VoxelDefinition::DoorData::Type::Raising;
-			}
-			else
-			{
-				// I don't believe any doors in Arena split (but they are
-				// supported by the engine).
-				DebugUnhandledReturnMsg(
-					VoxelDefinition::DoorData::Type, std::to_string(type));
-			}
-		}();
+				const int textureIndex = (map1Voxel & 0x003F) - 1;
+				const VoxelDefinition::DoorData::Type doorType = [map1Voxel]()
+				{
+					const int type = (map1Voxel & 0x00C0) >> 4;
+					if (type == 0x0)
+					{
+						return VoxelDefinition::DoorData::Type::Swinging;
+					}
+					else if (type == 0x4)
+					{
+						return VoxelDefinition::DoorData::Type::Sliding;
+					}
+					else if (type == 0x8)
+					{
+						return VoxelDefinition::DoorData::Type::Raising;
+					}
+					else
+					{
+						// I don't believe any doors in Arena split (but they are
+						// supported by the engine).
+						DebugUnhandledReturnMsg(
+							VoxelDefinition::DoorData::Type, std::to_string(type));
+					}
+				}();
 
-		return VoxelDefinition::makeDoor(
-			ArenaVoxelUtils::clampVoxelTextureID(textureIndex), doorType);
+				const int clampedTextureID = ArenaVoxelUtils::clampVoxelTextureID(textureIndex);
+				TextureAssetReference textureAssetRef(
+					ArenaVoxelUtils::getVoxelTextureFilename(clampedTextureID, inf),
+					ArenaVoxelUtils::getVoxelTextureSetIndex(clampedTextureID, inf));
+				return VoxelDefinition::makeDoor(std::move(textureAssetRef), doorType);
+			};
+
+			const int index = this->voxelGrid.addVoxelDef(makeTypeBVoxelData());
+			this->wallDataMappings.push_back(std::make_pair(map1Voxel, index));
+			return index;
+		}
 	};
 
-	// Lambda for creating type 0xD voxel data.
-	auto makeTypeDVoxelData = [](uint16_t map1Voxel)
+	// Lambda for obtaining the voxel data index of a type 0xD voxel.
+	auto getTypeDDataIndex = [this, &inf, &findWallMapping](uint16_t map1Voxel)
 	{
-		const int textureIndex = (map1Voxel & 0x00FF) - 1;
-		const bool isRightDiag = (map1Voxel & 0x0100) == 0;
-		return VoxelDefinition::makeDiagonal(
-			ArenaVoxelUtils::clampVoxelTextureID(textureIndex), isRightDiag);
+		const auto wallIter = findWallMapping(map1Voxel);
+		if (wallIter != this->wallDataMappings.end())
+		{
+			return wallIter->second;
+		}
+		else
+		{
+			// Lambda for creating type 0xD voxel data.
+			auto makeTypeDVoxelData = [&inf, map1Voxel]()
+			{
+				const int textureIndex = (map1Voxel & 0x00FF) - 1;
+				const int clampedTextureID = ArenaVoxelUtils::clampVoxelTextureID(textureIndex);
+				TextureAssetReference textureAssetRef(
+					ArenaVoxelUtils::getVoxelTextureFilename(clampedTextureID, inf),
+					ArenaVoxelUtils::getVoxelTextureSetIndex(clampedTextureID, inf));
+				const bool isRightDiag = (map1Voxel & 0x0100) == 0;
+				return VoxelDefinition::makeDiagonal(std::move(textureAssetRef), isRightDiag);
+			};
+
+			const int index = this->voxelGrid.addVoxelDef(makeTypeDVoxelData());
+			this->wallDataMappings.push_back(std::make_pair(map1Voxel, index));
+			return index;
+		}
 	};
 
 	// Write the voxel IDs into the voxel grid.
@@ -1066,7 +1151,7 @@ void LevelData::readMAP1(const BufferView2D<const ArenaTypes::VoxelID> &map1, co
 					// Transparent block with 1-sided texture on all sides, such as wooden 
 					// arches in dungeons. These do not have back-faces (especially when 
 					// standing in the voxel itself).
-					const int dataIndex = getDataIndex(map1Voxel, makeType9VoxelData);
+					const int dataIndex = getType9DataIndex(map1Voxel);
 					this->setVoxel(x, 1, z, dataIndex);
 				}
 				else if (mostSigNibble == 0xA)
@@ -1086,7 +1171,7 @@ void LevelData::readMAP1(const BufferView2D<const ArenaTypes::VoxelID> &map1, co
 				else if (mostSigNibble == 0xB)
 				{
 					// Door voxel.
-					const int dataIndex = getDataIndex(map1Voxel, makeTypeBVoxelData);
+					const int dataIndex = getTypeBDataIndex(map1Voxel);
 					this->setVoxel(x, 1, z, dataIndex);
 				}
 				else if (mostSigNibble == 0xC)
@@ -1097,7 +1182,7 @@ void LevelData::readMAP1(const BufferView2D<const ArenaTypes::VoxelID> &map1, co
 				else if (mostSigNibble == 0xD)
 				{
 					// Diagonal wall. Its type is determined by the nineth bit.
-					const int dataIndex = getDataIndex(map1Voxel, makeTypeDVoxelData);
+					const int dataIndex = getTypeDDataIndex(map1Voxel);
 					this->setVoxel(x, 1, z, dataIndex);
 				}
 			}
@@ -1134,9 +1219,13 @@ void LevelData::readMAP2(const BufferView2D<const ArenaTypes::VoxelID> &map2, co
 		else
 		{
 			const int textureIndex = (map2Voxel & 0x007F) - 1;
-			const int clampedTextureIndex = ArenaVoxelUtils::clampVoxelTextureID(textureIndex);
+			const int clampedTextureID = ArenaVoxelUtils::clampVoxelTextureID(textureIndex);
+			const TextureAssetReference textureAssetRef(
+				ArenaVoxelUtils::getVoxelTextureFilename(clampedTextureID, inf),
+				ArenaVoxelUtils::getVoxelTextureSetIndex(clampedTextureID, inf));
 			const int index = this->voxelGrid.addVoxelDef(VoxelDefinition::makeWall(
-				clampedTextureIndex, clampedTextureIndex, clampedTextureIndex));
+				TextureAssetReference(textureAssetRef), TextureAssetReference(textureAssetRef),
+				TextureAssetReference(textureAssetRef)));
 			this->map2DataMappings.push_back(std::make_pair(map2Voxel, index));
 			return index;
 		}
@@ -1176,8 +1265,11 @@ void LevelData::readCeiling(const INFFile &inf)
 	}();
 
 	// Define the ceiling voxel data.
-	const int index = this->voxelGrid.addVoxelDef(
-		VoxelDefinition::makeCeiling(ArenaVoxelUtils::clampVoxelTextureID(ceilingIndex)));
+	const int clampedTextureID = ArenaVoxelUtils::clampVoxelTextureID(ceilingIndex);
+	TextureAssetReference textureAssetRef(
+		ArenaVoxelUtils::getVoxelTextureFilename(clampedTextureID, inf),
+		ArenaVoxelUtils::getVoxelTextureSetIndex(clampedTextureID, inf));
+	const int index = this->voxelGrid.addVoxelDef(VoxelDefinition::makeCeiling(std::move(textureAssetRef)));
 
 	// Set all the ceiling voxels.
 	const SNInt gridWidth = this->voxelGrid.getWidth();
@@ -1349,8 +1441,11 @@ uint16_t LevelData::getChasmIdFromFadedFloorVoxel(const Int3 &voxel)
 		return chasmIndex.has_value() ? *chasmIndex : 0;
 	}();
 
-	const VoxelDefinition newDef = VoxelDefinition::makeChasm(
-		ArenaVoxelUtils::clampVoxelTextureID(newTextureID), newChasmType);
+	const int clampedTextureID = ArenaVoxelUtils::clampVoxelTextureID(newTextureID);
+	TextureAssetReference textureAssetRef(
+		ArenaVoxelUtils::getVoxelTextureFilename(clampedTextureID, this->inf),
+		ArenaVoxelUtils::getVoxelTextureSetIndex(clampedTextureID, this->inf));
+	const VoxelDefinition newDef = VoxelDefinition::makeChasm(std::move(textureAssetRef), newChasmType);
 
 	// Find matching chasm voxel definition, adding if missing.
 	const std::optional<uint16_t> optChasmID = this->voxelGrid.findVoxelDef(
@@ -1485,6 +1580,10 @@ void LevelData::setActive(bool nightLightsAreActive, const WorldData &worldData,
 	// Loads .INF voxel textures into the renderer.
 	auto loadVoxelTextures = [this, &textureManager, &renderer, &palette]()
 	{
+		// @todo: this should iterate the voxel grid's voxel definitions, get the texture asset reference(s),
+		// allocate VoxelTextureIDs from the renderer, and pair them together.
+		// - instead of iterating the whole .INF file's voxelTextures, just use the VoxelDefinition indices;
+		//   that way, we won't have to worry about extension-less filenames.
 		const auto &voxelTextures = this->inf.getVoxelTextures();
 		const int voxelTextureCount = static_cast<int>(voxelTextures.size());
 		for (int i = 0; i < voxelTextureCount; i++)

--- a/OpenTESArena/src/World/LevelData.cpp
+++ b/OpenTESArena/src/World/LevelData.cpp
@@ -1582,6 +1582,7 @@ void LevelData::setActive(bool nightLightsAreActive, const WorldData &worldData,
 	{
 		// Iterate the voxel grid's voxel definitions, get the texture asset reference(s), and allocate
 		// textures in the renderer.
+		// @todo: avoid allocating duplicate textures (maybe keep a hash set here).
 		const int voxelDefCount = this->voxelGrid.getVoxelDefCount();
 		for (int i = 0; i < voxelDefCount; i++)
 		{

--- a/OpenTESArena/src/World/MapGeneration.cpp
+++ b/OpenTESArena/src/World/MapGeneration.cpp
@@ -312,8 +312,11 @@ namespace MapGeneration
 		// Determine if the floor voxel is either solid or a chasm.
 		if (!MIFUtils::isChasm(textureID))
 		{
-			return VoxelDefinition::makeFloor(
-				ArenaVoxelUtils::clampVoxelTextureID(textureID),
+			const int clampedTextureID = ArenaVoxelUtils::clampVoxelTextureID(textureID);
+			TextureAssetReference textureAssetRef(
+				ArenaVoxelUtils::getVoxelTextureFilename(clampedTextureID, inf),
+				ArenaVoxelUtils::getVoxelTextureSetIndex(clampedTextureID, inf));
+			return VoxelDefinition::makeFloor(std::move(textureAssetRef),
 				ArenaVoxelUtils::isFloorWildWallColored(textureID, mapType));
 		}
 		else
@@ -370,7 +373,11 @@ namespace MapGeneration
 				DebugCrash("Unsupported chasm type \"" + std::to_string(textureID) + "\".");
 			}
 
-			return VoxelDefinition::makeChasm(ArenaVoxelUtils::clampVoxelTextureID(chasmID), chasmType);
+			const int clampedTextureID = ArenaVoxelUtils::clampVoxelTextureID(chasmID);
+			TextureAssetReference textureAssetRef(
+				ArenaVoxelUtils::getVoxelTextureFilename(clampedTextureID, inf),
+				ArenaVoxelUtils::getVoxelTextureSetIndex(clampedTextureID, inf));
+			return VoxelDefinition::makeChasm(std::move(textureAssetRef), chasmType);
 		}
 	}
 
@@ -391,8 +398,12 @@ namespace MapGeneration
 			{
 				// Regular solid wall.
 				const int textureIndex = mostSigByte - 1;
-				const int clampedTextureIndex = ArenaVoxelUtils::clampVoxelTextureID(textureIndex);
-				return VoxelDefinition::makeWall(clampedTextureIndex, clampedTextureIndex, clampedTextureIndex);
+				const int clampedTextureID = ArenaVoxelUtils::clampVoxelTextureID(textureIndex);
+				const TextureAssetReference textureAssetRef(
+					ArenaVoxelUtils::getVoxelTextureFilename(clampedTextureID, inf),
+					ArenaVoxelUtils::getVoxelTextureSetIndex(clampedTextureID, inf));
+				return VoxelDefinition::makeWall(TextureAssetReference(textureAssetRef),
+					TextureAssetReference(textureAssetRef), TextureAssetReference(textureAssetRef));
 			}
 			else
 			{
@@ -486,24 +497,35 @@ namespace MapGeneration
 				const double vTop = std::max(0.0, 1.0 - yOffsetNormalized - ySizeNormalized);
 				const double vBottom = std::min(vTop + ySizeNormalized, 1.0);
 
-				return VoxelDefinition::makeRaised(
-					ArenaVoxelUtils::clampVoxelTextureID(sideID),
-					ArenaVoxelUtils::clampVoxelTextureID(floorID),
-					ArenaVoxelUtils::clampVoxelTextureID(ceilingID),
-					yOffsetNormalized, ySizeNormalized, vTop, vBottom);
+				const int clampedSideID = ArenaVoxelUtils::clampVoxelTextureID(sideID);
+				const int clampedFloorID = ArenaVoxelUtils::clampVoxelTextureID(floorID);
+				const int clampedCeilingID = ArenaVoxelUtils::clampVoxelTextureID(ceilingID);
+				TextureAssetReference sideTextureAssetRef(
+					ArenaVoxelUtils::getVoxelTextureFilename(clampedSideID, inf),
+					ArenaVoxelUtils::getVoxelTextureSetIndex(clampedSideID, inf));
+				TextureAssetReference floorTextureAssetRef(
+					ArenaVoxelUtils::getVoxelTextureFilename(clampedFloorID, inf),
+					ArenaVoxelUtils::getVoxelTextureSetIndex(clampedFloorID, inf));
+				TextureAssetReference ceilingTextureAssetRef(
+					ArenaVoxelUtils::getVoxelTextureFilename(clampedCeilingID, inf),
+					ArenaVoxelUtils::getVoxelTextureSetIndex(clampedCeilingID, inf));
+				return VoxelDefinition::makeRaised(std::move(sideTextureAssetRef), std::move(floorTextureAssetRef),
+					std::move(ceilingTextureAssetRef), yOffsetNormalized, ySizeNormalized, vTop, vBottom);
 			}
 		}
 		else
 		{
 			if (mostSigNibble == 0x9)
 			{
-				// Transparent block with 1-sided texture on all sides, such as wooden arches in
-				// dungeons. These do not have back-faces (especially when standing in the voxel
-				// itself).
+				// Transparent block with 1-sided texture on all sides, such as wooden arches in dungeons.
+				// These do not have back-faces (especially when standing in the voxel itself).
 				const int textureIndex = (map1Voxel & 0x00FF) - 1;
 				const bool collider = (map1Voxel & 0x0100) == 0;
-				return VoxelDefinition::makeTransparentWall(
-					ArenaVoxelUtils::clampVoxelTextureID(textureIndex), collider);
+				const int clampedTextureID = ArenaVoxelUtils::clampVoxelTextureID(textureIndex);
+				TextureAssetReference textureAssetRef(
+					ArenaVoxelUtils::getVoxelTextureFilename(clampedTextureID, inf),
+					ArenaVoxelUtils::getVoxelTextureSetIndex(clampedTextureID, inf));
+				return VoxelDefinition::makeTransparentWall(std::move(textureAssetRef), collider);
 			}
 			else if (mostSigNibble == 0xA)
 			{
@@ -557,8 +579,11 @@ namespace MapGeneration
 					}
 				}();
 
-				return VoxelDefinition::makeEdge(ArenaVoxelUtils::clampVoxelTextureID(textureIndex),
-					yOffset, collider, flipped, facing);
+				const int clampedTextureID = ArenaVoxelUtils::clampVoxelTextureID(textureIndex);
+				TextureAssetReference textureAssetRef(
+					ArenaVoxelUtils::getVoxelTextureFilename(clampedTextureID, inf),
+					ArenaVoxelUtils::getVoxelTextureSetIndex(clampedTextureID, inf));
+				return VoxelDefinition::makeEdge(std::move(textureAssetRef), yOffset, collider, flipped, facing);
 			}
 			else if (mostSigNibble == 0xB)
 			{
@@ -588,7 +613,11 @@ namespace MapGeneration
 					}
 				}();
 
-				return VoxelDefinition::makeDoor(ArenaVoxelUtils::clampVoxelTextureID(textureIndex), doorType);
+				const int clampedTextureID = ArenaVoxelUtils::clampVoxelTextureID(textureIndex);
+				TextureAssetReference textureAssetRef(
+					ArenaVoxelUtils::getVoxelTextureFilename(clampedTextureID, inf),
+					ArenaVoxelUtils::getVoxelTextureSetIndex(clampedTextureID, inf));
+				return VoxelDefinition::makeDoor(std::move(textureAssetRef), doorType);
 			}
 			else if (mostSigNibble == 0xC)
 			{
@@ -601,8 +630,11 @@ namespace MapGeneration
 				// Diagonal wall.
 				const int textureIndex = (map1Voxel & 0x00FF) - 1;
 				const bool isRightDiag = (map1Voxel & 0x0100) == 0;
-				return VoxelDefinition::makeDiagonal(
-					ArenaVoxelUtils::clampVoxelTextureID(textureIndex), isRightDiag);
+				const int clampedTextureID = ArenaVoxelUtils::clampVoxelTextureID(textureIndex);
+				TextureAssetReference textureAssetRef(
+					ArenaVoxelUtils::getVoxelTextureFilename(clampedTextureID, inf),
+					ArenaVoxelUtils::getVoxelTextureSetIndex(clampedTextureID, inf));
+				return VoxelDefinition::makeDiagonal(std::move(textureAssetRef), isRightDiag);
 			}
 			else
 			{
@@ -611,11 +643,15 @@ namespace MapGeneration
 		}
 	}
 
-	VoxelDefinition makeVoxelDefFromMAP2(ArenaTypes::VoxelID map2Voxel)
+	VoxelDefinition makeVoxelDefFromMAP2(ArenaTypes::VoxelID map2Voxel, const INFFile &inf)
 	{
 		const int textureIndex = (map2Voxel & 0x007F) - 1;
-		const int clampedTextureIndex = ArenaVoxelUtils::clampVoxelTextureID(textureIndex);
-		return VoxelDefinition::makeWall(clampedTextureIndex, clampedTextureIndex, clampedTextureIndex);
+		const int clampedTextureID = ArenaVoxelUtils::clampVoxelTextureID(textureIndex);
+		const TextureAssetReference textureAssetRef(
+			ArenaVoxelUtils::getVoxelTextureFilename(clampedTextureID, inf),
+			ArenaVoxelUtils::getVoxelTextureSetIndex(clampedTextureID, inf));
+		return VoxelDefinition::makeWall(TextureAssetReference(textureAssetRef),
+			TextureAssetReference(textureAssetRef), TextureAssetReference(textureAssetRef));
 	}
 
 	LockDefinition makeLockDefFromArenaLock(const ArenaTypes::MIFLock &lock)
@@ -1060,7 +1096,7 @@ namespace MapGeneration
 				}
 				else
 				{
-					VoxelDefinition voxelDef = MapGeneration::makeVoxelDefFromMAP2(map2Voxel);
+					VoxelDefinition voxelDef = MapGeneration::makeVoxelDefFromMAP2(map2Voxel, inf);
 					voxelDefID = outLevelInfoDef->addVoxelDef(std::move(voxelDef));
 					voxelCache->insert(std::make_pair(map2Voxel, voxelDefID));
 				}
@@ -1089,8 +1125,11 @@ namespace MapGeneration
 		// hardcoding index 1 is enough?
 		const int textureIndex = ceiling.textureIndex.value_or(1);
 
-		VoxelDefinition voxelDef = VoxelDefinition::makeCeiling(
-			ArenaVoxelUtils::clampVoxelTextureID(textureIndex));
+		const int clampedTextureID = ArenaVoxelUtils::clampVoxelTextureID(textureIndex);
+		TextureAssetReference textureAssetRef(
+			ArenaVoxelUtils::getVoxelTextureFilename(clampedTextureID, inf),
+			ArenaVoxelUtils::getVoxelTextureSetIndex(clampedTextureID, inf));
+		VoxelDefinition voxelDef = VoxelDefinition::makeCeiling(std::move(textureAssetRef));
 		LevelDefinition::VoxelDefID voxelDefID = outLevelInfoDef->addVoxelDef(std::move(voxelDef));
 
 		for (SNInt levelX = 0; levelX < outLevelDef->getWidth(); levelX++)

--- a/OpenTESArena/src/World/VoxelDefinition.cpp
+++ b/OpenTESArena/src/World/VoxelDefinition.cpp
@@ -165,3 +165,68 @@ bool VoxelDefinition::allowsChasmFace() const
 {
 	return (this->type != VoxelType::None) && (this->type != VoxelType::Chasm);
 }
+
+Buffer<TextureAssetReference> VoxelDefinition::getTextureAssetReferences() const
+{
+	Buffer<TextureAssetReference> buffer;
+
+	if (this->type == VoxelType::None)
+	{
+		// Do nothing.
+	}
+	else if (this->type == VoxelType::Wall)
+	{
+		buffer.init(3);
+		buffer.set(0, this->wall.sideTextureAssetRef);
+		buffer.set(1, this->wall.floorTextureAssetRef);
+		buffer.set(2, this->wall.ceilingTextureAssetRef);
+	}
+	else if (this->type == VoxelType::Floor)
+	{
+		buffer.init(1);
+		buffer.set(0, this->floor.textureAssetRef);
+	}
+	else if (this->type == VoxelType::Ceiling)
+	{
+		buffer.init(1);
+		buffer.set(0, this->ceiling.textureAssetRef);
+	}
+	else if (this->type == VoxelType::Raised)
+	{
+		buffer.init(3);
+		buffer.set(0, this->raised.sideTextureAssetRef);
+		buffer.set(1, this->raised.floorTextureAssetRef);
+		buffer.set(2, this->raised.ceilingTextureAssetRef);
+	}
+	else if (this->type == VoxelType::Diagonal)
+	{
+		buffer.init(1);
+		buffer.set(0, this->diagonal.textureAssetRef);
+	}
+	else if (this->type == VoxelType::TransparentWall)
+	{
+		buffer.init(1);
+		buffer.set(0, this->transparentWall.textureAssetRef);
+	}
+	else if (this->type == VoxelType::Edge)
+	{
+		buffer.init(1);
+		buffer.set(0, this->edge.textureAssetRef);
+	}
+	else if (this->type == VoxelType::Chasm)
+	{
+		buffer.init(1);
+		buffer.set(0, this->chasm.textureAssetRef);
+	}
+	else if (this->type == VoxelType::Door)
+	{
+		buffer.init(1);
+		buffer.set(0, this->door.textureAssetRef);
+	}
+	else
+	{
+		DebugNotImplementedMsg(std::to_string(static_cast<int>(this->type)));
+	}
+
+	return buffer;
+}

--- a/OpenTESArena/src/World/VoxelDefinition.cpp
+++ b/OpenTESArena/src/World/VoxelDefinition.cpp
@@ -5,71 +5,75 @@
 
 #include "components/debug/Debug.h"
 
-void VoxelDefinition::WallData::init(int sideID, int floorID, int ceilingID)
+void VoxelDefinition::WallData::init(TextureAssetReference &&sideTextureAssetRef,
+	TextureAssetReference &&floorTextureAssetRef, TextureAssetReference &&ceilingTextureAssetRef)
 {
-	this->sideID = sideID;
-	this->floorID = floorID;
-	this->ceilingID = ceilingID;
+	this->sideTextureAssetRef = std::move(sideTextureAssetRef);
+	this->floorTextureAssetRef = std::move(floorTextureAssetRef);
+	this->ceilingTextureAssetRef = std::move(ceilingTextureAssetRef);
 }
 
-void VoxelDefinition::FloorData::init(int id, bool isWildWallColored)
+void VoxelDefinition::FloorData::init(TextureAssetReference &&textureAssetRef, bool isWildWallColored)
 {
-	this->id = id;
+	this->textureAssetRef = std::move(textureAssetRef);
 	this->isWildWallColored = isWildWallColored;
 }
 
-void VoxelDefinition::CeilingData::init(int id)
+void VoxelDefinition::CeilingData::init(TextureAssetReference &&textureAssetRef)
 {
-	this->id = id;
+	this->textureAssetRef = std::move(textureAssetRef);
 }
 
-void VoxelDefinition::RaisedData::init(int sideID, int floorID, int ceilingID, double yOffset, double ySize,
-	double vTop, double vBottom)
+void VoxelDefinition::RaisedData::init(TextureAssetReference &&sideTextureAssetRef,
+	TextureAssetReference &&floorTextureAssetRef, TextureAssetReference &&ceilingTextureAssetRef,
+	double yOffset, double ySize, double vTop, double vBottom)
 {
-	this->sideID = sideID;
-	this->floorID = floorID;
-	this->ceilingID = ceilingID;
+	this->sideTextureAssetRef = std::move(sideTextureAssetRef);
+	this->floorTextureAssetRef = std::move(floorTextureAssetRef);
+	this->ceilingTextureAssetRef = std::move(ceilingTextureAssetRef);
 	this->yOffset = yOffset;
 	this->ySize = ySize;
 	this->vTop = vTop;
 	this->vBottom = vBottom;
 }
 
-void VoxelDefinition::DiagonalData::init(int id, bool type1)
+void VoxelDefinition::DiagonalData::init(TextureAssetReference &&textureAssetRef, bool type1)
 {
-	this->id = id;
+	this->textureAssetRef = std::move(textureAssetRef);
 	this->type1 = type1;
 }
 
-void VoxelDefinition::TransparentWallData::init(int id, bool collider)
+void VoxelDefinition::TransparentWallData::init(TextureAssetReference &&textureAssetRef, bool collider)
 {
-	this->id = id;
+	this->textureAssetRef = std::move(textureAssetRef);
 	this->collider = collider;
 }
 
-void VoxelDefinition::EdgeData::init(int id, double yOffset, bool collider, bool flipped, VoxelFacing2D facing)
+void VoxelDefinition::EdgeData::init(TextureAssetReference &&textureAssetRef, double yOffset, bool collider,
+	bool flipped, VoxelFacing2D facing)
 {
-	this->id = id;
+	this->textureAssetRef = std::move(textureAssetRef);
 	this->yOffset = yOffset;
 	this->collider = collider;
 	this->flipped = flipped;
 	this->facing = facing;
 }
 
-void VoxelDefinition::ChasmData::init(int id, Type type)
+void VoxelDefinition::ChasmData::init(TextureAssetReference &&textureAssetRef, Type type)
 {
-	this->id = id;
+	this->textureAssetRef = std::move(textureAssetRef);
 	this->type = type;
 }
 
 bool VoxelDefinition::ChasmData::matches(const ChasmData &other) const
 {
-	return (this->id == other.id) && (this->type == other.type);
+	return (this->textureAssetRef.filename == other.textureAssetRef.filename) &&
+		(this->textureAssetRef.index == other.textureAssetRef.index) && (this->type == other.type);
 }
 
-void VoxelDefinition::DoorData::init(int id, Type type)
+void VoxelDefinition::DoorData::init(TextureAssetReference &&textureAssetRef, Type type)
 {
-	this->id = id;
+	this->textureAssetRef = std::move(textureAssetRef);
 	this->type = type;
 }
 
@@ -79,77 +83,81 @@ VoxelDefinition::VoxelDefinition()
 	this->type = VoxelType::None;
 }
 
-VoxelDefinition VoxelDefinition::makeWall(int sideID, int floorID, int ceilingID)
+VoxelDefinition VoxelDefinition::makeWall(TextureAssetReference &&sideTextureAssetRef,
+	TextureAssetReference &&floorTextureAssetRef, TextureAssetReference &&ceilingTextureAssetRef)
 {
 	VoxelDefinition voxelDef;
 	voxelDef.type = VoxelType::Wall;
-	voxelDef.wall.init(sideID, floorID, ceilingID);
+	voxelDef.wall.init(std::move(sideTextureAssetRef), std::move(floorTextureAssetRef), 
+		std::move(ceilingTextureAssetRef));
 	return voxelDef;
 }
 
-VoxelDefinition VoxelDefinition::makeFloor(int id, bool isWildWallColored)
+VoxelDefinition VoxelDefinition::makeFloor(TextureAssetReference &&textureAssetRef, bool isWildWallColored)
 {
 	VoxelDefinition voxelDef;
 	voxelDef.type = VoxelType::Floor;
-	voxelDef.floor.init(id, isWildWallColored);
+	voxelDef.floor.init(std::move(textureAssetRef), isWildWallColored);
 	return voxelDef;
 }
 
-VoxelDefinition VoxelDefinition::makeCeiling(int id)
+VoxelDefinition VoxelDefinition::makeCeiling(TextureAssetReference &&textureAssetRef)
 {
 	VoxelDefinition voxelDef;
 	voxelDef.type = VoxelType::Ceiling;
-	voxelDef.ceiling.init(id);
+	voxelDef.ceiling.init(std::move(textureAssetRef));
 	return voxelDef;
 }
 
-VoxelDefinition VoxelDefinition::makeRaised(int sideID, int floorID, int ceilingID, double yOffset,
-	double ySize, double vTop, double vBottom)
+VoxelDefinition VoxelDefinition::makeRaised(TextureAssetReference &&sideTextureAssetRef,
+	TextureAssetReference &&floorTextureAssetRef, TextureAssetReference &&ceilingTextureAssetRef,
+	double yOffset, double ySize, double vTop, double vBottom)
 {
 	VoxelDefinition voxelDef;
 	voxelDef.type = VoxelType::Raised;
-	voxelDef.raised.init(sideID, floorID, ceilingID, yOffset, ySize, vTop, vBottom);
+	voxelDef.raised.init(std::move(sideTextureAssetRef), std::move(floorTextureAssetRef), 
+		std::move(ceilingTextureAssetRef), yOffset, ySize, vTop, vBottom);
 	return voxelDef;
 }
 
-VoxelDefinition VoxelDefinition::makeDiagonal(int id, bool type1)
+VoxelDefinition VoxelDefinition::makeDiagonal(TextureAssetReference &&textureAssetRef, bool type1)
 {
 	VoxelDefinition voxelDef;
 	voxelDef.type = VoxelType::Diagonal;
-	voxelDef.diagonal.init(id, type1);
+	voxelDef.diagonal.init(std::move(textureAssetRef), type1);
 	return voxelDef;
 }
 
-VoxelDefinition VoxelDefinition::makeTransparentWall(int id, bool collider)
+VoxelDefinition VoxelDefinition::makeTransparentWall(TextureAssetReference &&textureAssetRef, bool collider)
 {
 	VoxelDefinition voxelDef;
 	voxelDef.type = VoxelType::TransparentWall;
-	voxelDef.transparentWall.init(id, collider);
+	voxelDef.transparentWall.init(std::move(textureAssetRef), collider);
 	return voxelDef;
 }
 
-VoxelDefinition VoxelDefinition::makeEdge(int id, double yOffset, bool collider,
+VoxelDefinition VoxelDefinition::makeEdge(TextureAssetReference &&textureAssetRef, double yOffset, bool collider,
 	bool flipped, VoxelFacing2D facing)
 {
 	VoxelDefinition voxelDef;
 	voxelDef.type = VoxelType::Edge;
-	voxelDef.edge.init(id, yOffset, collider, flipped, facing);
+	voxelDef.edge.init(std::move(textureAssetRef), yOffset, collider, flipped, facing);
 	return voxelDef;
 }
 
-VoxelDefinition VoxelDefinition::makeChasm(int id, ChasmData::Type type)
+VoxelDefinition VoxelDefinition::makeChasm(TextureAssetReference &&textureAssetRef, ChasmData::Type type)
 {
 	VoxelDefinition voxelDef;
 	voxelDef.type = VoxelType::Chasm;
-	voxelDef.chasm.init(id, type);
+	voxelDef.chasm.init(std::move(textureAssetRef), type);
 	return voxelDef;
 }
 
-VoxelDefinition VoxelDefinition::makeDoor(int id, DoorData::Type type)
+VoxelDefinition VoxelDefinition::makeDoor(TextureAssetReference &&textureAssetRef, DoorData::Type type)
 {
 	VoxelDefinition voxelDef;
 	voxelDef.type = VoxelType::Door;
-	voxelDef.door.init(id, type);
+	voxelDef.door.init(std::move(textureAssetRef), type);
 	return voxelDef;
 }
 

--- a/OpenTESArena/src/World/VoxelDefinition.h
+++ b/OpenTESArena/src/World/VoxelDefinition.h
@@ -3,6 +3,8 @@
 
 #include "../Assets/TextureAssetReference.h"
 
+#include "components/utilities/Buffer.h"
+
 // The definition that a voxel ID points to, used for rendering, collision detection, and coloring automap voxels.
 
 enum class VoxelFacing2D;
@@ -146,6 +148,9 @@ public:
 
 	// Whether this voxel definition contributes to a chasm having a wall face.
 	bool allowsChasmFace() const;
+
+	// Gets all the texture asset references from the voxel definition based on its type.
+	Buffer<TextureAssetReference> getTextureAssetReferences() const;
 };
 
 #endif

--- a/OpenTESArena/src/World/VoxelDefinition.h
+++ b/OpenTESArena/src/World/VoxelDefinition.h
@@ -1,15 +1,10 @@
 #ifndef VOXEL_DEFINITION_H
 #define VOXEL_DEFINITION_H
 
-#include "../Media/TextureUtils.h"
+#include "../Assets/TextureAssetReference.h"
 
-// The definition of a voxel that a voxel ID points to. Since there will only be a few kinds
-// of voxels per world, their size can be much larger than just a byte or two.
+// The definition that a voxel ID points to, used for rendering, collision detection, and coloring automap voxels.
 
-// A voxel's definition is used for several things, such as rendering, collision detection,
-// and coloring on the automap.
-
-enum class MapType;
 enum class VoxelFacing2D;
 enum class VoxelType;
 
@@ -19,64 +14,66 @@ public:
 	// Regular wall with height equal to ceiling height.
 	struct WallData
 	{
-		int sideID, floorID, ceilingID;
+		TextureAssetReference sideTextureAssetRef, floorTextureAssetRef, ceilingTextureAssetRef;
 
-		void init(int sideID, int floorID, int ceilingID);
+		void init(TextureAssetReference &&sideTextureAssetRef, TextureAssetReference &&floorTextureAssetRef,
+			TextureAssetReference &&ceilingTextureAssetRef);
 	};
 
 	// Floors only have their top rendered.
 	struct FloorData
 	{
-		int id;
+		TextureAssetReference textureAssetRef;
 
 		// Wild automap floor coloring to make roads, etc. easier to see.
 		bool isWildWallColored;
 
-		void init(int id, bool isWildWallColored);
+		void init(TextureAssetReference &&textureAssetRef, bool isWildWallColored);
 	};
 
 	// Ceilings only have their bottom rendered.
 	struct CeilingData
 	{
-		int id;
+		TextureAssetReference textureAssetRef;
 
-		void init(int id);
+		void init(TextureAssetReference &&textureAssetRef);
 	};
 
 	// Raised platform at some Y offset in the voxel.
 	struct RaisedData
 	{
-		int sideID, floorID, ceilingID;
+		TextureAssetReference sideTextureAssetRef, floorTextureAssetRef, ceilingTextureAssetRef;
 		double yOffset, ySize, vTop, vBottom;
 
-		void init(int sideID, int floorID, int ceilingID, double yOffset, double ySize,
-			double vTop, double vBottom);
+		void init(TextureAssetReference &&sideTextureAssetRef, TextureAssetReference &&floorTextureAssetRef,
+			TextureAssetReference &&ceilingTextureAssetRef, double yOffset, double ySize, double vTop,
+			double vBottom);
 	};
 
 	// Diagonal wall with variable start and end corners.
 	struct DiagonalData
 	{
-		int id;
+		TextureAssetReference textureAssetRef;
 		bool type1; // Type 1 is '/', (nearX, nearZ) -> (farX, farZ).
 
-		void init(int id, bool type1);
+		void init(TextureAssetReference &&textureAssetRef, bool type1);
 	};
 
 	// Transparent walls only shows front-facing textures (wooden arches, hedges, etc.).
 	// Nothing is drawn when the player is in the same voxel.
 	struct TransparentWallData
 	{
-		int id;
+		TextureAssetReference textureAssetRef;
 		bool collider; // Also affects automap visibility.
 
-		void init(int id, bool collider);
+		void init(TextureAssetReference &&textureAssetRef, bool collider);
 	};
 
 	// Rendered on one edge of a voxel with height equal to ceiling height. The facing determines
 	// which side the edge is on.
 	struct EdgeData
 	{
-		int id;
+		TextureAssetReference textureAssetRef;
 		double yOffset;
 		bool collider;
 
@@ -86,7 +83,8 @@ public:
 
 		VoxelFacing2D facing;
 
-		void init(int id, double yOffset, bool collider, bool flipped, VoxelFacing2D facing);
+		void init(TextureAssetReference &&textureAssetRef, double yOffset, bool collider, bool flipped,
+			VoxelFacing2D facing);
 	};
 
 	// Chasms have zero to four wall faces (stored with voxel instance) depending on adjacent floors.
@@ -95,10 +93,10 @@ public:
 	{
 		enum class Type { Dry, Wet, Lava };
 
-		int id;
+		TextureAssetReference textureAssetRef;
 		Type type;
 
-		void init(int id, Type type);
+		void init(TextureAssetReference &&textureAssetRef, Type type);
 
 		bool matches(const ChasmData &other) const;
 	};
@@ -109,40 +107,42 @@ public:
 		// Splitting doors are unused in the original game.
 		enum class Type { Swinging, Sliding, Raising, Splitting };
 
-		int id;
+		TextureAssetReference textureAssetRef;
 		Type type;
 
-		void init(int id, Type type);
+		void init(TextureAssetReference &&textureAssetRef, Type type);
 	};
 
-	VoxelType type; // Defines how the voxel is interpreted and rendered.
+	// Determines how the voxel definition is accessed.
+	VoxelType type;
 
-	// Only one voxel data type can be active at a time, given by "type".
-	union
-	{
-		WallData wall;
-		FloorData floor;
-		CeilingData ceiling;
-		RaisedData raised;
-		DiagonalData diagonal;
-		TransparentWallData transparentWall;
-		EdgeData edge;
-		ChasmData chasm;
-		DoorData door;
-	};
+	// Only one voxel type can be active at a time, given by "type". No longer a union due to the
+	// added complexity of texture asset references.
+	WallData wall;
+	FloorData floor;
+	CeilingData ceiling;
+	RaisedData raised;
+	DiagonalData diagonal;
+	TransparentWallData transparentWall;
+	EdgeData edge;
+	ChasmData chasm;
+	DoorData door;
 
 	VoxelDefinition();
 
-	static VoxelDefinition makeWall(int sideID, int floorID, int ceilingID);
-	static VoxelDefinition makeFloor(int id, bool isWildWallColored);
-	static VoxelDefinition makeCeiling(int id);
-	static VoxelDefinition makeRaised(int sideID, int floorID, int ceilingID, double yOffset,
-		double ySize, double vTop, double vBottom);
-	static VoxelDefinition makeDiagonal(int id, bool type1);
-	static VoxelDefinition makeTransparentWall(int id, bool collider);
-	static VoxelDefinition makeEdge(int id, double yOffset, bool collider, bool flipped, VoxelFacing2D facing);
-	static VoxelDefinition makeChasm(int id, ChasmData::Type type);
-	static VoxelDefinition makeDoor(int id, DoorData::Type type);
+	static VoxelDefinition makeWall(TextureAssetReference &&sideTextureAssetRef,
+		TextureAssetReference &&floorTextureAssetRef, TextureAssetReference &&ceilingTextureAssetRef);
+	static VoxelDefinition makeFloor(TextureAssetReference &&textureAssetRef, bool isWildWallColored);
+	static VoxelDefinition makeCeiling(TextureAssetReference &&textureAssetRef);
+	static VoxelDefinition makeRaised(TextureAssetReference &&sideTextureAssetRef,
+		TextureAssetReference &&floorTextureAssetRef, TextureAssetReference &&ceilingTextureAssetRef,
+		double yOffset, double ySize, double vTop, double vBottom);
+	static VoxelDefinition makeDiagonal(TextureAssetReference &&textureAssetRef, bool type1);
+	static VoxelDefinition makeTransparentWall(TextureAssetReference &&textureAssetRef, bool collider);
+	static VoxelDefinition makeEdge(TextureAssetReference &&textureAssetRef, double yOffset, bool collider,
+		bool flipped, VoxelFacing2D facing);
+	static VoxelDefinition makeChasm(TextureAssetReference &&textureAssetRef, ChasmData::Type type);
+	static VoxelDefinition makeDoor(TextureAssetReference &&textureAssetRef, DoorData::Type type);
 
 	// Whether this voxel definition contributes to a chasm having a wall face.
 	bool allowsChasmFace() const;

--- a/OpenTESArena/src/World/VoxelGrid.cpp
+++ b/OpenTESArena/src/World/VoxelGrid.cpp
@@ -50,6 +50,11 @@ uint16_t VoxelGrid::getVoxel(SNInt x, int y, WEInt z) const
 	return this->voxels.data()[index];
 }
 
+int VoxelGrid::getVoxelDefCount() const
+{
+	return static_cast<int>(this->voxelDefs.size());
+}
+
 VoxelDefinition &VoxelGrid::getVoxelDef(uint16_t id)
 {
 	DebugAssertIndex(this->voxelDefs, id);

--- a/OpenTESArena/src/World/VoxelGrid.h
+++ b/OpenTESArena/src/World/VoxelGrid.h
@@ -43,6 +43,8 @@ public:
 	// Convenience method for getting a voxel's ID.
 	uint16_t getVoxel(SNInt x, int y, WEInt z) const;
 
+	int getVoxelDefCount() const;
+
 	// Gets the voxel definitions associated with an ID.
 	VoxelDefinition &getVoxelDef(uint16_t id);
 	const VoxelDefinition &getVoxelDef(uint16_t id) const;


### PR DESCRIPTION
Previously, all SoftwareRenderer voxel textures were positioned in storage relative to VoxelDefinition integer IDs, but that seemed too tightly-coupled with the original game's limitations. Now all VoxelDefinitions have their textures defined by a filename and optional index if the texture file has a set of textures. This also allows the textures to be loaded right when they're needed by the renderer instead of sitting in the texture manager long before any system uses them.

Ideally, the renderer would be given a texture builder for each texture and would return an allocated texture handle to use with all instance geometry that reference that renderer texture, but there needs to be more refactoring/redesign done first to support instance geometry.