### PR TITLE
Using shield icons for readme info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # OpenTESArena
 
 [![GitHub release](https://img.shields.io/github/release/afritz1/OpenTESArena/all.svg)](https://github.com/afritz1/banner/OpenTESArena/latest)
-[![GitHub](https://img.shields.io/github/license/afritz1/OpenTESArena)](https://github.com/afritz1/OpenTESArena/blob/master/LICENSE.txt)
+[![MIT License](https://img.shields.io/badge/license-MIT-green)](LICENSE.txt) 
 [![Discord](https://img.shields.io/discord/395739926831824908.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/DgHe2jG)
 [![YouTube Channel Views](https://img.shields.io/youtube/channel/views/UCJpmkgtHRIxR7aOpi909GKw)](https://www.youtube.com/channel/UCJpmkgtHRIxR7aOpi909GKw)
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # OpenTESArena
 
-This open-source project aims to be a modern engine re-implementation for "The Elder Scrolls: Arena" from 1994 by Bethesda Softworks. It is written in C++17 and uses SDL2, WildMIDI for music, and OpenAL Soft for sound and mixing. There is support for Windows, Linux, and macOS.
+[![GitHub release](https://img.shields.io/github/release/afritz1/OpenTESArena/all.svg)](https://github.com/afritz1/banner/OpenTESArena/latest) [![GitHub](https://img.shields.io/github/license/afritz1/OpenTESArena)](https://github.com/afritz1/OpenTESArena/blob/master/LICENSE.txt) [![Discord](https://img.shields.io/discord/395739926831824908.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/DgHe2jG) [![YouTube Channel Views](https://img.shields.io/youtube/channel/views/UCJpmkgtHRIxR7aOpi909GKw)](https://www.youtube.com/channel/UCJpmkgtHRIxR7aOpi909GKw)
 
-- Version: 0.13.0
-- License: MIT
-- Discord: https://discord.gg/DgHe2jG
+
+This open-source project aims to be a modern engine re-implementation for "The Elder Scrolls: Arena" from 1994 by Bethesda Softworks. It is written in C++17 and uses SDL2, WildMIDI for music, and OpenAL Soft for sound and mixing. There is support for Windows, Linux, and macOS.
 
 ## Current status [![Build Status](https://travis-ci.org/afritz1/OpenTESArena.svg?branch=master)](https://travis-ci.org/afritz1/OpenTESArena)
 
@@ -136,5 +135,3 @@ If there is a bug or technical problem in the program, check out the issues tab!
 ## Resources
 
 The [Unofficial Elder Scrolls Pages](http://en.uesp.net/wiki/Arena:Arena) are a great resource for information all about Arena. [Various tools](http://en.uesp.net/wiki/Arena:Files#Misc_Utilities) like WinArena and BSATool allow for browsing Arena's content, and there is a very detailed [manual](http://en.uesp.net/wiki/Arena:Files#Official_Patches_and_Utilities) as well. I also recommend the [Lazy Game Review](https://www.youtube.com/watch?v=5MW5SxKMrtE) on YouTube for a humorous overview of the game's history and gameplay.
-
-Project YouTube channel: https://www.youtube.com/channel/UCJpmkgtHRIxR7aOpi909GKw

--- a/README.md
+++ b/README.md
@@ -36,8 +36,6 @@ Inspired by [OpenXcom](http://openxcom.org/) and [OpenMW](http://openmw.org/en/)
 
 There are two versions of Arena: the floppy disk version (which Bethesda released for free) and the CD version. The user must acquire their own copy of Arena because OpenTESArena is a standalone engine and does not contain content.
 
-OpenTESArena is [MIT-licensed](LICENSE.txt).
-
 Check out [CONTRIBUTING.md](CONTRIBUTING.md) for more details on how to assist with development.
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # OpenTESArena
 
-[![GitHub release](https://img.shields.io/github/release/afritz1/OpenTESArena/all.svg)](https://github.com/afritz1/banner/OpenTESArena/latest) [![GitHub](https://img.shields.io/github/license/afritz1/OpenTESArena)](https://github.com/afritz1/OpenTESArena/blob/master/LICENSE.txt) [![Discord](https://img.shields.io/discord/395739926831824908.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/DgHe2jG) [![YouTube Channel Views](https://img.shields.io/youtube/channel/views/UCJpmkgtHRIxR7aOpi909GKw)](https://www.youtube.com/channel/UCJpmkgtHRIxR7aOpi909GKw)
-
+[![GitHub release](https://img.shields.io/github/release/afritz1/OpenTESArena/all.svg)](https://github.com/afritz1/banner/OpenTESArena/latest)
+[![GitHub](https://img.shields.io/github/license/afritz1/OpenTESArena)](https://github.com/afritz1/OpenTESArena/blob/master/LICENSE.txt)
+[![Discord](https://img.shields.io/discord/395739926831824908.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/DgHe2jG)
+[![YouTube Channel Views](https://img.shields.io/youtube/channel/views/UCJpmkgtHRIxR7aOpi909GKw)](https://www.youtube.com/channel/UCJpmkgtHRIxR7aOpi909GKw)
 
 This open-source project aims to be a modern engine re-implementation for "The Elder Scrolls: Arena" from 1994 by Bethesda Softworks. It is written in C++17 and uses SDL2, WildMIDI for music, and OpenAL Soft for sound and mixing. There is support for Windows, Linux, and macOS.
 


### PR DESCRIPTION
Moving version, license, Discord, and YouTube info into shields.

<img width="606" alt="Shields" src="https://user-images.githubusercontent.com/6200170/123198293-74733680-d472-11eb-8cab-9124134e7323.png">

Note that Discord won't work unless [the Widget setting on the server is enabled](https://vimeo.com/364220040).