### PR TITLE
#188 - provide read only BufferViews

### DIFF
--- a/OpenTESArena/src/Assets/LGTFile.cpp
+++ b/OpenTESArena/src/Assets/LGTFile.cpp
@@ -26,9 +26,9 @@ bool LGTFile::init(const char *filename)
 	return true;
 }
 
-BufferView<const uint8_t> LGTFile::getLightPalette(int index) const
+BufferViewReadOnly<uint8_t> LGTFile::getLightPalette(int index) const
 {
 	DebugAssert(index < LGTFile::PALETTE_COUNT);
 	const uint8_t *ptr = this->palettes.get() + (index * this->palettes.getWidth());
-	return BufferView(ptr, LGTFile::ELEMENTS_PER_PALETTE);
+	return BufferViewReadOnly(ptr, LGTFile::ELEMENTS_PER_PALETTE);
 }

--- a/OpenTESArena/src/Assets/LGTFile.h
+++ b/OpenTESArena/src/Assets/LGTFile.h
@@ -4,7 +4,7 @@
 #include <cstdint>
 
 #include "components/utilities/Buffer2D.h"
-#include "components/utilities/BufferView.h"
+#include "components/utilities/BufferViewReadOnly.h"
 
 // Light level file, contains 13 light palettes for shading/transparencies.
 
@@ -20,7 +20,7 @@ public:
 
 	bool init(const char *filename);
 
-	BufferView<const uint8_t> getLightPalette(int index) const;
+	BufferViewReadOnly<uint8_t> getLightPalette(int index) const;
 };
 
 #endif

--- a/OpenTESArena/src/Assets/MIFFile.cpp
+++ b/OpenTESArena/src/Assets/MIFFile.cpp
@@ -378,39 +378,39 @@ BufferView2D<const ArenaTypes::VoxelID> MIFFile::Level::getMAP2() const
 		this->map2.get(), this->map2.getWidth(), this->map2.getHeight());
 }
 
-BufferView<const uint8_t> MIFFile::Level::getFLAT() const
+BufferViewReadOnly<uint8_t> MIFFile::Level::getFLAT() const
 {
-	return BufferView<const uint8_t>(this->flat.data(), static_cast<int>(this->flat.size()));
+	return BufferViewReadOnly<uint8_t>(this->flat.data(), static_cast<int>(this->flat.size()));
 }
 
-BufferView<const uint8_t> MIFFile::Level::getINNS() const
+BufferViewReadOnly<uint8_t> MIFFile::Level::getINNS() const
 {
-	return BufferView<const uint8_t>(this->inns.data(), static_cast<int>(this->inns.size()));
+	return BufferViewReadOnly<uint8_t>(this->inns.data(), static_cast<int>(this->inns.size()));
 }
 
-BufferView<const uint8_t> MIFFile::Level::getLOOT() const
+BufferViewReadOnly<uint8_t> MIFFile::Level::getLOOT() const
 {
-	return BufferView<const uint8_t>(this->loot.data(), static_cast<int>(this->loot.size()));
+	return BufferViewReadOnly<uint8_t>(this->loot.data(), static_cast<int>(this->loot.size()));
 }
 
-BufferView<const uint8_t> MIFFile::Level::getSTOR() const
+BufferViewReadOnly<uint8_t> MIFFile::Level::getSTOR() const
 {
-	return BufferView<const uint8_t>(this->stor.data(), static_cast<int>(this->stor.size()));
+	return BufferViewReadOnly<uint8_t>(this->stor.data(), static_cast<int>(this->stor.size()));
 }
 
-BufferView<const ArenaTypes::MIFTarget> MIFFile::Level::getTARG() const
+BufferViewReadOnly<ArenaTypes::MIFTarget> MIFFile::Level::getTARG() const
 {
-	return BufferView<const ArenaTypes::MIFTarget>(this->targ.data(), static_cast<int>(this->targ.size()));
+	return BufferViewReadOnly<ArenaTypes::MIFTarget>(this->targ.data(), static_cast<int>(this->targ.size()));
 }
 
-BufferView<const ArenaTypes::MIFLock> MIFFile::Level::getLOCK() const
+BufferViewReadOnly<ArenaTypes::MIFLock> MIFFile::Level::getLOCK() const
 {
-	return BufferView<const ArenaTypes::MIFLock>(this->lock.data(), static_cast<int>(this->lock.size()));
+	return BufferViewReadOnly<ArenaTypes::MIFLock>(this->lock.data(), static_cast<int>(this->lock.size()));
 }
 
-BufferView<const ArenaTypes::MIFTrigger> MIFFile::Level::getTRIG() const
+BufferViewReadOnly<ArenaTypes::MIFTrigger> MIFFile::Level::getTRIG() const
 {
-	return BufferView<const ArenaTypes::MIFTrigger>(this->trig.data(), static_cast<int>(this->trig.size()));
+	return BufferViewReadOnly<ArenaTypes::MIFTrigger>(this->trig.data(), static_cast<int>(this->trig.size()));
 }
 
 bool MIFFile::init(const char *filename)

--- a/OpenTESArena/src/Assets/MIFFile.cpp
+++ b/OpenTESArena/src/Assets/MIFFile.cpp
@@ -360,21 +360,21 @@ int MIFFile::Level::getNumf() const
 	return this->numf;
 }
 
-BufferView2D<const ArenaTypes::VoxelID> MIFFile::Level::getFLOR() const
+BufferView2DReadOnly<ArenaTypes::VoxelID> MIFFile::Level::getFLOR() const
 {
-	return BufferView2D<const ArenaTypes::VoxelID>(
+	return BufferView2DReadOnly<ArenaTypes::VoxelID>(
 		this->flor.get(), this->flor.getWidth(), this->flor.getHeight());
 }
 
-BufferView2D<const ArenaTypes::VoxelID> MIFFile::Level::getMAP1() const
+BufferView2DReadOnly<ArenaTypes::VoxelID> MIFFile::Level::getMAP1() const
 {
-	return BufferView2D<const ArenaTypes::VoxelID>(
+	return BufferView2DReadOnly<ArenaTypes::VoxelID>(
 		this->map1.get(), this->map1.getWidth(), this->map1.getHeight());
 }
 
-BufferView2D<const ArenaTypes::VoxelID> MIFFile::Level::getMAP2() const
+BufferView2DReadOnly< ArenaTypes::VoxelID> MIFFile::Level::getMAP2() const
 {
-	return BufferView2D<const ArenaTypes::VoxelID>(
+	return BufferView2DReadOnly<ArenaTypes::VoxelID>(
 		this->map2.get(), this->map2.getWidth(), this->map2.getHeight());
 }
 

--- a/OpenTESArena/src/Assets/MIFFile.h
+++ b/OpenTESArena/src/Assets/MIFFile.h
@@ -13,6 +13,7 @@
 #include "components/utilities/Buffer2D.h"
 #include "components/utilities/BufferView2D.h"
 #include "components/utilities/BufferViewReadOnly.h"
+#include "components/utilities/BufferView2DReadOnly.h"
 
 // A .MIF file contains a map header and an array of levels. It defines the dimensions of
 // a particular area and which voxels have which IDs, as well as some other data. It is normally
@@ -66,9 +67,9 @@ public:
 		const std::string &getInfo() const;
 		int getNumf() const;
 
-		BufferView2D<const ArenaTypes::VoxelID> getFLOR() const;
-		BufferView2D<const ArenaTypes::VoxelID> getMAP1() const;
-		BufferView2D<const ArenaTypes::VoxelID> getMAP2() const;
+		BufferView2DReadOnly<ArenaTypes::VoxelID> getFLOR() const;
+		BufferView2DReadOnly<ArenaTypes::VoxelID> getMAP1() const;
+		BufferView2DReadOnly<ArenaTypes::VoxelID> getMAP2() const;
 
 		BufferViewReadOnly<uint8_t> getFLAT() const;
 		BufferViewReadOnly<uint8_t> getINNS() const;

--- a/OpenTESArena/src/Assets/MIFFile.h
+++ b/OpenTESArena/src/Assets/MIFFile.h
@@ -11,8 +11,8 @@
 #include "../World/VoxelUtils.h"
 
 #include "components/utilities/Buffer2D.h"
-#include "components/utilities/BufferView.h"
 #include "components/utilities/BufferView2D.h"
+#include "components/utilities/BufferViewReadOnly.h"
 
 // A .MIF file contains a map header and an array of levels. It defines the dimensions of
 // a particular area and which voxels have which IDs, as well as some other data. It is normally
@@ -70,14 +70,14 @@ public:
 		BufferView2D<const ArenaTypes::VoxelID> getMAP1() const;
 		BufferView2D<const ArenaTypes::VoxelID> getMAP2() const;
 
-		BufferView<const uint8_t> getFLAT() const;
-		BufferView<const uint8_t> getINNS() const;
-		BufferView<const uint8_t> getLOOT() const;
-		BufferView<const uint8_t> getSTOR() const;
+		BufferViewReadOnly<uint8_t> getFLAT() const;
+		BufferViewReadOnly<uint8_t> getINNS() const;
+		BufferViewReadOnly<uint8_t> getLOOT() const;
+		BufferViewReadOnly<uint8_t> getSTOR() const;
 
-		BufferView<const ArenaTypes::MIFTarget> getTARG() const;
-		BufferView<const ArenaTypes::MIFLock> getLOCK() const;
-		BufferView<const ArenaTypes::MIFTrigger> getTRIG() const;
+		BufferViewReadOnly<ArenaTypes::MIFTarget> getTARG() const;
+		BufferViewReadOnly<ArenaTypes::MIFLock> getLOCK() const;
+		BufferViewReadOnly<ArenaTypes::MIFTrigger> getTRIG() const;
 	};
 private:
 	WEInt width;

--- a/OpenTESArena/src/Assets/RMDFile.cpp
+++ b/OpenTESArena/src/Assets/RMDFile.cpp
@@ -71,20 +71,20 @@ bool RMDFile::init(const char *filename)
 	return true;
 }
 
-BufferView2D<const ArenaTypes::VoxelID> RMDFile::getFLOR() const
+BufferView2DReadOnly<ArenaTypes::VoxelID> RMDFile::getFLOR() const
 {
-	return BufferView2D<const ArenaTypes::VoxelID>(
+	return BufferView2DReadOnly<ArenaTypes::VoxelID>(
 		this->flor.get(), this->flor.getWidth(), this->flor.getHeight());
 }
 
-BufferView2D<const ArenaTypes::VoxelID> RMDFile::getMAP1() const
+BufferView2DReadOnly<ArenaTypes::VoxelID> RMDFile::getMAP1() const
 {
-	return BufferView2D<const ArenaTypes::VoxelID>(
+	return BufferView2DReadOnly<ArenaTypes::VoxelID>(
 		this->map1.get(), this->map1.getWidth(), this->map1.getHeight());
 }
 
-BufferView2D<const ArenaTypes::VoxelID> RMDFile::getMAP2() const
+BufferView2DReadOnly<ArenaTypes::VoxelID> RMDFile::getMAP2() const
 {
-	return BufferView2D<const ArenaTypes::VoxelID>(
+	return BufferView2DReadOnly<ArenaTypes::VoxelID>(
 		this->map2.get(), this->map2.getWidth(), this->map2.getHeight());
 }

--- a/OpenTESArena/src/Assets/RMDFile.h
+++ b/OpenTESArena/src/Assets/RMDFile.h
@@ -8,7 +8,7 @@
 #include "../World/VoxelUtils.h"
 
 #include "components/utilities/Buffer2D.h"
-#include "components/utilities/BufferView2D.h"
+#include "components/utilities/BufferView2DReadOnly.h"
 
 class RMDFile
 {
@@ -24,9 +24,9 @@ public:
 	static constexpr int ELEMENTS_PER_FLOOR = BYTES_PER_FLOOR / sizeof(ArenaTypes::VoxelID);
 
 	// Get voxel data for each floor.
-	BufferView2D<const ArenaTypes::VoxelID> getFLOR() const;
-	BufferView2D<const ArenaTypes::VoxelID> getMAP1() const;
-	BufferView2D<const ArenaTypes::VoxelID> getMAP2() const;
+	BufferView2DReadOnly<ArenaTypes::VoxelID> getFLOR() const;
+	BufferView2DReadOnly<ArenaTypes::VoxelID> getMAP1() const;
+	BufferView2DReadOnly<ArenaTypes::VoxelID> getMAP2() const;
 };
 
 #endif

--- a/OpenTESArena/src/Audio/MusicLibrary.h
+++ b/OpenTESArena/src/Audio/MusicLibrary.h
@@ -8,8 +8,6 @@
 
 #include "MusicDefinition.h"
 
-#include "components/utilities/BufferView.h"
-
 class Random;
 
 class MusicLibrary

--- a/OpenTESArena/src/Entities/EntityAnimationDefinition.h
+++ b/OpenTESArena/src/Entities/EntityAnimationDefinition.h
@@ -9,8 +9,6 @@
 #include "EntityAnimationUtils.h"
 #include "../Assets/TextureAssetReference.h"
 
-#include "components/utilities/BufferView.h"
-
 // Shared entity animation data for a particular set of animation directions.
 
 class EntityAnimationDefinition

--- a/OpenTESArena/src/Entities/EntityAnimationInstance.h
+++ b/OpenTESArena/src/Entities/EntityAnimationInstance.h
@@ -11,8 +11,6 @@
 #include "../Assets/TextureAssetReference.h"
 #include "../Media/TextureUtils.h"
 
-#include "components/utilities/BufferView.h"
-
 // Instance-specific animation data, references a shared animation definition.
 
 class TextureBuilder;

--- a/OpenTESArena/src/GameLogic/PlayerLogicController.cpp
+++ b/OpenTESArena/src/GameLogic/PlayerLogicController.cpp
@@ -14,7 +14,7 @@
 #include "components/utilities/String.h"
 
 void PlayerLogicController::handlePlayerTurning(Game &game, double dt, const Int2 &mouseDelta,
-	const BufferView<const Rect> &nativeCursorRegions)
+	BufferViewReadOnly<Rect> &nativeCursorRegions)
 {
 	// @todo: move this to some game/player logic controller namespace
 
@@ -139,7 +139,7 @@ void PlayerLogicController::handlePlayerTurning(Game &game, double dt, const Int
 }
 
 void PlayerLogicController::handlePlayerMovement(Game &game, double dt,
-	const BufferView<const Rect> &nativeCursorRegions)
+	BufferViewReadOnly<Rect> &nativeCursorRegions)
 {
 	// @todo: this should be in some game/player logic controller namespace
 

--- a/OpenTESArena/src/GameLogic/PlayerLogicController.h
+++ b/OpenTESArena/src/GameLogic/PlayerLogicController.h
@@ -13,10 +13,10 @@ namespace PlayerLogicController
 {
 	// Handles input for the player camera.
 	void handlePlayerTurning(Game &game, double dt, const Int2 &mouseDelta,
-		const BufferView<const Rect> &nativeCursorRegions);
+		BufferViewReadOnly<Rect> &nativeCursorRegions);
 
 	// Handles input for player movement in the game world.
-	void handlePlayerMovement(Game &game, double dt, const BufferView<const Rect> &nativeCursorRegions);
+	void handlePlayerMovement(Game &game, double dt, BufferViewReadOnly<Rect> &nativeCursorRegions);
 
 	// Handles input for the player's attack. Takes the change in mouse position since the previous frame.
 	void handlePlayerAttack(Game &game, const Int2 &mouseDelta);

--- a/OpenTESArena/src/GameLogic/PlayerLogicController.h
+++ b/OpenTESArena/src/GameLogic/PlayerLogicController.h
@@ -3,7 +3,7 @@
 
 #include "../Math/Vector2.h"
 
-#include "components/utilities/BufferView.h"
+#include "components/utilities/BufferViewReadOnly.h"
 
 class Game;
 class Rect;

--- a/OpenTESArena/src/Interface/GameWorldPanel.cpp
+++ b/OpenTESArena/src/Interface/GameWorldPanel.cpp
@@ -466,7 +466,7 @@ void GameWorldPanel::tick(double dt)
 	const Int2 mouseDelta = inputManager.getMouseDelta();
 
 	// Handle input for player motion.
-	const BufferView<const Rect> nativeCursorRegionsView(
+	BufferViewReadOnly<Rect> nativeCursorRegionsView(
 		this->nativeCursorRegions.data(), static_cast<int>(this->nativeCursorRegions.size()));
 	PlayerLogicController::handlePlayerTurning(game, dt, mouseDelta, nativeCursorRegionsView);
 	PlayerLogicController::handlePlayerMovement(game, dt, nativeCursorRegionsView);

--- a/OpenTESArena/src/Interface/GameWorldUiModel.cpp
+++ b/OpenTESArena/src/Interface/GameWorldUiModel.cpp
@@ -250,7 +250,7 @@ Radians GameWorldUiModel::getCompassAngle(const VoxelDouble2 &direction)
 	return std::atan2(-direction.y, -direction.x);
 }
 
-void GameWorldUiModel::updateNativeCursorRegions(BufferView<Rect> nativeCursorRegions, int width, int height)
+void GameWorldUiModel::updateNativeCursorRegions(BufferView<Rect> &&nativeCursorRegions, int width, int height)
 {
 	// @todo: maybe the classic rects should be converted to vector space then scaled by the ratio of aspect ratios?
 	const double xScale = static_cast<double>(width) / static_cast<double>(ArenaRenderUtils::SCREEN_WIDTH);

--- a/OpenTESArena/src/Interface/GameWorldUiModel.h
+++ b/OpenTESArena/src/Interface/GameWorldUiModel.h
@@ -37,7 +37,7 @@ namespace GameWorldUiModel
 
 	// Modifies the values in the native cursor regions array so rectangles in
 	// the current window correctly represent regions for different arrow cursors.
-	void updateNativeCursorRegions(BufferView<Rect> nativeCursorRegions, int width, int height);
+	void updateNativeCursorRegions(BufferView<Rect> &&nativeCursorRegions, int width, int height);
 }
 
 #endif

--- a/OpenTESArena/src/Media/TextureManager.cpp
+++ b/OpenTESArena/src/Media/TextureManager.cpp
@@ -302,7 +302,7 @@ bool TextureManager::tryLoadTextureData(const char *filename, Buffer<TextureBuil
 			outTextures->init(LGTFile::PALETTE_COUNT);
 			for (int i = 0; i < outTextures->getCount(); i++)
 			{
-				const BufferView<const uint8_t> lightPalette = lgt.getLightPalette(i);
+				BufferViewReadOnly<uint8_t> lightPalette = lgt.getLightPalette(i);
 				TextureBuilder textureBuilder = makePaletted(lightPalette.getCount(), 1, lightPalette.get());
 				outTextures->set(i, std::move(textureBuilder));
 			}
@@ -313,7 +313,7 @@ bool TextureManager::tryLoadTextureData(const char *filename, Buffer<TextureBuil
 			Buffer<Int2> dimensions(LGTFile::PALETTE_COUNT);
 			for (int i = 0; i < LGTFile::PALETTE_COUNT; i++)
 			{
-				const BufferView<const uint8_t> lightPalette = lgt.getLightPalette(i);
+				BufferViewReadOnly<uint8_t> lightPalette = lgt.getLightPalette(i);
 				dimensions.set(i, Int2(lightPalette.getCount(), 1));
 			}
 

--- a/OpenTESArena/src/Media/TextureUtils.cpp
+++ b/OpenTESArena/src/Media/TextureUtils.cpp
@@ -320,7 +320,7 @@ Texture TextureUtils::createTooltip(const std::string &text, FontLibrary &fontLi
 
 	std::vector<std::string_view> textLines = TextRenderUtils::getTextLines(text);
 	constexpr TextAlignment alignment = TextAlignment::TopLeft;
-	TextRenderUtils::drawTextLines(BufferView<const std::string_view>(textLines.data(), static_cast<int>(textLines.size())),
+	TextRenderUtils::drawTextLines(BufferViewReadOnly<std::string_view>(textLines.data(), static_cast<int>(textLines.size())),
 		fontDef, dstX, dstY, textColor, alignment, lineSpacing, nullptr, nullptr, surfacePixelsView);
 
 	Texture texture = renderer.createTextureFromSurface(surface);

--- a/OpenTESArena/src/Rendering/SoftwareRenderer.cpp
+++ b/OpenTESArena/src/Rendering/SoftwareRenderer.cpp
@@ -1673,7 +1673,7 @@ void SoftwareRenderer::updatePotentiallyVisibleFlats(const Camera &camera, int c
 		return entityManager.getCountInChunk(ChunkInt2(chunkX, chunkZ));
 	};
 
-	auto getTotalPotentiallyVisFlatCount = [](const BufferView2D<const int> &chunkPotentiallyVisFlatCounts)
+	auto getTotalPotentiallyVisFlatCount = [](BufferView2DReadOnly<int> &&chunkPotentiallyVisFlatCounts)
 	{
 		int count = 0;
 		for (WEInt z = 0; z < chunkPotentiallyVisFlatCounts.getHeight(); z++)
@@ -1701,7 +1701,7 @@ void SoftwareRenderer::updatePotentiallyVisibleFlats(const Camera &camera, int c
 	}
 
 	// Total potentially visible flat count (in the chunks surrounding the player).
-	const int potentiallyVisFlatCount = getTotalPotentiallyVisFlatCount(BufferView2D<const int>(
+	const int potentiallyVisFlatCount = getTotalPotentiallyVisFlatCount(BufferView2DReadOnly<int>(
 		chunkPotentiallyVisFlatCounts.get(), chunkPotentiallyVisFlatCounts.getWidth(),
 		chunkPotentiallyVisFlatCounts.getHeight()));
 

--- a/OpenTESArena/src/Rendering/SoftwareRenderer.cpp
+++ b/OpenTESArena/src/Rendering/SoftwareRenderer.cpp
@@ -869,7 +869,7 @@ void SoftwareRenderer::VisibleLightList::clear()
 }
 
 void SoftwareRenderer::VisibleLightList::sortByNearest(const CoordDouble3 &coord,
-	const BufferView<const VisibleLight> &visLights)
+	BufferViewReadOnly<VisibleLight> &visLights)
 {
 	// @todo: can only do this if we know the lightID index when sorting.
 	// Cache distance calculations for less redundant work.
@@ -1996,7 +1996,7 @@ void SoftwareRenderer::updateVisibleLightLists(const Camera &camera, int chunkDi
 	}
 
 	// Sort all of the touched voxel columns' light references by distance (shading optimization).
-	const BufferView<const VisibleLight> visLightsView(
+	BufferViewReadOnly<VisibleLight> visLightsView(
 		this->visibleLights.data(), static_cast<int>(this->visibleLights.size()));
 	for (auto &pair : this->visLightLists)
 	{
@@ -2291,7 +2291,7 @@ void SoftwareRenderer::getChasmTextureGroupTexture(const ChasmTextureGroups &tex
 }
 
 const SoftwareRenderer::VisibleLight &SoftwareRenderer::getVisibleLightByID(
-	const BufferView<const VisibleLight> &visLights, VisibleLightList::LightID lightID)
+	BufferViewReadOnly<VisibleLight> &visLights, VisibleLightList::LightID lightID)
 {
 	return visLights.get(lightID);
 }
@@ -3282,7 +3282,7 @@ void SoftwareRenderer::getLightVisibilityData(const CoordDouble3 &flatCoord, dou
 
 template <bool CappedSum>
 double SoftwareRenderer::getLightContributionAtPoint(const CoordDouble2 &coord,
-	const BufferView<const VisibleLight> &visLights, const VisibleLightList &visLightList)
+	BufferViewReadOnly<VisibleLight> &visLights, const VisibleLightList &visLightList)
 {
 	double lightContributionPercent = 0.0;
 	for (int i = 0; i < visLightList.count; i++)
@@ -3579,7 +3579,7 @@ template <bool Fading>
 void SoftwareRenderer::drawPerspectivePixelsShader(int x, const DrawRange &drawRange,
 	const NewDouble2 &startPoint, const NewDouble2 &endPoint, double depthStart, double depthEnd,
 	const Double3 &normal, const VoxelTexture &texture, double fadePercent,
-	const BufferView<const VisibleLight> &visLights, const VisibleLightList &visLightList,
+	BufferViewReadOnly<VisibleLight> &visLights, const VisibleLightList &visLightList,
 	const ShadingInfo &shadingInfo, OcclusionData &occlusion, const FrameView &frame)
 {
 	// Draw range values.
@@ -3690,7 +3690,7 @@ void SoftwareRenderer::drawPerspectivePixelsShader(int x, const DrawRange &drawR
 void SoftwareRenderer::drawPerspectivePixels(int x, const DrawRange &drawRange,
 	const NewDouble2 &startPoint, const NewDouble2 &endPoint, double depthStart, double depthEnd,
 	const Double3 &normal, const VoxelTexture &texture, double fadePercent,
-	const BufferView<const VisibleLight> &visLights, const VisibleLightList &visLightList,
+	BufferViewReadOnly<VisibleLight> &visLights, const VisibleLightList &visLightList,
 	const ShadingInfo &shadingInfo, OcclusionData &occlusion, const FrameView &frame)
 {
 	if (fadePercent == 1.0)
@@ -4647,7 +4647,7 @@ void SoftwareRenderer::drawInitialVoxelSameFloor(int x, const Chunk &chunk, cons
 	const Camera &camera, const Ray &ray, VoxelFacing2D facing, const NewDouble2 &nearPoint,
 	const NewDouble2 &farPoint, double nearZ, double farZ, double wallU, const Double3 &wallNormal,
 	const ShadingInfo &shadingInfo, int chunkDistance, double ceilingScale,
-	const ChunkManager &chunkManager, const BufferView<const VisibleLight> &visLights,
+	const ChunkManager &chunkManager, BufferViewReadOnly<VisibleLight> &visLights,
 	const VisibleLightLists &visLightLists, const VoxelTextures &textures,
 	const ChasmTextureGroups &chasmTextureGroups, OcclusionData &occlusion, const FrameView &frame)
 {
@@ -5078,7 +5078,7 @@ void SoftwareRenderer::drawInitialVoxelAbove(int x, const Chunk &chunk, const Vo
 	const Camera &camera, const Ray &ray, VoxelFacing2D facing, const NewDouble2 &nearPoint,
 	const NewDouble2 &farPoint, double nearZ, double farZ, double wallU, const Double3 &wallNormal,
 	const ShadingInfo &shadingInfo, int chunkDistance, double ceilingScale,
-	const ChunkManager &chunkManager, const BufferView<const VisibleLight> &visLights,
+	const ChunkManager &chunkManager, BufferViewReadOnly<VisibleLight> &visLights,
 	const VisibleLightLists &visLightLists, const VoxelTextures &textures,
 	const ChasmTextureGroups &chasmTextureGroups, OcclusionData &occlusion, const FrameView &frame)
 {
@@ -5408,7 +5408,7 @@ void SoftwareRenderer::drawInitialVoxelBelow(int x, const Chunk &chunk, const Vo
 	const Camera &camera, const Ray &ray, VoxelFacing2D facing, const NewDouble2 &nearPoint,
 	const NewDouble2 &farPoint, double nearZ, double farZ, double wallU, const Double3 &wallNormal,
 	const ShadingInfo &shadingInfo, int chunkDistance, double ceilingScale,
-	const ChunkManager &chunkManager, const BufferView<const VisibleLight> &visLights,
+	const ChunkManager &chunkManager, BufferViewReadOnly<VisibleLight> &visLights,
 	const VisibleLightLists &visLightLists, const VoxelTextures &textures,
 	const ChasmTextureGroups &chasmTextureGroups, OcclusionData &occlusion, const FrameView &frame)
 {
@@ -5815,7 +5815,7 @@ void SoftwareRenderer::drawInitialVoxelBelow(int x, const Chunk &chunk, const Vo
 void SoftwareRenderer::drawInitialVoxelColumn(int x, const CoordInt2 &coord, const Camera &camera,
 	const Ray &ray, VoxelFacing2D facing, const NewDouble2 &nearPoint, const NewDouble2 &farPoint,
 	double nearZ, double farZ, const ShadingInfo &shadingInfo, int chunkDistance, double ceilingScale,
-	const ChunkManager &chunkManager, const BufferView<const VisibleLight> &visLights,
+	const ChunkManager &chunkManager, BufferViewReadOnly<VisibleLight> &visLights,
 	const VisibleLightLists &visLightLists, const VoxelTextures &textures,
 	const ChasmTextureGroups &chasmTextureGroups, OcclusionData &occlusion, const FrameView &frame)
 {
@@ -5894,7 +5894,7 @@ void SoftwareRenderer::drawVoxelSameFloor(int x, const Chunk &chunk, const Voxel
 	const Ray &ray, VoxelFacing2D facing, const NewDouble2 &nearPoint, const NewDouble2 &farPoint,
 	double nearZ, double farZ, double wallU, const Double3 &wallNormal, const ShadingInfo &shadingInfo,
 	int chunkDistance, double ceilingScale, const ChunkManager &chunkManager,
-	const BufferView<const VisibleLight> &visLights, const VisibleLightLists &visLightLists,
+	BufferViewReadOnly<VisibleLight> &visLights, const VisibleLightLists &visLightLists,
 	const VoxelTextures &textures, const ChasmTextureGroups &chasmTextureGroups, OcclusionData &occlusion,
 	const FrameView &frame)
 {
@@ -6336,7 +6336,7 @@ void SoftwareRenderer::drawVoxelSameFloor(int x, const Chunk &chunk, const Voxel
 void SoftwareRenderer::drawVoxelAbove(int x, const Chunk &chunk, const VoxelInt3 &voxel, const Camera &camera,
 	const Ray &ray, VoxelFacing2D facing, const NewDouble2 &nearPoint, const NewDouble2 &farPoint, double nearZ,
 	double farZ, double wallU, const Double3 &wallNormal, const ShadingInfo &shadingInfo, int chunkDistance,
-	double ceilingScale, const ChunkManager &chunkManager, const BufferView<const VisibleLight> &visLights,
+	double ceilingScale, const ChunkManager &chunkManager, BufferViewReadOnly<VisibleLight> &visLights,
 	const VisibleLightLists &visLightLists, const VoxelTextures &textures,
 	const ChasmTextureGroups &chasmTextureGroups, OcclusionData &occlusion, const FrameView &frame)
 {
@@ -6686,7 +6686,7 @@ void SoftwareRenderer::drawVoxelAbove(int x, const Chunk &chunk, const VoxelInt3
 void SoftwareRenderer::drawVoxelBelow(int x, const Chunk &chunk, const VoxelInt3 &voxel, const Camera &camera,
 	const Ray &ray, VoxelFacing2D facing, const NewDouble2 &nearPoint, const NewDouble2 &farPoint, double nearZ,
 	double farZ, double wallU, const Double3 &wallNormal, const ShadingInfo &shadingInfo, int chunkDistance,
-	double ceilingScale, const ChunkManager &chunkManager, const BufferView<const VisibleLight> &visLights,
+	double ceilingScale, const ChunkManager &chunkManager, BufferViewReadOnly<VisibleLight> &visLights,
 	const VisibleLightLists &visLightLists, const VoxelTextures &textures,
 	const ChasmTextureGroups &chasmTextureGroups, OcclusionData &occlusion, const FrameView &frame)
 {
@@ -7134,7 +7134,7 @@ void SoftwareRenderer::drawVoxelBelow(int x, const Chunk &chunk, const VoxelInt3
 void SoftwareRenderer::drawVoxelColumn(int x, const CoordInt2 &coord, const Camera &camera,
 	const Ray &ray, VoxelFacing2D facing, const NewDouble2 &nearPoint, const NewDouble2 &farPoint,
 	double nearZ, double farZ, const ShadingInfo &shadingInfo, int chunkDistance, double ceilingScale,
-	const ChunkManager &chunkManager, const BufferView<const VisibleLight> &visLights,
+	const ChunkManager &chunkManager, BufferViewReadOnly<VisibleLight> &visLights,
 	const VisibleLightLists &visLightLists, const VoxelTextures &textures,
 	const ChasmTextureGroups &chasmTextureGroups, OcclusionData &occlusion, const FrameView &frame)
 {
@@ -7219,7 +7219,7 @@ void SoftwareRenderer::drawVoxelColumn(int x, const CoordInt2 &coord, const Came
 void SoftwareRenderer::drawFlat(int startX, int endX, const VisibleFlat &flat, const Double3 &normal,
 	const NewDouble2 &eye, const NewInt2 &eyeVoxelXZ, double horizonProjY, const ShadingInfo &shadingInfo,
 	const Palette *overridePalette, int chunkDistance, const FlatTexture &texture,
-	const BufferView<const VisibleLight> &visLights, const VisibleLightLists &visLightLists,
+	BufferViewReadOnly<VisibleLight> &visLights, const VisibleLightLists &visLightLists,
 	const FrameView &frame)
 {
 	// X percents across the screen for the given start and end columns.
@@ -7422,7 +7422,7 @@ void SoftwareRenderer::drawFlat(int startX, int endX, const VisibleFlat &flat, c
 template <bool NonNegativeDirX, bool NonNegativeDirZ>
 void SoftwareRenderer::rayCast2DInternal(int x, const Camera &camera, const Ray &ray,
 	const ShadingInfo &shadingInfo, int chunkDistance, double ceilingScale, const ChunkManager &chunkManager,
-	const BufferView<const VisibleLight> &visLights, const VisibleLightLists &visLightLists,
+	BufferViewReadOnly<VisibleLight> &visLights, const VisibleLightLists &visLightLists,
 	const VoxelTextures &textures, const ChasmTextureGroups &chasmTextureGroups, OcclusionData &occlusion,
 	const FrameView &frame)
 {
@@ -7644,7 +7644,7 @@ void SoftwareRenderer::rayCast2DInternal(int x, const Camera &camera, const Ray 
 
 void SoftwareRenderer::rayCast2D(int x, const Camera &camera, const Ray &ray, const ShadingInfo &shadingInfo,
 	int chunkDistance, double ceilingScale, const ChunkManager &chunkManager,
-	const BufferView<const VisibleLight> &visLights, const VisibleLightLists &visLightLists,
+	BufferViewReadOnly<VisibleLight> &visLights, const VisibleLightLists &visLightLists,
 	const VoxelTextures &textures, const ChasmTextureGroups &chasmTextureGroups, OcclusionData &occlusion,
 	const FrameView &frame)
 {
@@ -7830,7 +7830,7 @@ void SoftwareRenderer::drawDistantSky(int startX, int endX, const VisDistantObje
 }
 
 void SoftwareRenderer::drawVoxels(int startX, int stride, const Camera &camera, int chunkDistance,
-	double ceilingScale, const ChunkManager &chunkManager, const BufferView<const VisibleLight> &visLights,
+	double ceilingScale, const ChunkManager &chunkManager, BufferViewReadOnly<VisibleLight> &visLights,
 	const VisibleLightLists &visLightLists, const VoxelTextures &voxelTextures,
 	const ChasmTextureGroups &chasmTextureGroups, Buffer<OcclusionData> &occlusion,
 	const ShadingInfo &shadingInfo, const FrameView &frame)
@@ -7862,7 +7862,7 @@ void SoftwareRenderer::drawVoxels(int startX, int stride, const Camera &camera, 
 void SoftwareRenderer::drawFlats(int startX, int endX, const Camera &camera,
 	const Double3 &flatNormal, const std::vector<VisibleFlat> &visibleFlats,
 	const EntityTextures &entityTextures, const ShadingInfo &shadingInfo, int chunkDistance,
-	const BufferView<const VisibleLight> &visLights,
+	BufferViewReadOnly<VisibleLight> &visLights,
 	const VisibleLightLists &visLightLists, const FrameView &frame)
 {
 	// Iterate through all flats, rendering those visible within the given X range of 
@@ -8287,7 +8287,7 @@ void SoftwareRenderer::renderThreadLoop(RenderThreadData &threadData, int thread
 		const int strideX = threadData.totalThreads;
 
 		// Draw this thread's portion of voxels.
-		const BufferView<const VisibleLight> voxelsVisLightsView(voxels.visLights->data(),
+		BufferViewReadOnly<VisibleLight> voxelsVisLightsView(voxels.visLights->data(),
 			static_cast<int>(voxels.visLights->size()));
 		SoftwareRenderer::drawVoxels(threadIndex, strideX, *threadData.camera, voxels.chunkDistance,
 			voxels.ceilingScale, *voxels.chunkManager, voxelsVisLightsView, *voxels.visLightLists,
@@ -8304,7 +8304,7 @@ void SoftwareRenderer::renderThreadLoop(RenderThreadData &threadData, int thread
 		lk.unlock();
 
 		// Draw this thread's portion of flats.
-		const BufferView<const VisibleLight> flatsVisLightsView(flats.visLights->data(),
+		BufferViewReadOnly<VisibleLight> flatsVisLightsView(flats.visLights->data(),
 			static_cast<int>(flats.visLights->size()));
 		SoftwareRenderer::drawFlats(startX, endX, *threadData.camera, *flats.flatNormal, *flats.visibleFlats,
 			*flats.entityTextures, *threadData.shadingInfo, voxels.chunkDistance, flatsVisLightsView,

--- a/OpenTESArena/src/Rendering/SoftwareRenderer.h
+++ b/OpenTESArena/src/Rendering/SoftwareRenderer.h
@@ -437,7 +437,7 @@ private:
 		void clear();
 
 		// Shading optimization, only useful when the light intensity cap is on for early-out.
-		void sortByNearest(const CoordDouble3 &coord, const BufferView<const VisibleLight> &visLights);
+		void sortByNearest(const CoordDouble3 &coord, BufferViewReadOnly<VisibleLight> &visLights);
 	};
 
 	// Each chunk has a visible light list per voxel column.
@@ -597,7 +597,7 @@ private:
 		ArenaTypes::ChasmType chasmType, double chasmAnimPercent, const ChasmTexture **outTexture);
 
 	// Looks up a light in the visible lights list given some light ID.
-	static const VisibleLight &getVisibleLightByID(const BufferView<const VisibleLight> &visLights,
+	static const VisibleLight &getVisibleLightByID(BufferViewReadOnly<VisibleLight> &visLights,
 		VisibleLightList::LightID lightID);
 
 	// Gets the visible light list associated with some voxel column if the given chunk is available.
@@ -695,7 +695,7 @@ private:
 	// list max lights).
 	template <bool CappedSum>
 	static double getLightContributionAtPoint(const CoordDouble2 &coord,
-		const BufferView<const VisibleLight> &visLights, const VisibleLightList &visLightList);
+		BufferViewReadOnly<VisibleLight> &visLights, const VisibleLightList &visLightList);
 
 	// Low-level texture sampling function.
 	template <int FilterMode, bool Transparency>
@@ -729,14 +729,14 @@ private:
 	static void drawPerspectivePixelsShader(int x, const DrawRange &drawRange,
 		const NewDouble2 &startPoint, const NewDouble2 &endPoint, double depthStart, double depthEnd,
 		const Double3 &normal, const VoxelTexture &texture, double fadePercent,
-		const BufferView<const VisibleLight> &visLights, const VisibleLightList &visLightList,
+		BufferViewReadOnly<VisibleLight> &visLights, const VisibleLightList &visLightList,
 		const ShadingInfo &shadingInfo, OcclusionData &occlusion, const FrameView &frame);
 
 	// Draws a column of pixels with perspective but no transparency. The pixel drawing order is 
 	// top to bottom, so the start and end values should be passed with that in mind.
 	static void drawPerspectivePixels(int x, const DrawRange &drawRange, const NewDouble2 &startPoint,
 		const NewDouble2 &endPoint, double depthStart, double depthEnd, const Double3 &normal,
-		const VoxelTexture &texture, double fadePercent, const BufferView<const VisibleLight> &visLights,
+		const VoxelTexture &texture, double fadePercent, BufferViewReadOnly<VisibleLight> &visLights,
 		const VisibleLightList &visLightList, const ShadingInfo &shadingInfo, OcclusionData &occlusion,
 		const FrameView &frame);
 
@@ -805,21 +805,21 @@ private:
 		const Camera &camera, const Ray &ray, VoxelFacing2D facing, const NewDouble2 &nearPoint,
 		const NewDouble2 &farPoint, double nearZ, double farZ, double wallU, const Double3 &wallNormal,
 		const ShadingInfo &shadingInfo, int chunkDistance, double ceilingScale,
-		const ChunkManager &chunkManager, const BufferView<const VisibleLight> &visLights,
+		const ChunkManager &chunkManager, BufferViewReadOnly<VisibleLight> &visLights,
 		const VisibleLightLists &visLightLists, const VoxelTextures &textures,
 		const ChasmTextureGroups &chasmTextureGroups, OcclusionData &occlusion, const FrameView &frame);
 	static void drawInitialVoxelAbove(int x, const Chunk &chunk, const VoxelInt3 &voxel,
 		const Camera &camera, const Ray &ray, VoxelFacing2D facing, const NewDouble2 &nearPoint,
 		const NewDouble2 &farPoint, double nearZ, double farZ, double wallU, const Double3 &wallNormal,
 		const ShadingInfo &shadingInfo, int chunkDistance, double ceilingScale,
-		const ChunkManager &chunkManager, const BufferView<const VisibleLight> &visLights,
+		const ChunkManager &chunkManager, BufferViewReadOnly<VisibleLight> &visLights,
 		const VisibleLightLists &visLightLists, const VoxelTextures &textures,
 		const ChasmTextureGroups &chasmTextureGroups, OcclusionData &occlusion, const FrameView &frame);
 	static void drawInitialVoxelBelow(int x, const Chunk &chunk, const VoxelInt3 &voxel,
 		const Camera &camera, const Ray &ray, VoxelFacing2D facing, const NewDouble2 &nearPoint,
 		const NewDouble2 &farPoint, double nearZ, double farZ, double wallU, const Double3 &wallNormal,
 		const ShadingInfo &shadingInfo, int chunkDistance, double ceilingScale,
-		const ChunkManager &chunkManager, const BufferView<const VisibleLight> &visLights,
+		const ChunkManager &chunkManager, BufferViewReadOnly<VisibleLight> &visLights,
 		const VisibleLightLists &visLightLists, const VoxelTextures &textures,
 		const ChasmTextureGroups &chasmTextureGroups, OcclusionData &occlusion, const FrameView &frame);
 
@@ -827,7 +827,7 @@ private:
 	static void drawInitialVoxelColumn(int x, const CoordInt2 &coord, const Camera &camera,
 		const Ray &ray, VoxelFacing2D facing, const NewDouble2 &nearPoint, const NewDouble2 &farPoint,
 		double nearZ, double farZ, const ShadingInfo &shadingInfo, int chunkDistance, double ceilingScale,
-		const ChunkManager &chunkManager, const BufferView<const VisibleLight> &visLights,
+		const ChunkManager &chunkManager, BufferViewReadOnly<VisibleLight> &visLights,
 		const VisibleLightLists &visLightLists, const VoxelTextures &textures,
 		const ChasmTextureGroups &chasmTextureGroups, OcclusionData &occlusion, const FrameView &frame);
 
@@ -836,21 +836,21 @@ private:
 		const Ray &ray, VoxelFacing2D facing, const NewDouble2 &nearPoint, const NewDouble2 &farPoint,
 		double nearZ, double farZ, double wallU, const Double3 &wallNormal, const ShadingInfo &shadingInfo,
 		int chunkDistance, double ceilingScale, const ChunkManager &chunkManager,
-		const BufferView<const VisibleLight> &visLights, const VisibleLightLists &visLightLists,
+		BufferViewReadOnly<VisibleLight> &visLights, const VisibleLightLists &visLightLists,
 		const VoxelTextures &textures, const ChasmTextureGroups &chasmTextureGroups, OcclusionData &occlusion,
 		const FrameView &frame);
 	static void drawVoxelAbove(int x, const Chunk &chunk, const VoxelInt3 &voxel, const Camera &camera,
 		const Ray &ray, VoxelFacing2D facing, const NewDouble2 &nearPoint, const NewDouble2 &farPoint,
 		double nearZ, double farZ, double wallU, const Double3 &wallNormal, const ShadingInfo &shadingInfo,
 		int chunkDistance, double ceilingScale, const ChunkManager &chunkManager,
-		const BufferView<const VisibleLight> &visLights, const VisibleLightLists &visLightLists,
+		BufferViewReadOnly<VisibleLight> &visLights, const VisibleLightLists &visLightLists,
 		const VoxelTextures &textures, const ChasmTextureGroups &chasmTextureGroups, OcclusionData &occlusion,
 		const FrameView &frame);
 	static void drawVoxelBelow(int x, const Chunk &chunk, const VoxelInt3 &voxel, const Camera &camera,
 		const Ray &ray, VoxelFacing2D facing, const NewDouble2 &nearPoint, const NewDouble2 &farPoint,
 		double nearZ, double farZ, double wallU, const Double3 &wallNormal, const ShadingInfo &shadingInfo,
 		int chunkDistance, double ceilingScale, const ChunkManager &chunkManager,
-		const BufferView<const VisibleLight> &visLights, const VisibleLightLists &visLightLists,
+		BufferViewReadOnly<VisibleLight> &visLights, const VisibleLightLists &visLightLists,
 		const VoxelTextures &textures, const ChasmTextureGroups &chasmTextureGroups, OcclusionData &occlusion,
 		const FrameView &frame);
 
@@ -858,7 +858,7 @@ private:
 	static void drawVoxelColumn(int x, const CoordInt2 &coord, const Camera &camera,
 		const Ray &ray, VoxelFacing2D facing, const NewDouble2 &nearPoint, const NewDouble2 &farPoint,
 		double nearZ, double farZ, const ShadingInfo &shadingInfo, int chunkDistance, double ceilingScale,
-		const ChunkManager &chunkManager, const BufferView<const VisibleLight> &visLights,
+		const ChunkManager &chunkManager, BufferViewReadOnly<VisibleLight> &visLights,
 		const VisibleLightLists &visLightLists, const VoxelTextures &textures,
 		const ChasmTextureGroups &chasmTextureGroups, OcclusionData &occlusion, const FrameView &frame);
 
@@ -867,14 +867,14 @@ private:
 	static void drawFlat(int startX, int endX, const VisibleFlat &flat, const Double3 &normal,
 		const NewDouble2 &eye, const NewInt2 &eyeVoxelXZ, double horizonProjY, const ShadingInfo &shadingInfo,
 		const Palette *overridePalette, int chunkDistance, const FlatTexture &texture,
-		const BufferView<const VisibleLight> &visLights, const VisibleLightLists &visLightLists,
+		BufferViewReadOnly<VisibleLight> &visLights, const VisibleLightLists &visLightLists,
 		const FrameView &frame);
 
 	// Casts a 2D ray that steps through the current floor, rendering all voxels in the XZ column of each voxel.
 	template <bool NonNegativeDirX, bool NonNegativeDirZ>
 	static void rayCast2DInternal(int x, const Camera &camera, const Ray &ray,
 		const ShadingInfo &shadingInfo, int chunkDistance, double ceilingScale,
-		const ChunkManager &chunkManager, const BufferView<const VisibleLight> &visLights,
+		const ChunkManager &chunkManager, BufferViewReadOnly<VisibleLight> &visLights,
 		const VisibleLightLists &visLightLists, const VoxelTextures &textures,
 		const ChasmTextureGroups &chasmTextureGroups, OcclusionData &occlusion, const FrameView &frame);
 
@@ -882,7 +882,7 @@ private:
 	// code generation.
 	static void rayCast2D(int x, const Camera &camera, const Ray &ray, const ShadingInfo &shadingInfo,
 		int chunkDistance, double ceilingScale, const ChunkManager &chunkManager,
-		const BufferView<const VisibleLight> &visLights, const VisibleLightLists &visLightLists,
+		BufferViewReadOnly<VisibleLight> &visLights, const VisibleLightLists &visLightLists,
 		const VoxelTextures &textures, const ChasmTextureGroups &chasmTextureGroups, OcclusionData &occlusion,
 		const FrameView &frame);
 
@@ -900,7 +900,7 @@ private:
 
 	// Handles drawing all voxels for the current frame.
 	static void drawVoxels(int startX, int stride, const Camera &camera, int chunkDistance,
-		double ceilingScale, const ChunkManager &chunkManager, const BufferView<const VisibleLight> &visLights,
+		double ceilingScale, const ChunkManager &chunkManager, BufferViewReadOnly<VisibleLight> &visLights,
 		const VisibleLightLists &visLightLists, const VoxelTextures &voxelTextures,
 		const ChasmTextureGroups &chasmTextureGroups, Buffer<OcclusionData> &occlusion,
 		const ShadingInfo &shadingInfo, const FrameView &frame);
@@ -908,7 +908,7 @@ private:
 	// Handles drawing all flats for the current frame.
 	static void drawFlats(int startX, int endX, const Camera &camera, const Double3 &flatNormal,
 		const std::vector<VisibleFlat> &visibleFlats, const EntityTextures &entityTextures,
-		const ShadingInfo &shadingInfo, int chunkDistance, const BufferView<const VisibleLight> &visLights,
+		const ShadingInfo &shadingInfo, int chunkDistance, BufferViewReadOnly<VisibleLight> &visLights,
 		const VisibleLightLists &visLightLists, const FrameView &frame);
 
 	// Handles drawing the current weather (if any).

--- a/OpenTESArena/src/UI/TextBox.cpp
+++ b/OpenTESArena/src/UI/TextBox.cpp
@@ -209,7 +209,7 @@ void TextBox::updateTexture()
 			(this->colorOverrideInfo.getEntryCount() > 0) ? &this->colorOverrideInfo : nullptr;
 		const TextRenderUtils::TextShadowInfo *shadowInfoPtr =
 			this->properties.shadowInfo.has_value() ? &(*this->properties.shadowInfo) : nullptr;
-		TextRenderUtils::drawTextLines(BufferView<const std::string_view>(textLines.data(), static_cast<int>(textLines.size())),
+		TextRenderUtils::drawTextLines(BufferViewReadOnly<std::string_view>(textLines.data(), static_cast<int>(textLines.size())),
 			fontDef, 0, 0, this->properties.defaultColor, this->properties.alignment, this->properties.lineSpacing,
 			colorOverrideInfoPtr, shadowInfoPtr, textureView);
 	}

--- a/OpenTESArena/src/UI/TextRenderUtils.cpp
+++ b/OpenTESArena/src/UI/TextRenderUtils.cpp
@@ -169,7 +169,7 @@ int TextRenderUtils::getLinePixelWidth(const std::string_view &line, const FontD
 	return TextRenderUtils::getLinePixelWidth(charIDs, fontDef, shadow);
 }
 
-int TextRenderUtils::getLinesPixelWidth(const BufferView<const std::string_view> &textLines, const FontDefinition &fontDef,
+int TextRenderUtils::getLinesPixelWidth(BufferViewReadOnly<std::string_view> &textLines, const FontDefinition &fontDef,
 	const std::optional<TextShadowInfo> &shadow)
 {
 	int width = 0;
@@ -183,7 +183,7 @@ int TextRenderUtils::getLinesPixelWidth(const BufferView<const std::string_view>
 	return width;
 }
 
-int TextRenderUtils::getLinesPixelHeight(const BufferView<const std::string_view> &textLines, const FontDefinition &fontDef,
+int TextRenderUtils::getLinesPixelHeight(BufferViewReadOnly<std::string_view> &textLines, const FontDefinition &fontDef,
 	const std::optional<TextShadowInfo> &shadow, int lineSpacing)
 {
 	const int lineCount = textLines.getCount();
@@ -191,7 +191,7 @@ int TextRenderUtils::getLinesPixelHeight(const BufferView<const std::string_view
 		(shadow.has_value() ? std::abs(shadow->offsetY) : 0);
 }
 
-TextRenderUtils::TextureGenInfo TextRenderUtils::makeTextureGenInfo(const BufferView<const std::string_view> &textLines,
+TextRenderUtils::TextureGenInfo TextRenderUtils::makeTextureGenInfo(BufferViewReadOnly<std::string_view> &textLines,
 	const FontDefinition &fontDef, const std::optional<TextShadowInfo> &shadow, int lineSpacing)
 {
 	const int width = TextRenderUtils::getLinesPixelWidth(textLines, fontDef, shadow);
@@ -206,11 +206,11 @@ TextRenderUtils::TextureGenInfo TextRenderUtils::makeTextureGenInfo(const std::s
 	const FontDefinition &fontDef, const std::optional<TextShadowInfo> &shadow, int lineSpacing)
 {
 	const std::vector<std::string_view> textLines = TextRenderUtils::getTextLines(text);
-	const BufferView<const std::string_view> textLinesView(textLines.data(), static_cast<int>(textLines.size()));
+	BufferViewReadOnly<std::string_view> textLinesView(textLines.data(), static_cast<int>(textLines.size()));
 	return TextRenderUtils::makeTextureGenInfo(textLinesView, fontDef, shadow, lineSpacing);
 }
 
-std::vector<Int2> TextRenderUtils::makeAlignmentOffsets(const BufferView<const std::string_view> &textLines,
+std::vector<Int2> TextRenderUtils::makeAlignmentOffsets(BufferViewReadOnly<std::string_view> &textLines,
 	int textureWidth, int textureHeight, TextAlignment alignment, const FontDefinition &fontDef,
 	const std::optional<TextShadowInfo> &shadow, int lineSpacing)
 {
@@ -323,7 +323,7 @@ void TextRenderUtils::drawChar(const FontDefinition::Character &fontChar, int ds
 	}
 }
 
-void TextRenderUtils::drawTextLine(const BufferView<const FontDefinition::CharID> &charIDs, const FontDefinition &fontDef,
+void TextRenderUtils::drawTextLine(BufferViewReadOnly<FontDefinition::CharID> &charIDs, const FontDefinition &fontDef,
 	int dstX, int dstY, const Color &textColor, const ColorOverrideInfo *colorOverrideInfo, const TextShadowInfo *shadow,
 	BufferView2D<uint32_t> &outBuffer)
 {
@@ -376,11 +376,11 @@ void TextRenderUtils::drawTextLine(const std::string_view &line, const FontDefin
 	BufferView2D<uint32_t> &outBuffer)
 {
 	const std::vector<FontDefinition::CharID> charIDs = TextRenderUtils::getLineFontCharIDs(line, fontDef);
-	const BufferView<const FontDefinition::CharID> charIdsView(charIDs.data(), static_cast<int>(charIDs.size()));
+	BufferViewReadOnly<FontDefinition::CharID> charIdsView(charIDs.data(), static_cast<int>(charIDs.size()));
 	TextRenderUtils::drawTextLine(charIdsView, fontDef, dstX, dstY, textColor, colorOverrideInfo, shadow, outBuffer);
 }
 
-void TextRenderUtils::drawTextLines(const BufferView<const std::string_view> &textLines, const FontDefinition &fontDef,
+void TextRenderUtils::drawTextLines(BufferViewReadOnly<std::string_view> &&textLines, const FontDefinition &fontDef,
 	int dstX, int dstY, const Color &textColor, TextAlignment alignment, int lineSpacing,
 	const ColorOverrideInfo *colorOverrideInfo, const TextShadowInfo *shadow, BufferView2D<uint32_t> &outBuffer)
 {

--- a/OpenTESArena/src/UI/TextRenderUtils.h
+++ b/OpenTESArena/src/UI/TextRenderUtils.h
@@ -12,8 +12,8 @@
 #include "../Media/Palette.h"
 
 #include "components/utilities/Buffer2D.h"
-#include "components/utilities/BufferView.h"
 #include "components/utilities/BufferView2D.h"
+#include "components/utilities/BufferViewReadOnly.h"
 
 enum class TextAlignment;
 
@@ -84,20 +84,20 @@ namespace TextRenderUtils
 		const std::optional<TextShadowInfo> &shadow = std::nullopt);
 
 	// Gets the number of pixels wide or tall a rendered block of text lines would be.
-	int getLinesPixelWidth(const BufferView<const std::string_view> &textLines, const FontDefinition &fontDef,
+	int getLinesPixelWidth(BufferViewReadOnly<std::string_view> &textLines, const FontDefinition &fontDef,
 		const std::optional<TextShadowInfo> &shadow = std::nullopt);
-	int getLinesPixelHeight(const BufferView<const std::string_view> &textLines, const FontDefinition &fontDef,
+	int getLinesPixelHeight(BufferViewReadOnly<std::string_view> &textLines, const FontDefinition &fontDef,
 		const std::optional<TextShadowInfo> &shadow = std::nullopt, int lineSpacing = 0);
 
 	// Determines how large a text box texture should be in pixels.
 	// @todo: might need to change lineSpacing to a percent of character height so it scales with HD fonts
-	TextureGenInfo makeTextureGenInfo(const BufferView<const std::string_view> &textLines, const FontDefinition &fontDef,
+	TextureGenInfo makeTextureGenInfo(BufferViewReadOnly<std::string_view> &textLines, const FontDefinition &fontDef,
 		const std::optional<TextShadowInfo> &shadow = std::nullopt, int lineSpacing = 0);
 	TextureGenInfo makeTextureGenInfo(const std::string_view &text, const FontDefinition &fontDef,
 		const std::optional<TextShadowInfo> &shadow = std::nullopt, int lineSpacing = 0);
 
 	// Generates XY pixel offsets for each line of a text box based on text alignment.
-	std::vector<Int2> makeAlignmentOffsets(const BufferView<const std::string_view> &textLines, int textureWidth,
+	std::vector<Int2> makeAlignmentOffsets(BufferViewReadOnly<std::string_view> &textLines, int textureWidth,
 		int textureHeight, TextAlignment alignment, const FontDefinition &fontDef,
 		const std::optional<TextShadowInfo> &shadow, int lineSpacing);
 
@@ -109,13 +109,13 @@ namespace TextRenderUtils
 	// - render
 	void drawChar(const FontDefinition::Character &fontChar, int dstX, int dstY, const Color &textColor,
 		BufferView2D<uint32_t> &outBuffer);
-	void drawTextLine(const BufferView<const FontDefinition::CharID> &charIDs, const FontDefinition &fontDef,
+	void drawTextLine(BufferViewReadOnly<FontDefinition::CharID> &charIDs, const FontDefinition &fontDef,
 		int dstX, int dstY, const Color &textColor, const ColorOverrideInfo *colorOverrideInfo, const TextShadowInfo *shadow,
 		BufferView2D<uint32_t> &outBuffer);
 	void drawTextLine(const std::string_view &line, const FontDefinition &fontDef, int dstX, int dstY,
 		const Color &textColor, const ColorOverrideInfo *colorOverrideInfo, const TextShadowInfo *shadow,
 		BufferView2D<uint32_t> &outBuffer);
-	void drawTextLines(const BufferView<const std::string_view> &textLines, const FontDefinition &fontDef, int dstX, int dstY,
+	void drawTextLines(BufferViewReadOnly<std::string_view> &&textLines, const FontDefinition &fontDef, int dstX, int dstY,
 		const Color &textColor, TextAlignment alignment, int lineSpacing, const ColorOverrideInfo *colorOverrideInfo,
 		const TextShadowInfo *shadow, BufferView2D<uint32_t> &outBuffer);
 }

--- a/OpenTESArena/src/World/ArenaCityUtils.cpp
+++ b/OpenTESArena/src/World/ArenaCityUtils.cpp
@@ -101,7 +101,7 @@ void ArenaCityUtils::writeSkeleton(const MIFFile::Level &level,
 }
 
 void ArenaCityUtils::generateCity(uint32_t citySeed, int cityDim, WEInt gridDepth,
-	const BufferView<const uint8_t> &reservedBlocks, const OriginalInt2 &startPosition,
+	BufferViewReadOnly<uint8_t> &reservedBlocks, const OriginalInt2 &startPosition,
 	ArenaRandom &random, const BinaryAssetLibrary &binaryAssetLibrary,
 	Buffer2D<ArenaTypes::VoxelID> &dstFlor, Buffer2D<ArenaTypes::VoxelID> &dstMap1,
 	Buffer2D<ArenaTypes::VoxelID> &dstMap2)

--- a/OpenTESArena/src/World/ArenaCityUtils.cpp
+++ b/OpenTESArena/src/World/ArenaCityUtils.cpp
@@ -80,9 +80,9 @@ void ArenaCityUtils::writeSkeleton(const MIFFile::Level &level,
 	BufferView2D<ArenaTypes::VoxelID> &dstFlor, BufferView2D<ArenaTypes::VoxelID> &dstMap1,
 	BufferView2D<ArenaTypes::VoxelID> &dstMap2)
 {
-	const BufferView2D<const ArenaTypes::VoxelID> levelFLOR = level.getFLOR();
-	const BufferView2D<const ArenaTypes::VoxelID> levelMAP1 = level.getMAP1();
-	const BufferView2D<const ArenaTypes::VoxelID> levelMAP2 = level.getMAP2();
+	BufferView2DReadOnly<ArenaTypes::VoxelID> levelFLOR = level.getFLOR();
+	BufferView2DReadOnly<ArenaTypes::VoxelID> levelMAP1 = level.getMAP1();
+	BufferView2DReadOnly<ArenaTypes::VoxelID> levelMAP2 = level.getMAP2();
 	const WEInt levelWidth = levelFLOR.getWidth();
 	const SNInt levelDepth = levelFLOR.getHeight();
 
@@ -177,9 +177,9 @@ void ArenaCityUtils::generateCity(uint32_t citySeed, int cityDim, WEInt gridDept
 			const WEInt blockWidth = blockMif.getWidth();
 			const SNInt blockDepth = blockMif.getDepth();
 			const auto &blockLevel = blockMif.getLevel(0);
-			const BufferView2D<const ArenaTypes::VoxelID> blockFLOR = blockLevel.getFLOR();
-			const BufferView2D<const ArenaTypes::VoxelID> blockMAP1 = blockLevel.getMAP1();
-			const BufferView2D<const ArenaTypes::VoxelID> blockMAP2 = blockLevel.getMAP2();
+			BufferView2DReadOnly<ArenaTypes::VoxelID> blockFLOR = blockLevel.getFLOR();
+			BufferView2DReadOnly<ArenaTypes::VoxelID> blockMAP1 = blockLevel.getMAP1();
+			BufferView2DReadOnly<ArenaTypes::VoxelID> blockMAP2 = blockLevel.getMAP2();
 
 			// Offset of the block in the voxel grid.
 			const WEInt xOffset = startPosition.x + (xDim * 20);

--- a/OpenTESArena/src/World/ArenaCityUtils.h
+++ b/OpenTESArena/src/World/ArenaCityUtils.h
@@ -36,7 +36,7 @@ namespace ArenaCityUtils
 	// Writes generated city building data into the output buffers. The buffers should already
 	// be initialized with the city skeleton.
 	void generateCity(uint32_t citySeed, int cityDim, WEInt gridDepth,
-		const BufferView<const uint8_t> &reservedBlocks, const OriginalInt2 &startPosition,
+		BufferViewReadOnly<uint8_t> &reservedBlocks, const OriginalInt2 &startPosition,
 		ArenaRandom &random, const BinaryAssetLibrary &binaryAssetLibrary,
 		Buffer2D<ArenaTypes::VoxelID> &dstFlor, Buffer2D<ArenaTypes::VoxelID> &dstMap1,
 		Buffer2D<ArenaTypes::VoxelID> &dstMap2);

--- a/OpenTESArena/src/World/ArenaLevelUtils.cpp
+++ b/OpenTESArena/src/World/ArenaLevelUtils.cpp
@@ -49,7 +49,7 @@ int ArenaLevelUtils::getMap2VoxelHeight(ArenaTypes::VoxelID map2Voxel)
 	}
 }
 
-int ArenaLevelUtils::getMap2Height(const BufferView2D<const ArenaTypes::VoxelID> &map2)
+int ArenaLevelUtils::getMap2Height(BufferView2DReadOnly<ArenaTypes::VoxelID> &map2)
 {
 	DebugAssert(map2.isValid());
 
@@ -69,7 +69,7 @@ int ArenaLevelUtils::getMap2Height(const BufferView2D<const ArenaTypes::VoxelID>
 
 int ArenaLevelUtils::getMifLevelHeight(const MIFFile::Level &level, const INFFile::CeilingData *ceiling)
 {
-	const BufferView2D<const ArenaTypes::VoxelID> map2 = level.getMAP2();
+	BufferView2DReadOnly<ArenaTypes::VoxelID> map2 = level.getMAP2();
 
 	if (map2.isValid())
 	{

--- a/OpenTESArena/src/World/ArenaLevelUtils.h
+++ b/OpenTESArena/src/World/ArenaLevelUtils.h
@@ -11,7 +11,7 @@
 #include "../Assets/MIFFile.h"
 #include "../WorldMap/LocationDefinition.h"
 
-#include "components/utilities/BufferView2D.h"
+#include "components/utilities/BufferView2DReadOnly.h"
 
 class ArenaRandom;
 class ExeData;
@@ -45,7 +45,7 @@ namespace ArenaLevelUtils
 	int getMap2VoxelHeight(ArenaTypes::VoxelID map2Voxel);
 
 	// Gets the max height from a set of MAP2 voxels.
-	int getMap2Height(const BufferView2D<const ArenaTypes::VoxelID> &map2);
+	int getMap2Height(BufferView2DReadOnly<ArenaTypes::VoxelID> &map2);
 
 	// Gets the voxel height of a .MIF level with optional ceiling data.
 	int getMifLevelHeight(const MIFFile::Level &level, const INFFile::CeilingData *ceiling);

--- a/OpenTESArena/src/World/ArenaWildUtils.cpp
+++ b/OpenTESArena/src/World/ArenaWildUtils.cpp
@@ -186,7 +186,7 @@ void ArenaWildUtils::reviseWildCityBlock(ArenaWildUtils::WildBlockID wildBlockID
 	if (!isPremadeCity)
 	{
 		const int cityBlocksPerSide = cityDef.cityBlocksPerSide;
-		const BufferView<const uint8_t> reservedBlocks(cityDef.reservedBlocks->data(),
+		BufferViewReadOnly<uint8_t> reservedBlocks(cityDef.reservedBlocks->data(),
 			static_cast<int>(cityDef.reservedBlocks->size()));
 		const OriginalInt2 blockStartPosition(cityDef.blockStartPosX, cityDef.blockStartPosY);
 		const uint32_t citySeed = cityDef.citySeed;

--- a/OpenTESArena/src/World/MapDefinition.cpp
+++ b/OpenTESArena/src/World/MapDefinition.cpp
@@ -108,7 +108,7 @@ bool MapDefinition::initInteriorLevels(const MIFFile &mif, ArenaTypes::InteriorT
 
 		// Set LevelDefinition and LevelInfoDefinition voxels and entities from .MIF + .INF together
 		// (due to ceiling, etc.).
-		const BufferView<const MIFFile::Level> mifLevelView(&mifLevel, 1);
+		BufferViewReadOnly<MIFFile::Level> mifLevelView(&mifLevel, 1);
 		constexpr MapType mapType = MapType::Interior;
 		constexpr std::optional<bool> palaceIsMainQuestDungeon; // Not necessary for interiors.
 		constexpr std::optional<ArenaTypes::CityType> cityType; // Not necessary for interiors.
@@ -248,7 +248,7 @@ bool MapDefinition::initDungeonLevels(const MIFFile &mif, WEInt widthChunks, SNI
 }
 
 bool MapDefinition::initCityLevel(const MIFFile &mif, uint32_t citySeed, uint32_t rulerSeed, int raceID,
-	bool isPremade, const BufferView<const uint8_t> &reservedBlocks, WEInt blockStartPosX,
+	bool isPremade, BufferViewReadOnly<uint8_t> &reservedBlocks, WEInt blockStartPosX,
 	SNInt blockStartPosY, int cityBlocksPerSide, bool coastal, bool rulerIsMale, bool palaceIsMainQuestDungeon,
 	const std::string_view &cityTypeName, ArenaTypes::CityType cityType,
 	const LocationDefinition::CityDefinition::MainQuestTempleOverride *mainQuestTempleOverride,
@@ -352,7 +352,7 @@ bool MapDefinition::initWildLevels(const BufferView2D<const ArenaWildUtils::Wild
 	const double ceilingScale = ArenaLevelUtils::convertCeilingHeightToScale(ceiling.height);
 	levelInfoDef.init(ceilingScale);
 
-	const BufferView<const ArenaWildUtils::WildBlockID> uniqueWildBlockIdsConstView(
+	BufferViewReadOnly<ArenaWildUtils::WildBlockID> uniqueWildBlockIdsConstView(
 		uniqueWildBlockIDs.data(), static_cast<int>(uniqueWildBlockIDs.size()));
 	const BufferView2D<const int> levelDefIndicesConstView(levelDefIndices.get(),
 		levelDefIndices.getWidth(), levelDefIndices.getHeight());
@@ -476,7 +476,7 @@ bool MapDefinition::initCity(const MapGeneration::CityGenInfo &generationInfo,
 		return false;
 	}
 
-	const BufferView<const uint8_t> reservedBlocks(generationInfo.reservedBlocks.get(),
+	BufferViewReadOnly<uint8_t> reservedBlocks(generationInfo.reservedBlocks.get(),
 		generationInfo.reservedBlocks.getCount());
 	const LocationDefinition::CityDefinition::MainQuestTempleOverride *mainQuestTempleOverride =
 		generationInfo.mainQuestTempleOverride.has_value() ? &(*generationInfo.mainQuestTempleOverride) : nullptr;

--- a/OpenTESArena/src/World/MapDefinition.cpp
+++ b/OpenTESArena/src/World/MapDefinition.cpp
@@ -354,7 +354,6 @@ bool MapDefinition::initWildLevels(BufferView2DReadOnly<ArenaWildUtils::WildBloc
 
 	BufferViewReadOnly<ArenaWildUtils::WildBlockID> uniqueWildBlockIdsConstView(
 		uniqueWildBlockIDs.data(), static_cast<int>(uniqueWildBlockIDs.size()));
-	// TODO
 	BufferView2DReadOnly<int> levelDefIndicesConstView(levelDefIndices.get(),
 		levelDefIndices.getWidth(), levelDefIndices.getHeight());
 	BufferView<LevelDefinition> levelDefsView(this->levels.get(), this->levels.getCount());

--- a/OpenTESArena/src/World/MapDefinition.cpp
+++ b/OpenTESArena/src/World/MapDefinition.cpp
@@ -297,7 +297,7 @@ bool MapDefinition::initCityLevel(const MIFFile &mif, uint32_t citySeed, uint32_
 	return true;
 }
 
-bool MapDefinition::initWildLevels(const BufferView2D<const ArenaWildUtils::WildBlockID> &wildBlockIDs,
+bool MapDefinition::initWildLevels(BufferView2DReadOnly<ArenaWildUtils::WildBlockID> &wildBlockIDs,
 	uint32_t fallbackSeed, const LocationDefinition::CityDefinition &cityDef,
 	const SkyGeneration::ExteriorSkyGenInfo &skyGenInfo, const INFFile &inf,
 	const CharacterClassLibrary &charClassLibrary, const EntityDefinitionLibrary &entityDefLibrary,
@@ -354,7 +354,8 @@ bool MapDefinition::initWildLevels(const BufferView2D<const ArenaWildUtils::Wild
 
 	BufferViewReadOnly<ArenaWildUtils::WildBlockID> uniqueWildBlockIdsConstView(
 		uniqueWildBlockIDs.data(), static_cast<int>(uniqueWildBlockIDs.size()));
-	const BufferView2D<const int> levelDefIndicesConstView(levelDefIndices.get(),
+	// TODO
+	BufferView2DReadOnly<int> levelDefIndicesConstView(levelDefIndices.get(),
 		levelDefIndices.getWidth(), levelDefIndices.getHeight());
 	BufferView<LevelDefinition> levelDefsView(this->levels.get(), this->levels.getCount());
 	std::vector<MapGeneration::WildChunkBuildingNameInfo> buildingNameInfos;
@@ -508,7 +509,7 @@ bool MapDefinition::initWild(const MapGeneration::WildGenInfo &generationInfo,
 		return false;
 	}
 	
-	const BufferView2D<const ArenaWildUtils::WildBlockID> wildBlockIDs(generationInfo.wildBlockIDs.get(),
+	BufferView2DReadOnly<ArenaWildUtils::WildBlockID> wildBlockIDs(generationInfo.wildBlockIDs.get(),
 		generationInfo.wildBlockIDs.getWidth(), generationInfo.wildBlockIDs.getHeight());
 	const LocationDefinition::CityDefinition &cityDef = *generationInfo.cityDef;
 

--- a/OpenTESArena/src/World/MapDefinition.h
+++ b/OpenTESArena/src/World/MapDefinition.h
@@ -17,7 +17,7 @@
 #include "../WorldMap/LocationDefinition.h"
 
 #include "components/utilities/Buffer.h"
-#include "components/utilities/BufferView2D.h"
+#include "components/utilities/BufferView2DReadOnly.h"
 
 // Modern replacement for .MIF/.RMD files. Helps create a buffer between how the game world data
 // is defined and how it's represented in-engine, so that it doesn't care about things like
@@ -97,7 +97,7 @@ private:
 		const CharacterClassLibrary &charClassLibrary, const EntityDefinitionLibrary &entityDefLibrary,
 		const BinaryAssetLibrary &binaryAssetLibrary, const TextAssetLibrary &textAssetLibrary,
 		TextureManager &textureManager);
-	bool initWildLevels(const BufferView2D<const ArenaWildUtils::WildBlockID> &wildBlockIDs,
+	bool initWildLevels(BufferView2DReadOnly<ArenaWildUtils::WildBlockID> &wildBlockIDs,
 		uint32_t fallbackSeed, const LocationDefinition::CityDefinition &cityDef,
 		const SkyGeneration::ExteriorSkyGenInfo &skyGenInfo, const INFFile &inf,
 		const CharacterClassLibrary &charClassLibrary, const EntityDefinitionLibrary &entityDefLibrary,

--- a/OpenTESArena/src/World/MapDefinition.h
+++ b/OpenTESArena/src/World/MapDefinition.h
@@ -89,7 +89,7 @@ private:
 		const EntityDefinitionLibrary &entityDefLibrary, const BinaryAssetLibrary &binaryAssetLibrary,
 		TextureManager &textureManager, LevelInt2 *outStartPoint);
 	bool initCityLevel(const MIFFile &mif, uint32_t citySeed, uint32_t rulerSeed, int raceID,
-		bool isPremade, const BufferView<const uint8_t> &reservedBlocks, WEInt blockStartPosX,
+		bool isPremade, BufferViewReadOnly<uint8_t> &reservedBlocks, WEInt blockStartPosX,
 		SNInt blockStartPosY, int cityBlocksPerSide, bool coastal, bool rulerIsMale,
 		bool palaceIsMainQuestDungeon, const std::string_view &cityTypeName, ArenaTypes::CityType cityType,
 		const LocationDefinition::CityDefinition::MainQuestTempleOverride *mainQuestTempleOverride,

--- a/OpenTESArena/src/World/MapGeneration.cpp
+++ b/OpenTESArena/src/World/MapGeneration.cpp
@@ -29,6 +29,7 @@
 #include "../WorldMap/LocationUtils.h"
 
 #include "components/debug/Debug.h"
+#include "components/utilities/BufferViewReadOnly.h"
 #include "components/utilities/BufferView2D.h"
 #include "components/utilities/String.h"
 
@@ -1327,7 +1328,7 @@ namespace MapGeneration
 				}
 
 				// Assign locks to the current block.
-				const BufferView<const ArenaTypes::MIFLock> &blockLOCK = blockLevel.getLOCK();
+				const BufferViewReadOnly<ArenaTypes::MIFLock> &blockLOCK = blockLevel.getLOCK();
 				for (int i = 0; i < blockLOCK.getCount(); i++)
 				{
 					const auto &lock = blockLOCK.get(i);
@@ -1341,7 +1342,7 @@ namespace MapGeneration
 				}
 
 				// Assign text/sound triggers to the current block.
-				const BufferView<const ArenaTypes::MIFTrigger> &blockTRIG = blockLevel.getTRIG();
+				const BufferViewReadOnly<ArenaTypes::MIFTrigger> &blockTRIG = blockLevel.getTRIG();
 				for (int i = 0; i < blockTRIG.getCount(); i++)
 				{
 					const auto &trigger = blockTRIG.get(i);
@@ -2035,7 +2036,7 @@ void MapGeneration::DoorDefGenInfo::init(ArenaTypes::DoorType doorType, int open
 	this->closeType = closeType;
 }
 
-void MapGeneration::readMifVoxels(const BufferView<const MIFFile::Level> &levels, MapType mapType,
+void MapGeneration::readMifVoxels(BufferViewReadOnly<MIFFile::Level> &levels, MapType mapType,
 	const std::optional<ArenaTypes::InteriorType> &interiorType, const std::optional<uint32_t> &rulerSeed,
 	const std::optional<bool> &rulerIsMale, const std::optional<bool> &palaceIsMainQuestDungeon,
 	const std::optional<ArenaTypes::CityType> &cityType, const LocationDefinition::DungeonDefinition *dungeonDef,
@@ -2172,7 +2173,7 @@ void MapGeneration::generateMifDungeon(const MIFFile &mif, int levelCount, WEInt
 
 void MapGeneration::generateMifCity(const MIFFile &mif, uint32_t citySeed, uint32_t rulerSeed, int raceID,
 	bool isPremade, bool rulerIsMale, bool palaceIsMainQuestDungeon,
-	const BufferView<const uint8_t> &reservedBlocks, WEInt blockStartPosX, SNInt blockStartPosY,
+	BufferViewReadOnly<uint8_t> &reservedBlocks, WEInt blockStartPosX, SNInt blockStartPosY,
 	int cityBlocksPerSide, bool coastal, const std::string_view &cityTypeName, ArenaTypes::CityType cityType,
 	const LocationDefinition::CityDefinition::MainQuestTempleOverride *mainQuestTempleOverride,
 	const INFFile &inf, const CharacterClassLibrary &charClassLibrary,
@@ -2237,7 +2238,7 @@ void MapGeneration::generateMifCity(const MIFFile &mif, uint32_t citySeed, uint3
 		outLevelInfoDef);
 }
 
-void MapGeneration::generateRmdWilderness(const BufferView<const ArenaWildUtils::WildBlockID> &uniqueWildBlockIDs,
+void MapGeneration::generateRmdWilderness(BufferViewReadOnly<ArenaWildUtils::WildBlockID> &uniqueWildBlockIDs,
 	const BufferView2D<const int> &levelDefIndices, const LocationDefinition::CityDefinition &cityDef,
 	const INFFile &inf, const CharacterClassLibrary &charClassLibrary, const EntityDefinitionLibrary &entityDefLibrary,
 	const BinaryAssetLibrary &binaryAssetLibrary, TextureManager &textureManager,
@@ -2349,7 +2350,7 @@ void MapGeneration::generateRmdWilderness(const BufferView<const ArenaWildUtils:
 	}
 }
 
-void MapGeneration::readMifLocks(const BufferView<const MIFFile::Level> &levels, const INFFile &inf,
+void MapGeneration::readMifLocks(BufferViewReadOnly<MIFFile::Level> &levels, const INFFile &inf,
 	BufferView<LevelDefinition> &outLevelDefs, LevelInfoDefinition *outLevelInfoDef)
 {
 	ArenaLockMappingCache lockMappings;
@@ -2358,7 +2359,7 @@ void MapGeneration::readMifLocks(const BufferView<const MIFFile::Level> &levels,
 	{
 		const MIFFile::Level &level = levels.get(i);
 		LevelDefinition &levelDef = outLevelDefs.get(i);
-		const BufferView<const ArenaTypes::MIFLock> locks = level.getLOCK();
+		BufferViewReadOnly<ArenaTypes::MIFLock> locks = level.getLOCK();
 
 		for (int j = 0; j < locks.getCount(); j++)
 		{
@@ -2368,7 +2369,7 @@ void MapGeneration::readMifLocks(const BufferView<const MIFFile::Level> &levels,
 	}
 }
 
-void MapGeneration::readMifTriggers(const BufferView<const MIFFile::Level> &levels, const INFFile &inf,
+void MapGeneration::readMifTriggers(BufferViewReadOnly<MIFFile::Level> &levels, const INFFile &inf,
 	BufferView<LevelDefinition> &outLevelDefs, LevelInfoDefinition *outLevelInfoDef)
 {
 	ArenaTriggerMappingCache triggerMappings;
@@ -2377,7 +2378,7 @@ void MapGeneration::readMifTriggers(const BufferView<const MIFFile::Level> &leve
 	{
 		const MIFFile::Level &level = levels.get(i);
 		LevelDefinition &levelDef = outLevelDefs.get(i);
-		const BufferView<const ArenaTypes::MIFTrigger> triggers = level.getTRIG();
+		BufferViewReadOnly<ArenaTypes::MIFTrigger> triggers = level.getTRIG();
 
 		for (int j = 0; j < triggers.getCount(); j++)
 		{

--- a/OpenTESArena/src/World/MapGeneration.h
+++ b/OpenTESArena/src/World/MapGeneration.h
@@ -170,7 +170,7 @@ namespace MapGeneration
 	};
 
 	// Converts .MIF voxels into a more modern voxel + entity format.
-	void readMifVoxels(const BufferView<const MIFFile::Level> &levels, MapType mapType,
+	void readMifVoxels(BufferViewReadOnly<MIFFile::Level> &levels, MapType mapType,
 		const std::optional<ArenaTypes::InteriorType> &interiorType, const std::optional<uint32_t> &rulerSeed,
 		const std::optional<bool> &rulerIsMale, const std::optional<bool> &palaceIsMainQuestDungeon,
 		const std::optional<ArenaTypes::CityType> &cityType, const LocationDefinition::DungeonDefinition *dungeonDef,
@@ -193,7 +193,7 @@ namespace MapGeneration
 	// is not a premade city, and converts the level to the modern format.
 	void generateMifCity(const MIFFile &mif, uint32_t citySeed, uint32_t rulerSeed, int raceID,
 		bool isPremade, bool rulerIsMale, bool palaceIsMainQuestDungeon,
-		const BufferView<const uint8_t> &reservedBlocks, WEInt blockStartPosX, SNInt blockStartPosY,
+		BufferViewReadOnly<uint8_t> &reservedBlocks, WEInt blockStartPosX, SNInt blockStartPosY,
 		int cityBlocksPerSide, bool coastal, const std::string_view &cityTypeName, ArenaTypes::CityType cityType,
 		const LocationDefinition::CityDefinition::MainQuestTempleOverride *mainQuestTempleOverride,
 		const INFFile &inf, const CharacterClassLibrary &charClassLibrary,
@@ -203,7 +203,7 @@ namespace MapGeneration
 
 	// Generates wilderness chunks from a list of unique wild block IDs. Each block ID maps to the
 	// level definition at the same index.
-	void generateRmdWilderness(const BufferView<const ArenaWildUtils::WildBlockID> &uniqueWildBlockIDs,
+	void generateRmdWilderness(BufferViewReadOnly<ArenaWildUtils::WildBlockID> &uniqueWildBlockIDs,
 		const BufferView2D<const int> &levelDefIndices, const LocationDefinition::CityDefinition &cityDef,
 		const INFFile &inf, const CharacterClassLibrary &charClassLibrary,
 		const EntityDefinitionLibrary &entityDefLibrary,const BinaryAssetLibrary &binaryAssetLibrary,
@@ -211,9 +211,9 @@ namespace MapGeneration
 		LevelInfoDefinition *outLevelInfoDef,
 		std::vector<MapGeneration::WildChunkBuildingNameInfo> *outBuildingNameInfos);
 
-	void readMifLocks(const BufferView<const MIFFile::Level> &levels, const INFFile &inf,
+	void readMifLocks(BufferViewReadOnly<MIFFile::Level> &levels, const INFFile &inf,
 		BufferView<LevelDefinition> &outLevelDefs, LevelInfoDefinition *outLevelInfoDef);
-	void readMifTriggers(const BufferView<const MIFFile::Level> &levels, const INFFile &inf,
+	void readMifTriggers(BufferViewReadOnly<MIFFile::Level> &levels, const INFFile &inf,
 		BufferView<LevelDefinition> &outLevelDefs, LevelInfoDefinition *outLevelInfoDef);
 }
 

--- a/OpenTESArena/src/World/MapGeneration.h
+++ b/OpenTESArena/src/World/MapGeneration.h
@@ -20,6 +20,7 @@
 #include "components/utilities/Buffer.h"
 #include "components/utilities/Buffer2D.h"
 #include "components/utilities/BufferView.h"
+#include "components/utilities/BufferView2DReadOnly.h"
 
 class ArenaRandom;
 class BinaryAssetLibrary;
@@ -204,7 +205,7 @@ namespace MapGeneration
 	// Generates wilderness chunks from a list of unique wild block IDs. Each block ID maps to the
 	// level definition at the same index.
 	void generateRmdWilderness(BufferViewReadOnly<ArenaWildUtils::WildBlockID> &uniqueWildBlockIDs,
-		const BufferView2D<const int> &levelDefIndices, const LocationDefinition::CityDefinition &cityDef,
+		BufferView2DReadOnly<int> &levelDefIndices, const LocationDefinition::CityDefinition &cityDef,
 		const INFFile &inf, const CharacterClassLibrary &charClassLibrary,
 		const EntityDefinitionLibrary &entityDefLibrary,const BinaryAssetLibrary &binaryAssetLibrary,
 		TextureManager &textureManager, BufferView<LevelDefinition> &outLevelDefs,

--- a/OpenTESArena/src/World/SkyDefinition.h
+++ b/OpenTESArena/src/World/SkyDefinition.h
@@ -7,7 +7,6 @@
 #include "../Media/Color.h"
 
 #include "components/utilities/Buffer.h"
-#include "components/utilities/BufferView.h"
 
 // Contains a location's distant sky values and objects (mountains, clouds, stars, etc.).
 // Similar to LevelDefinition where it defines where various sky objects will be once they

--- a/components/utilities/BufferView2DReadOnly.h
+++ b/components/utilities/BufferView2DReadOnly.h
@@ -1,0 +1,78 @@
+#ifndef BUFFER_VIEW_2D_READ_ONLY_H
+#define BUFFER_VIEW_2D_READ_ONLY_H
+
+#include <algorithm>
+#include <type_traits>
+
+#include "../debug/Debug.h"
+
+// Non-owning view over a 2D range of data stored in memory as a 1D array. More complex than 1D buffer
+// view due to the look-up requirements of a 2D array.
+
+// Data can be null. Only need assertions on things that reach into the buffer itself.
+
+template <typename T>
+class BufferView2DReadOnly
+{
+private:
+	const T *data; // Start of original 2D array.
+	const int width, height; // Dimensions of original 2D array.
+	const int viewX, viewY; // View coordinates.
+	const int viewWidth, viewHeight; // View dimensions.
+
+	int getIndex(int x, int y) const
+	{
+		DebugAssert(x >= 0);
+		DebugAssert(y >= 0);
+		DebugAssert(x < this->viewWidth);
+		DebugAssert(y < this->viewHeight);
+		return (viewX + x) + ((viewY + y) * this->width);
+	}
+public:
+	BufferView2DReadOnly() : BufferView2DReadOnly(nullptr, 0, 0)
+	{
+	}
+
+	// View across a subset of a 2D range of data. The original 2D range's dimensions are required
+	// for proper look-up (and bounds-checking).
+	BufferView2DReadOnly(const T *data, int width, int height, int viewX, int viewY, int viewWidth, int viewHeight) : data(data), width(width), height(height), viewX(viewX), viewY(viewY), viewWidth(viewWidth), viewHeight(viewHeight)
+	{
+		DebugAssert(width >= 0);
+		DebugAssert(height >= 0);
+		DebugAssert(viewX >= 0);
+		DebugAssert(viewY >= 0);
+		DebugAssert(viewWidth >= 0);
+		DebugAssert(viewHeight >= 0);
+		DebugAssert((viewX + viewWidth) <= width);
+		DebugAssert((viewY + viewHeight) <= height);
+	}
+
+	// View across a 2D range of data.
+	BufferView2DReadOnly(const T *data, int width, int height) : BufferView2DReadOnly(data, width, height, 0, 0, width, height)
+	{
+	}
+
+	bool isValid() const
+	{
+		return this->data != nullptr;
+	}
+
+	const T &get(int x, int y) const
+	{
+		DebugAssert(this->isValid());
+		const int index = this->getIndex(x, y);
+		return this->data[index];
+	}
+
+	int getWidth() const
+	{
+		return this->viewWidth;
+	}
+
+	int getHeight() const
+	{
+		return this->viewHeight;
+	}
+};
+
+#endif

--- a/components/utilities/BufferViewReadOnly.h
+++ b/components/utilities/BufferViewReadOnly.h
@@ -1,0 +1,77 @@
+#ifndef BUFFER_VIEW_READ_ONLY_H
+#define BUFFER_VIEW_READ_ONLY_H
+
+#include <algorithm>
+#include <type_traits>
+
+#include "../debug/Debug.h"
+
+// Simple non-owning view over a 1D range of data. Useful when separating a container from the usage
+// of its data.
+
+// Data can be null. Only need assertions on things that reach into the buffer itself.
+
+template <typename T>
+class BufferViewReadOnly
+{
+private:
+	const T *data;
+	const int count;
+public:
+	BufferViewReadOnly() : BufferViewReadOnly(nullptr, 0)
+	{
+		this->reset();
+	}
+
+	// View across a subset of a range of data. Provided for bounds-checking the view range
+	// inside a full range (data, data + count) at initialization.
+	BufferViewReadOnly(const T *data, int count, int viewOffset, int viewCount) : data(data + viewOffset), count(viewCount)
+	{
+		DebugAssert(count >= 0);
+		DebugAssert(viewOffset >= 0);
+		DebugAssert(viewCount >= 0);
+		DebugAssert((viewOffset + viewCount) <= count);
+	}
+
+	BufferViewReadOnly(T *data, int count, int viewOffset, int viewCount) : data(data + viewOffset), count(viewCount)
+	{
+	}
+
+	BufferViewReadOnly(const T *data, int count) : BufferViewReadOnly(data, count, 0, count)
+	{
+	}
+
+	BufferViewReadOnly(T *data, int count) : BufferViewReadOnly(data, count, 0, count)
+	{
+	}
+
+	bool isValid() const
+	{
+		return this->data != nullptr;
+	}
+
+	const T *get() const
+	{
+		return this->data;
+	}
+
+	const T &get(int index) const
+	{
+		DebugAssert(this->isValid());
+		DebugAssert(index >= 0);
+		DebugAssert(index < this->count);
+		return this->data[index];
+	}
+
+	const T *end() const
+	{
+		return (this->data != nullptr) ? (this->data + this->count) : nullptr;
+	}
+
+	int getCount() const
+	{
+		return this->count;
+	}
+};
+
+#endif


### PR DESCRIPTION
somewhat extensive changes but mostly straightforward:
* created read only versions of `BufferView` and `Buffer2DView`
* used the read only versions everywhere I found and it made sense
* changed refs to move semantics in a handful of cases

of note, [this code](https://github.com/afritz1/OpenTESArena/compare/main...makemeunsee:188-bufferviewreadonly?expand=1#diff-bf598bec18f69d37f1387b9b29935a9a66ac9b43661ecc9e82e745228f7de688R1971) doesnt seem called ever, maybe I miss something?