### PR TITLE
New CMake configuration types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ ELSEIF (CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang") # GCC
     #SET(CMAKE_CXX_FLAGS_RELEASENATIVE "${CMAKE_CXX_FLAGS_RELEASENATIVE} -mfpu=neon")
 
     # Sanitizers (can affect performance).
-    SET(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=address")
+    #SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
     #SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=thread")
     #SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=undefined")
 ENDIF ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ set(CMAKE_CXX_EXTENSIONS ON)
 # Replace default configurations (Debug/Release/RelWithDebInfo/MinSizeRel) with custom ones.
 # - Debug: maximum debugging
 # - DebugFast: like Debug but for typical development
-# - ReleaseGeneric: distributed at project releases, works with most CPUs
+# - ReleaseGeneric: distributed at project releases, works with the most CPUs
 # - ReleaseNative: maximum performance for the computer it's compiled on
 set(CMAKE_CONFIGURATION_TYPES "Debug;DebugFast;ReleaseGeneric;ReleaseNative" CACHE STRING "" FORCE)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,46 +13,56 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS ON)
 
-# Configure for GNU Compiler (also affects MSYS2). Use "MATCHES" instead of "STREQUAL"
-# to cover both Clang and AppleClang.
-IF (CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    # To use std::thread and friends, we must pass -lpthread and -pthread to the compiler and Linker for GCC
+# Replace default configurations (Debug/Release/RelWithDebInfo/MinSizeRel) with custom ones.
+# - Debug: maximum debugging
+# - DebugFast: like Debug but for typical development
+# - ReleaseGeneric: distributed at project releases, works with most CPUs
+# - ReleaseNative: maximum performance for the computer it's compiled on
+set(CMAKE_CONFIGURATION_TYPES "Debug;DebugFast;ReleaseGeneric;ReleaseNative" CACHE STRING "" FORCE)
+
+# CMake-required flags for new configurations.
+SET(CMAKE_EXE_LINKER_FLAGS_DEBUGFAST "${CMAKE_EXE_LINKER_FLAGS_DEBUG}")
+SET(CMAKE_EXE_LINKER_FLAGS_RELEASEGENERIC "${CMAKE_EXE_LINKER_FLAGS_RELEASE}")
+SET(CMAKE_EXE_LINKER_FLAGS_RELEASENATIVE "${CMAKE_EXE_LINKER_FLAGS_RELEASE}")
+
+# Compiler settings (optimizations, debugging, etc.)
+IF (MSVC)
+    # Multi-processor compilation.
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
+
+    # Add custom debug flags to DebugFast (/RTCs and /RTCu are not compatible with /Ox).
+    SET(CMAKE_CXX_FLAGS_DEBUGFAST "/DEBUG /Zi /MDd /Ox /Ob0")
+    SET(CMAKE_RC_FLAGS_DEBUGFAST "${CMAKE_RC_FLAGS_DEBUG}")
+
+    # Add various optimizations to release builds.
+    SET(CMAKE_CXX_FLAGS_RELEASEGENERIC "/O2 /Ob2 /Oi /Ot /Oy /GL /fp:fast")
+    SET(CMAKE_CXX_FLAGS_RELEASENATIVE "${CMAKE_CXX_FLAGS_RELEASEGENERIC}")
+    #SET(CMAKE_CXX_FLAGS_RELEASENATIVE "${CMAKE_CXX_FLAGS_RELEASENATIVE} /arch:AVX2")
+    SET(CMAKE_EXE_LINKER_FLAGS_RELEASEGENERIC "${CMAKE_EXE_LINKER_FLAGS_RELEASEGENERIC} /LTCG")
+    SET(CMAKE_EXE_LINKER_FLAGS_RELEASENATIVE "${CMAKE_EXE_LINKER_FLAGS_RELEASEGENERIC}")
+ELSEIF (CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang") # GCC, {Apple}Clang, MSYS2.
+    # To use std::thread and friends, we must pass -lpthread and -pthread to the compiler and Linker for GCC.
     IF (NOT WIN32 AND NOT APPLE)
-        SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pthread")
         SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
         SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lpthread -pthread")
     ENDIF ()
 
-    # Keep debug info.
-    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
+    # Debug builds.
+    SET(CMAKE_CXX_FLAGS_DEBUG "-g")
+    SET(CMAKE_CXX_FLAGS_DEBUGFAST "-g -Og")
 
-    # Optimizations. These settings are meant to work with a variety of CPUs.
-    # Modify for your personal build if desired.
-    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
-    #SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Ofast")
-    #SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -flto")
-    #SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
-    #SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse4.1")
-    #SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx")
-    #SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mfpu=neon")
+    # Generic release build (works with a variety of CPUs).
+    SET(CMAKE_CXX_FLAGS_RELEASEGENERIC "-g -O3 -flto")
 
-    # Sanitizers (some can affect performance).
-    #SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
+    # Native release build for the computer compiling it.
+    SET(CMAKE_CXX_FLAGS_RELEASENATIVE "-g -Ofast -flto -march=native")
+    #SET(CMAKE_CXX_FLAGS_RELEASENATIVE "${CMAKE_CXX_FLAGS_RELEASENATIVE} -mavx")
+    #SET(CMAKE_CXX_FLAGS_RELEASENATIVE "${CMAKE_CXX_FLAGS_RELEASENATIVE} -mfpu=neon")
+
+    # Sanitizers (can affect performance).
+    SET(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=address")
     #SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=thread")
     #SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=undefined")
-ENDIF ()
-
-# We want RelWithDebInfo to actually include debug stuff (define _DEBUG
-# instead of NDEBUG)
-FOREACH(flag_var CMAKE_C_FLAGS_RELWITHDEBINFO CMAKE_CXX_FLAGS_RELWITHDEBINFO)
-    IF(${flag_var} MATCHES "-DNDEBUG")
-        STRING(REGEX REPLACE "-DNDEBUG" "-D_DEBUG" ${flag_var} "${${flag_var}}")
-    ENDIF()
-ENDFOREACH()
-
-IF (MSVC)
-    # Add multi-processor compilation.
-    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
 ENDIF ()
 
 ADD_SUBDIRECTORY(components)

--- a/OpenTESArena/CMakeLists.txt
+++ b/OpenTESArena/CMakeLists.txt
@@ -106,6 +106,10 @@ IF (NOT APPLE)
     FILE(COPY ${TES_DATA_FOLDER} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
     FILE(COPY ${TES_OPTIONS_FOLDER} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
+    # @todo: probably need to add some post-build command here for data/options folders for
+    # the folder the executable goes into. This is necessary on MSVC and Linux/Raspberry Pi.
+    # The destination is probably ${OpenTESArena_BINARY_DIR}.
+
     # Add the rest
     ADD_EXECUTABLE(TESArena ${TES_SOURCES} ${TES_WIN32_RESOURCES})
 ELSE (APPLE)

--- a/README.md
+++ b/README.md
@@ -109,17 +109,19 @@ If you would like to use a different sound patches library like OPL3, edit `Midi
 - [WildMIDI 0.4.3](https://github.com/Mindwerks/wildmidi/releases) (optional; required for music)
 
 ### Building the executable
-- Create a `build` folder in the project's top-level directory.
-- Use CMake to generate your project files in `build`. In a Unix terminal, the command might look like:
-```bash
-cd build
-cmake ..
-make -j4
-```
-- Other user-specific parameters may be necessary for CMake depending on your IDE.
+- Navigate to the root of the repository
+- Use CMake to generate your project file (Visual Studio .sln, Unix Makefile, etc.). In a Unix terminal, the commands might look like:
+    ```bash
+    mkdir build
+    cd build
+    cmake -DCMAKE_BUILD_TYPE=<?> ..
+    make -j8
+    ```
+    where `CMAKE_BUILD_TYPE` is one of `Debug`|`DebugFast`|`ReleaseGeneric`|`ReleaseNative`. For maximum optimizations, `ReleaseNative` should be used.
+- Other parameters for CMake may be necessary depending on the IDE you are using.
 
 ### Running the executable
-- Verify that the `data` and `options` folders are in the same folder as the executable. If not, then copy them from the project's root folder.
+- Verify that the `data` and `options` folders are in the same folder as the executable. If not, then copy them from the project's root folder (this should be fixed in the future with a post-build command).
 - Make sure that `MidiConfig` and `ArenaPath` in the options file point to valid locations on your computer (i.e., `data/eawpats/timidity.cfg` and `data/ARENA` respectively).
 
 If you struggle, here are some more detailed guides:


### PR DESCRIPTION
This branch replaces 
```
Debug
Release
RelWithDebInfo
MinSizeRel
```
with
```
Debug
DebugFast
ReleaseGeneric
ReleaseNative
```
`Debug` is like it used to be. `DebugFast` is like `Debug` but slightly faster for typical development. `ReleaseGeneric` is for distribution at project releases. `ReleaseNative` enables maximum code optimizations for the machine it's compiling on.