### PR TITLE
SoftwareRenderer: Fix data race on flats.threadsDone

### DIFF
--- a/OpenTESArena/src/Rendering/SoftwareRenderer.cpp
+++ b/OpenTESArena/src/Rendering/SoftwareRenderer.cpp
@@ -7856,17 +7856,9 @@ void SoftwareRenderer::renderThreadLoop(RenderThreadData &threadData, int thread
 			{
 				lk.unlock();
 				threadData.condVar.notify_all();
+				return;
 			}
-			else
-			{
-				// Wait for other threads to finish.
-				threadData.condVar.wait(lk, [&threadData, &data]()
-				{
-					return data.threadsDone == threadData.totalThreads;
-				});
-
-				lk.unlock();
-			}
+			lk.unlock();
 		};
 
 		// Draw this thread's portion of the sky gradient.


### PR DESCRIPTION
When the last render thread notify that flats are drawn, the main thread
have time to loop on and init flats again before others render threads
have time to do their own checks and continue, so they stay waiting
because flats.threadsDone was init to 0 again.

Remove the wait is safe because the first render threads to finish will
wait on the threadData.go already to false.