### PR TITLE
Input action system and re-designed UI event handling

### DIFF
--- a/OpenTESArena/src/Assets/WorldMapMask.cpp
+++ b/OpenTESArena/src/Assets/WorldMapMask.cpp
@@ -2,6 +2,8 @@
 
 #include "WorldMapMask.h"
 
+#include "components/debug/Debug.h"
+
 WorldMapMask::WorldMapMask(std::vector<uint8_t> &&mask, const Rect &rect)
 	: mask(std::move(mask)), rect(rect) { }
 
@@ -21,7 +23,9 @@ bool WorldMapMask::get(int x, int y) const
 	const int relativeY = y - this->rect.getTop();
 	const int byteIndex = ((relativeX / 8) + 
 		(relativeY * WorldMapMask::getAdjustedWidth(this->rect.getWidth())));
-	const uint8_t maskByte = this->mask.at(byteIndex);
+
+	DebugAssertIndex(this->mask, byteIndex);
+	const uint8_t maskByte = this->mask[byteIndex];
 	const int bitIndex = 7 - (relativeX % 8);
 	return (maskByte & (1 << bitIndex)) != 0;
 }

--- a/OpenTESArena/src/Game/Game.cpp
+++ b/OpenTESArena/src/Game/Game.cpp
@@ -462,25 +462,22 @@ void Game::handlePanelChanges()
 		this->requestedSubPanelPop = false;
 		
 		// Unpause the panel that is now the top-most one.
-		const bool paused = false;
-		this->getActivePanel()->onPauseChanged(paused);
+		this->getActivePanel()->onPauseChanged(false);
+	}
+
+	// If a new panel was requested, switch to it.
+	if (this->nextPanel.get() != nullptr)
+	{
+		this->panel = std::move(this->nextPanel);
 	}
 
 	// If a new sub-panel was requested, then add it to the stack.
 	if (this->nextSubPanel.get() != nullptr)
 	{
 		// Pause the top-most panel.
-		const bool paused = true;
-		this->getActivePanel()->onPauseChanged(paused);
+		this->getActivePanel()->onPauseChanged(true);
 
-		this->subPanels.push_back(std::move(this->nextSubPanel));
-	}
-
-	// If a new panel was requested, switch to it. If it will be the active panel 
-	// (i.e., there are no sub-panels), then subsequent events will be sent to it.
-	if (this->nextPanel.get() != nullptr)
-	{
-		this->panel = std::move(this->nextPanel);
+		this->subPanels.emplace_back(std::move(this->nextSubPanel));
 	}
 }
 

--- a/OpenTESArena/src/Game/Game.cpp
+++ b/OpenTESArena/src/Game/Game.cpp
@@ -484,10 +484,10 @@ void Game::handlePanelChanges()
 	}
 }
 
-void Game::handleEvents()
+void Game::handleInput(double dt)
 {
 	// Handle input listener callbacks and general input updating.
-	this->inputManager.update();
+	this->inputManager.update(dt);
 
 	// Handle events for the current game state.
 	// @todo: this is now the legacy input handling for panels. It should eventually all be handled by the InputManager.
@@ -648,7 +648,7 @@ void Game::loop()
 		// Listen for input events.
 		try
 		{
-			this->handleEvents();
+			this->handleInput(dt);
 		}
 		catch (const std::exception &e)
 		{

--- a/OpenTESArena/src/Game/Game.cpp
+++ b/OpenTESArena/src/Game/Game.cpp
@@ -234,17 +234,17 @@ Game::~Game()
 {
 	if (this->applicationExitListenerID.has_value())
 	{
-		this->inputManager.removeApplicationExitListener(*this->applicationExitListenerID);
+		this->inputManager.removeListener(*this->applicationExitListenerID);
 	}
 
 	if (this->windowResizedListenerID.has_value())
 	{
-		this->inputManager.removeWindowResizedListener(*this->windowResizedListenerID);
+		this->inputManager.removeListener(*this->windowResizedListenerID);
 	}
 
 	if (this->takeScreenshotListenerID.has_value())
 	{
-		this->inputManager.removeInputActionListener(*this->takeScreenshotListenerID);
+		this->inputManager.removeListener(*this->takeScreenshotListenerID);
 	}
 }
 

--- a/OpenTESArena/src/Game/Game.cpp
+++ b/OpenTESArena/src/Game/Game.cpp
@@ -487,7 +487,8 @@ void Game::handlePanelChanges()
 void Game::handleInput(double dt)
 {
 	// Handle input listener callbacks and general input updating.
-	this->inputManager.update(*this, dt, [this]()
+	const BufferView<const ButtonProxy> buttonProxies = this->getActivePanel()->getButtonProxies();
+	this->inputManager.update(*this, dt, buttonProxies, [this]()
 	{
 		// @todo: uncomment when fully moved over to InputManager and the one in the loop below is removed, otherwise
 		// they'll get double-processed (i.e. pressing Esc in the automap will close it and simultaneously open the 

--- a/OpenTESArena/src/Game/Game.cpp
+++ b/OpenTESArena/src/Game/Game.cpp
@@ -487,7 +487,13 @@ void Game::handlePanelChanges()
 void Game::handleInput(double dt)
 {
 	// Handle input listener callbacks and general input updating.
-	this->inputManager.update(dt);
+	this->inputManager.update(dt, [this]()
+	{
+		// @todo: uncomment when fully moved over to InputManager and the one in the loop below is removed, otherwise
+		// they'll get double-processed (i.e. pressing Esc in the automap will close it and simultaneously open the 
+		// pause menu).
+		//this->handlePanelChanges();
+	});
 
 	// Handle events for the current game state.
 	// @todo: this is now the legacy input handling for panels. It should eventually all be handled by the InputManager.

--- a/OpenTESArena/src/Game/Game.cpp
+++ b/OpenTESArena/src/Game/Game.cpp
@@ -485,11 +485,13 @@ void Game::handleInput(double dt)
 {
 	// Handle input listener callbacks and general input updating.
 	const BufferView<const ButtonProxy> buttonProxies = this->getActivePanel()->getButtonProxies();
-	this->inputManager.update(*this, dt, buttonProxies, [this]()
+	auto onFinishedProcessingEventFunc = [this]()
 	{
 		// See if the event requested any changes in active panels.
 		this->handlePanelChanges();
-	});
+	};
+
+	this->inputManager.update(*this, dt, buttonProxies, onFinishedProcessingEventFunc);
 }
 
 void Game::handleApplicationExit()

--- a/OpenTESArena/src/Game/Game.cpp
+++ b/OpenTESArena/src/Game/Game.cpp
@@ -490,25 +490,9 @@ void Game::handleInput(double dt)
 	const BufferView<const ButtonProxy> buttonProxies = this->getActivePanel()->getButtonProxies();
 	this->inputManager.update(*this, dt, buttonProxies, [this]()
 	{
-		// @todo: uncomment when fully moved over to InputManager and the one in the loop below is removed, otherwise
-		// they'll get double-processed (i.e. pressing Esc in the automap will close it and simultaneously open the 
-		// pause menu).
-		//this->handlePanelChanges();
-	});
-
-	// Handle events for the current game state.
-	// @todo: this is now the legacy input handling for panels. It should eventually all be handled by the InputManager.
-	// - Will probably want to wrap in a try/catch (preferably somewhere that the exception can print input info).
-	for (int i = 0; i < this->inputManager.getEventCount(); i++)
-	{
-		const SDL_Event &e = this->inputManager.getEvent(i);
-
-		// Panel-specific events are handled by the active panel.
-		this->getActivePanel()->handleEvent(e);
-
 		// See if the event requested any changes in active panels.
 		this->handlePanelChanges();
-	}
+	});
 }
 
 void Game::handleApplicationExit()
@@ -659,7 +643,7 @@ void Game::loop()
 		}
 		catch (const std::exception &e)
 		{
-			DebugCrash("handleEvents() exception: " + std::string(e.what()));
+			DebugCrash("handleInput() exception: " + std::string(e.what()));
 		}
 
 		// Animate the current game state by delta time.

--- a/OpenTESArena/src/Game/Game.cpp
+++ b/OpenTESArena/src/Game/Game.cpp
@@ -487,7 +487,7 @@ void Game::handlePanelChanges()
 void Game::handleInput(double dt)
 {
 	// Handle input listener callbacks and general input updating.
-	this->inputManager.update(dt, [this]()
+	this->inputManager.update(*this, dt, [this]()
 	{
 		// @todo: uncomment when fully moved over to InputManager and the one in the loop below is removed, otherwise
 		// they'll get double-processed (i.e. pressing Esc in the automap will close it and simultaneously open the 

--- a/OpenTESArena/src/Game/Game.cpp
+++ b/OpenTESArena/src/Game/Game.cpp
@@ -79,6 +79,8 @@ Game::Game()
 		throw DebugException("Couldn't init renderer.");
 	}
 
+	this->inputManager.init();
+
 	// Determine which version of the game the Arena path is pointing to.
 	const bool isFloppyVersion = [this, arenaPathIsRelative]()
 	{

--- a/OpenTESArena/src/Game/Game.h
+++ b/OpenTESArena/src/Game/Game.h
@@ -89,7 +89,7 @@ private:
 	void handlePanelChanges();
 
 	// Handles SDL events for the current frame.
-	void handleEvents();
+	void handleInput(double dt);
 	void handleApplicationExit();
 	void handleWindowResized(int width, int height);
 

--- a/OpenTESArena/src/Game/Game.h
+++ b/OpenTESArena/src/Game/Game.h
@@ -47,7 +47,11 @@ private:
 
 	AudioManager audioManager;
 	MusicLibrary musicLibrary;
+
+	// Listener IDs are optional in case of failed Game construction.
 	InputManager inputManager;
+	std::optional<InputManager::ListenerID> applicationExitListenerID, windowResizedListenerID;
+
 	FontLibrary fontLibrary;
 	CinematicLibrary cinematicLibrary;
 	CharacterClassLibrary charClassLibrary;
@@ -66,6 +70,7 @@ private:
 	FPSCounter fpsCounter;
 	std::string basePath, optionsPath;
 	bool requestedSubPanelPop;
+	bool running;
 
 	// Gets the top-most sub-panel if one exists, or the main panel if no sub-panels exist.
 	Panel *getActivePanel() const;
@@ -83,7 +88,9 @@ private:
 	void handlePanelChanges();
 
 	// Handles SDL events for the current frame.
-	void handleEvents(bool &running);
+	void handleEvents();
+	void handleApplicationExit();
+	void handleWindowResized(int width, int height);
 
 	// Animates the game state by delta time.
 	void tick(double dt);
@@ -97,6 +104,7 @@ public:
 	Game();
 	Game(const Game&) = delete;
 	Game(Game&&) = delete;
+	~Game();
 
 	Game &operator=(const Game&) = delete;
 	Game &operator=(Game&&) = delete;

--- a/OpenTESArena/src/Game/Game.h
+++ b/OpenTESArena/src/Game/Game.h
@@ -50,7 +50,8 @@ private:
 
 	// Listener IDs are optional in case of failed Game construction.
 	InputManager inputManager;
-	std::optional<InputManager::ListenerID> applicationExitListenerID, windowResizedListenerID;
+	std::optional<InputManager::ListenerID> applicationExitListenerID, windowResizedListenerID,
+		takeScreenshotListenerID;
 
 	FontLibrary fontLibrary;
 	CinematicLibrary cinematicLibrary;

--- a/OpenTESArena/src/Game/GameState.cpp
+++ b/OpenTESArena/src/Game/GameState.cpp
@@ -110,6 +110,7 @@ GameState::GameState(Player &&player, const BinaryAssetLibrary &binaryAssetLibra
 	this->actionTextRemainingSeconds = 0.0;
 	this->effectTextRemainingSeconds = 0.0;
 
+	this->isCamping = false;
 	this->chasmAnimSeconds = 0.0;
 }
 
@@ -917,6 +918,11 @@ bool GameState::effectTextIsVisible() const
 	return this->effectTextRemainingSeconds > 0.0;
 }
 
+void GameState::setIsCamping(bool isCamping)
+{
+	this->isCamping = isCamping;
+}
+
 void GameState::setTravelData(std::unique_ptr<ProvinceMapUiModel::TravelData> travelData)
 {
 	this->travelData = std::move(travelData);
@@ -1118,7 +1124,8 @@ void GameState::tick(double dt, Game &game)
 
 	// Tick the game clock.
 	const int oldHour = this->clock.getHours24();
-	this->clock.tick(dt * GameState::TIME_SCALE);
+	const double timeScale = GameState::GAME_TIME_SCALE * (this->isCamping ? 250.0 : 1.0);
+	this->clock.tick(dt * timeScale);
 	const int newHour = this->clock.getHours24();
 
 	// Check if the hour changed.

--- a/OpenTESArena/src/Game/GameState.h
+++ b/OpenTESArena/src/Game/GameState.h
@@ -86,9 +86,9 @@ private:
 			const std::optional<bool> &enteringInteriorFromExterior);
 	};
 
-	// Determines length of a real-time second in-game. For the original game, one real
-	// second is twenty in-game seconds.
-	static constexpr double TIME_SCALE = static_cast<double>(Clock::SECONDS_IN_A_DAY) / 4320.0;
+	// Determines length of a real-time second in-game. For the original game, one real second is
+	// twenty in-game seconds.
+	static constexpr double GAME_TIME_SCALE = static_cast<double>(Clock::SECONDS_IN_A_DAY) / 4320.0;
 
 	Player player;
 
@@ -125,6 +125,7 @@ private:
 	Clock clock;
 	ArenaRandom arenaRandom;
 	double chasmAnimSeconds;
+	bool isCamping;
 
 	WeatherDefinition weatherDef;
 	WeatherInstance weatherInst;
@@ -251,6 +252,9 @@ public:
 	bool triggerTextIsVisible() const;
 	bool actionTextIsVisible() const;
 	bool effectTextIsVisible() const;
+
+	// Sets whether the player is camping, which influences time passing and other things.
+	void setIsCamping(bool isCamping);
 
 	// Sets the player's world map travel data when they select a destination.
 	void setTravelData(std::unique_ptr<ProvinceMapUiModel::TravelData> travelData);

--- a/OpenTESArena/src/GameLogic/PlayerLogicController.cpp
+++ b/OpenTESArena/src/GameLogic/PlayerLogicController.cpp
@@ -518,8 +518,8 @@ void PlayerLogicController::handlePlayerAttack(Game &game, const Int2 &mouseDelt
 	}
 }
 
-void PlayerLogicController::handleClickInWorld(Game &game, const Int2 &nativePoint, bool primaryClick,
-	bool debugFadeVoxel, TextBox &actionTextBox)
+void PlayerLogicController::handleScreenToWorldInteraction(Game &game, const Int2 &nativePoint,
+	bool primaryInteraction, bool debugFadeVoxel, TextBox &actionTextBox)
 {
 	auto &gameState = game.getGameState();
 	const auto &options = game.getOptions();
@@ -569,9 +569,9 @@ void PlayerLogicController::handleClickInWorld(Game &game, const Int2 &nativePoi
 			const Chunk::VoxelID voxelID = chunkPtr->getVoxel(voxel.x, voxel.y, voxel.z);
 			const VoxelDefinition &voxelDef = chunkPtr->getVoxelDef(voxelID);
 
-			// Primary click handles selection in the game world. Secondary click handles
+			// Primary interaction handles selection in the game world. Secondary interaction handles
 			// reading names of things.
-			if (primaryClick)
+			if (primaryInteraction)
 			{
 				// Arbitrary max distance for selection.
 				// @todo: move to some ArenaPlayerUtils maybe
@@ -671,7 +671,7 @@ void PlayerLogicController::handleClickInWorld(Game &game, const Int2 &nativePoi
 			const Physics::Hit::EntityHit &entityHit = hit.getEntityHit();
 			const auto &exeData = game.getBinaryAssetLibrary().getExeData();
 
-			if (primaryClick)
+			if (primaryInteraction)
 			{
 				// @todo: max selection distance matters when talking to NPCs and selecting corpses.
 				// - need to research a bit since I think it switches between select and inspect

--- a/OpenTESArena/src/GameLogic/PlayerLogicController.h
+++ b/OpenTESArena/src/GameLogic/PlayerLogicController.h
@@ -21,10 +21,10 @@ namespace PlayerLogicController
 	// Handles input for the player's attack. Takes the change in mouse position since the previous frame.
 	void handlePlayerAttack(Game &game, const Int2 &mouseDelta);
 
-	// Handles the behavior of the player clicking in the game world. "primaryClick" is true for left clicks,
+	// Handles the behavior of the player clicking in the game world. "primaryInteraction" is true for left clicks,
 	// false for right clicks.
-	void handleClickInWorld(Game &game, const Int2 &nativePoint, bool primaryClick, bool debugFadeVoxel,
-		TextBox &actionTextBox);
+	void handleScreenToWorldInteraction(Game &game, const Int2 &nativePoint, bool primaryInteraction,
+		bool debugFadeVoxel, TextBox &actionTextBox);
 }
 
 #endif

--- a/OpenTESArena/src/GameLogic/PlayerLogicController.h
+++ b/OpenTESArena/src/GameLogic/PlayerLogicController.h
@@ -11,9 +11,13 @@ class TextBox;
 
 namespace PlayerLogicController
 {
-	// Handles input for the player camera.
-	void handlePlayerTurning(Game &game, double dt, const Int2 &mouseDelta,
-		const BufferView<const Rect> &nativeCursorRegions);
+	// Determines how much to turn the player by, given user input and delta time.
+	// @todo: make these be Radians instead of "units".
+	Double2 makeTurningAngularValues(Game &game, double dt, const BufferView<const Rect> &nativeCursorRegions);
+
+	// Turns the player by some angle values (note: the units are not yet formalized to be degrees/radians).
+	// @todo: this should take like delta angles or something, not sure.
+	void turnPlayer(Game &game, double dx, double dy);
 
 	// Handles input for player movement in the game world.
 	void handlePlayerMovement(Game &game, double dt, const BufferView<const Rect> &nativeCursorRegions);

--- a/OpenTESArena/src/Input/ApplicationEvents.h
+++ b/OpenTESArena/src/Input/ApplicationEvents.h
@@ -1,0 +1,12 @@
+#ifndef APPLICATION_EVENTS_H
+#define APPLICATION_EVENTS_H
+
+#include <functional>
+
+// When the X button on the application window is selected.
+using ApplicationExitCallback = std::function<void()>;
+
+// When the application window has received a resize event from the operating system.
+using WindowResizedCallback = std::function<void(int width, int height)>;
+
+#endif

--- a/OpenTESArena/src/Input/InputActionDefinition.cpp
+++ b/OpenTESArena/src/Input/InputActionDefinition.cpp
@@ -26,10 +26,10 @@ void InputActionDefinition::MouseScrollDefinition::init(MouseWheelScrollType typ
 InputActionDefinition::KeyDefinition::KeyDefinition()
 {
 	this->keycode = static_cast<SDL_Keycode>(-1);
-	this->keymod = static_cast<SDL_Keymod>(-1);
+	this->keymod = 0;
 }
 
-void InputActionDefinition::KeyDefinition::init(SDL_Keycode keycode, SDL_Keymod keymod)
+void InputActionDefinition::KeyDefinition::init(SDL_Keycode keycode, Keymod keymod)
 {
 	this->keycode = keycode;
 	this->keymod = keymod;
@@ -62,7 +62,7 @@ void InputActionDefinition::initMouseScrollDef(const std::string &name, MouseWhe
 }
 
 void InputActionDefinition::initKeyDef(const std::string &name, InputStateType stateType,
-	SDL_Keycode keycode, const std::optional<SDL_Keymod> &keymod)
+	SDL_Keycode keycode, const std::optional<KeyDefinition::Keymod> &keymod)
 {
 	this->init(std::string(name), InputActionType::Key, stateType);
 	this->keyDef.init(keycode, keymod.value_or(SDL_Keymod::KMOD_NONE));

--- a/OpenTESArena/src/Input/InputActionDefinition.h
+++ b/OpenTESArena/src/Input/InputActionDefinition.h
@@ -4,6 +4,7 @@
 #include <optional>
 #include <string>
 
+#include "SDL_keyboard.h"
 #include "SDL_keycode.h"
 
 enum class InputActionType;
@@ -35,12 +36,15 @@ public:
 
 	struct KeyDefinition
 	{
+		// Union of one or more keys (Ctrl, Ctrl + Alt, etc.). All must be pressed when matching key definitions.
+		using Keymod = decltype(SDL_Keysym::mod);
+
 		SDL_Keycode keycode;
-		SDL_Keymod keymod;
+		Keymod keymod;
 
 		KeyDefinition();
 
-		void init(SDL_Keycode keycode, SDL_Keymod keymod);
+		void init(SDL_Keycode keycode, Keymod keymod);
 	};
 
 	std::string name;
@@ -61,7 +65,7 @@ public:
 	void initMouseButtonDef(const std::string &name, InputStateType stateType, MouseButtonType buttonType);
 	void initMouseScrollDef(const std::string &name, MouseWheelScrollType scrollType);
 	void initKeyDef(const std::string &name, InputStateType stateType, SDL_Keycode keycode,
-		const std::optional<SDL_Keymod> &keymod = std::nullopt);
+		const std::optional<KeyDefinition::Keymod> &keymod = std::nullopt);
 };
 
 #endif

--- a/OpenTESArena/src/Input/InputActionEvents.cpp
+++ b/OpenTESArena/src/Input/InputActionEvents.cpp
@@ -1,13 +1,7 @@
 #include "InputActionEvents.h"
 
-InputActionCallbackValues::InputActionCallbackValues()
-{
-	this->performed = false;
-	this->held = false;
-	this->released = false;
-}
-
-void InputActionCallbackValues::init(bool performed, bool held, bool released)
+InputActionCallbackValues::InputActionCallbackValues(Game &game, bool performed, bool held, bool released)
+	: game(game)
 {
 	this->performed = performed;
 	this->held = held;

--- a/OpenTESArena/src/Input/InputActionEvents.h
+++ b/OpenTESArena/src/Input/InputActionEvents.h
@@ -3,16 +3,16 @@
 
 #include <functional>
 
+class Game;
+
 struct InputActionCallbackValues
 {
-	// More than one of these might be true, like for key inputs where it's considered held as soon as it's down.
+	Game &game;
 	bool performed;
 	bool held;
 	bool released;
 
-	InputActionCallbackValues();
-
-	void init(bool performed, bool held, bool released);
+	InputActionCallbackValues(Game &game, bool performed, bool held, bool released);
 };
 
 using InputActionCallback = std::function<void(const InputActionCallbackValues &values)>;

--- a/OpenTESArena/src/Input/InputActionMap.cpp
+++ b/OpenTESArena/src/Input/InputActionMap.cpp
@@ -40,8 +40,9 @@ namespace
 		InputActionMap map;
 
 		// Common map is always active.
-		const bool active = StringView::equals(mapName, InputActionMapName::Common);
-		map.init(mapName, active);
+		const bool allowedDuringTextEntry = StringView::equals(mapName, InputActionMapName::Common);
+		const bool active = allowedDuringTextEntry;
+		map.init(mapName, allowedDuringTextEntry, active);
 
 		std::vector<InputActionDefinition> &defs = map.defs;
 		if (StringView::equals(mapName, InputActionMapName::Common))
@@ -217,12 +218,14 @@ namespace
 
 InputActionMap::InputActionMap()
 {
+	this->allowedDuringTextEntry = false;
 	this->active = false;
 }
 
-void InputActionMap::init(const std::string &name, bool active)
+void InputActionMap::init(const std::string &name, bool allowedDuringTextEntry, bool active)
 {
 	this->name = name;
+	this->allowedDuringTextEntry = allowedDuringTextEntry;
 	this->active = active;
 }
 

--- a/OpenTESArena/src/Input/InputActionMap.cpp
+++ b/OpenTESArena/src/Input/InputActionMap.cpp
@@ -30,7 +30,7 @@ namespace
 		};
 
 		auto makeKeyDef = [](const std::string &defName, InputStateType stateType, SDL_Keycode keycode,
-			const std::optional<SDL_Keymod> &keymod = std::nullopt)
+			const std::optional<InputActionDefinition::KeyDefinition::Keymod> &keymod = std::nullopt)
 		{
 			InputActionDefinition def;
 			def.initKeyDef(defName, stateType, keycode, keymod);

--- a/OpenTESArena/src/Input/InputActionMap.cpp
+++ b/OpenTESArena/src/Input/InputActionMap.cpp
@@ -59,6 +59,10 @@ namespace
 				InputActionName::Screenshot,
 				InputStateType::BeginPerform,
 				SDLK_PRINTSCREEN));
+			defs.emplace_back(makeKeyDef(
+				InputActionName::Backspace,
+				InputStateType::BeginPerform,
+				SDLK_BACKSPACE)); // @todo: or SDLK_KP_BACKSPACE?
 			// Going to keep scroll up/down as pointer events since scrollable UI things need the pointer over them.
 		}
 		else if (StringView::equals(mapName, InputActionMapName::Automap))

--- a/OpenTESArena/src/Input/InputActionMap.cpp
+++ b/OpenTESArena/src/Input/InputActionMap.cpp
@@ -83,6 +83,13 @@ namespace
 				InputStateType::BeginPerform,
 				SDLK_r));
 		}
+		else if (StringView::equals(mapName, InputActionMapName::CharacterEquipment))
+		{
+			defs.emplace_back(makeKeyDef(
+				InputActionName::CharacterSheet,
+				InputStateType::BeginPerform,
+				SDLK_TAB));
+		}
 		else if (StringView::equals(mapName, InputActionMapName::CharacterSheet))
 		{
 			defs.emplace_back(makeKeyDef(

--- a/OpenTESArena/src/Input/InputActionMap.cpp
+++ b/OpenTESArena/src/Input/InputActionMap.cpp
@@ -60,14 +60,12 @@ namespace
 				SDLK_PRINTSCREEN));
 			// Going to keep scroll up/down as pointer events since scrollable UI things need the pointer over them.
 		}
-		else if (StringView::equals(mapName, InputActionMapName::Cinematic))
+		else if (StringView::equals(mapName, InputActionMapName::Automap))
 		{
-			// @todo: support multiple input buttons like left click, right click, escape, space, enter, keypad enter, etc..
-			// The triggering of the Skip input action is the union of those physical inputs.
 			defs.emplace_back(makeKeyDef(
-				InputActionName::Skip,
+				InputActionName::Automap,
 				InputStateType::BeginPerform,
-				SDLK_ESCAPE));
+				SDLK_n));
 		}
 		else if (StringView::equals(mapName, InputActionMapName::CharacterCreation))
 		{
@@ -79,6 +77,15 @@ namespace
 				InputActionName::RerollAttributes,
 				InputStateType::BeginPerform,
 				SDLK_r));
+		}
+		else if (StringView::equals(mapName, InputActionMapName::Cinematic))
+		{
+			// @todo: support multiple input buttons like left click, right click, escape, space, enter, keypad enter, etc..
+			// The triggering of the Skip input action is the union of those physical inputs.
+			defs.emplace_back(makeKeyDef(
+				InputActionName::Skip,
+				InputStateType::BeginPerform,
+				SDLK_ESCAPE));
 		}
 		else if (StringView::equals(mapName, InputActionMapName::GameWorld))
 		{

--- a/OpenTESArena/src/Input/InputActionMap.cpp
+++ b/OpenTESArena/src/Input/InputActionMap.cpp
@@ -83,6 +83,13 @@ namespace
 				InputStateType::BeginPerform,
 				SDLK_r));
 		}
+		else if (StringView::equals(mapName, InputActionMapName::CharacterSheet))
+		{
+			defs.emplace_back(makeKeyDef(
+				InputActionName::CharacterSheet,
+				InputStateType::BeginPerform,
+				SDLK_TAB));
+		}
 		else if (StringView::equals(mapName, InputActionMapName::Cinematic))
 		{
 			// @todo: support multiple input buttons like left click, right click, escape, space, enter, keypad enter, etc..

--- a/OpenTESArena/src/Input/InputActionMap.cpp
+++ b/OpenTESArena/src/Input/InputActionMap.cpp
@@ -226,6 +226,13 @@ namespace
 				InputStateType::BeginPerform,
 				SDLK_f));
 		}
+		else if (StringView::equals(mapName, InputActionMapName::WorldMap))
+		{
+			defs.emplace_back(makeKeyDef(
+				InputActionName::WorldMap,
+				InputStateType::BeginPerform,
+				SDLK_m));
+		}
 		else
 		{
 			DebugLogError("Unrecognized default map name \"" + std::string(mapName) + "\".");

--- a/OpenTESArena/src/Input/InputActionMap.cpp
+++ b/OpenTESArena/src/Input/InputActionMap.cpp
@@ -200,6 +200,13 @@ namespace
 				InputStateType::BeginPerform,
 				SDLK_F4));
 		}
+		else if (StringView::equals(mapName, InputActionMapName::Logbook))
+		{
+			defs.emplace_back(makeKeyDef(
+				InputActionName::Logbook,
+				InputStateType::BeginPerform,
+				SDLK_l));
+		}
 		else if (StringView::equals(mapName, InputActionMapName::MainMenu))
 		{
 			defs.emplace_back(makeKeyDef(

--- a/OpenTESArena/src/Input/InputActionMap.cpp
+++ b/OpenTESArena/src/Input/InputActionMap.cpp
@@ -51,7 +51,7 @@ namespace
 				InputStateType::BeginPerform,
 				SDLK_RETURN));
 			defs.emplace_back(makeKeyDef(
-				InputActionName::Cancel,
+				InputActionName::Back,
 				InputStateType::BeginPerform,
 				SDLK_ESCAPE));
 			defs.emplace_back(makeKeyDef(

--- a/OpenTESArena/src/Input/InputActionMap.cpp
+++ b/OpenTESArena/src/Input/InputActionMap.cpp
@@ -1,6 +1,232 @@
 #include "InputActionMap.h"
+#include "InputActionMapName.h"
+#include "InputActionName.h"
+#include "InputStateType.h"
+#include "PointerTypes.h"
+
+#include "components/debug/Debug.h"
+#include "components/utilities/String.h"
+#include "components/utilities/StringView.h"
+
+namespace
+{
+	InputActionMap MakeInputActionMapFromDefault(const char *mapName)
+	{
+		DebugAssert(!String::isNullOrEmpty(mapName));
+
+		auto makeMouseButtonDef = [](const std::string &defName, InputStateType stateType,
+			MouseButtonType buttonType)
+		{
+			InputActionDefinition def;
+			def.initMouseButtonDef(defName, stateType, buttonType);
+			return def;
+		};
+
+		auto makeMouseScrollDef = [](const std::string &defName, MouseWheelScrollType scrollType)
+		{
+			InputActionDefinition def;
+			def.initMouseScrollDef(defName, scrollType);
+			return def;
+		};
+
+		auto makeKeyDef = [](const std::string &defName, InputStateType stateType, SDL_Keycode keycode,
+			const std::optional<SDL_Keymod> &keymod = std::nullopt)
+		{
+			InputActionDefinition def;
+			def.initKeyDef(defName, stateType, keycode, keymod);
+			return def;
+		};
+
+		InputActionMap map;
+
+		// Common map is always active.
+		const bool active = StringView::equals(mapName, InputActionMapName::Common);
+		map.init(mapName, active);
+
+		std::vector<InputActionDefinition> &defs = map.defs;
+		if (StringView::equals(mapName, InputActionMapName::Common))
+		{
+			defs.emplace_back(makeKeyDef(
+				InputActionName::Accept,
+				InputStateType::BeginPerform,
+				SDLK_RETURN));
+			defs.emplace_back(makeKeyDef(
+				InputActionName::Cancel,
+				InputStateType::BeginPerform,
+				SDLK_ESCAPE));
+			defs.emplace_back(makeKeyDef(
+				InputActionName::Screenshot,
+				InputStateType::BeginPerform,
+				SDLK_PRINTSCREEN));
+			// Going to keep scroll up/down as pointer events since scrollable UI things need the pointer over them.
+		}
+		else if (StringView::equals(mapName, InputActionMapName::Cinematic))
+		{
+			// @todo: support multiple input buttons like left click, right click, escape, space, enter, keypad enter, etc..
+			// The triggering of the Skip input action is the union of those physical inputs.
+			defs.emplace_back(makeKeyDef(
+				InputActionName::Skip,
+				InputStateType::BeginPerform,
+				SDLK_ESCAPE));
+		}
+		else if (StringView::equals(mapName, InputActionMapName::CharacterCreation))
+		{
+			defs.emplace_back(makeKeyDef(
+				InputActionName::SaveAttributes,
+				InputStateType::BeginPerform,
+				SDLK_s));
+			defs.emplace_back(makeKeyDef(
+				InputActionName::RerollAttributes,
+				InputStateType::BeginPerform,
+				SDLK_r));
+		}
+		else if (StringView::equals(mapName, InputActionMapName::GameWorld))
+		{
+			// Game world interaction.
+			// @todo: might want Move{...}Fast variations w/ LeftShift if we want to keep sprint (wasn't in the original game).
+			// - might be a good time to remove sprint altogether too.
+			defs.emplace_back(makeKeyDef(
+				InputActionName::MoveForward,
+				InputStateType::Performing,
+				SDLK_w));
+			defs.emplace_back(makeKeyDef(
+				InputActionName::MoveBackward,
+				InputStateType::Performing,
+				SDLK_s));
+			defs.emplace_back(makeKeyDef(
+				InputActionName::TurnLeft,
+				InputStateType::Performing,
+				SDLK_a));
+			defs.emplace_back(makeKeyDef(
+				InputActionName::TurnRight,
+				InputStateType::Performing,
+				SDLK_d));
+			defs.emplace_back(makeKeyDef(
+				InputActionName::StrafeLeft,
+				InputStateType::Performing,
+				SDLK_a,
+				SDL_Keymod::KMOD_LCTRL));
+			defs.emplace_back(makeKeyDef(
+				InputActionName::StrafeRight,
+				InputStateType::Performing,
+				SDLK_d,
+				SDL_Keymod::KMOD_LCTRL));
+			defs.emplace_back(makeKeyDef(
+				InputActionName::Jump,
+				InputStateType::Performing,
+				SDLK_SPACE));
+			defs.emplace_back(makeKeyDef(
+				InputActionName::Activate,
+				InputStateType::BeginPerform,
+				SDLK_e));
+			defs.emplace_back(makeMouseButtonDef(
+				InputActionName::Inspect,
+				InputStateType::BeginPerform,
+				MouseButtonType::Left));
+
+			// UI interaction.
+			defs.emplace_back(makeKeyDef(
+				InputActionName::Automap,
+				InputStateType::BeginPerform,
+				SDLK_n));
+			defs.emplace_back(makeKeyDef(
+				InputActionName::Camp,
+				InputStateType::BeginPerform,
+				SDLK_r));
+			defs.emplace_back(makeKeyDef(
+				InputActionName::CastMagic,
+				InputStateType::BeginPerform,
+				SDLK_c));
+			defs.emplace_back(makeKeyDef(
+				InputActionName::CharacterSheet,
+				InputStateType::BeginPerform,
+				SDLK_TAB));
+			defs.emplace_back(makeKeyDef(
+				InputActionName::Logbook,
+				InputStateType::BeginPerform,
+				SDLK_l));
+			defs.emplace_back(makeKeyDef(
+				InputActionName::PauseMenu,
+				InputStateType::BeginPerform,
+				SDLK_ESCAPE));
+			defs.emplace_back(makeKeyDef(
+				InputActionName::PlayerPosition,
+				InputStateType::BeginPerform,
+				SDLK_F2));
+			defs.emplace_back(makeKeyDef(
+				InputActionName::Status,
+				InputStateType::BeginPerform,
+				SDLK_v));
+			defs.emplace_back(makeKeyDef(
+				InputActionName::Steal,
+				InputStateType::BeginPerform,
+				SDLK_p));
+			defs.emplace_back(makeKeyDef(
+				InputActionName::ToggleWeapon,
+				InputStateType::BeginPerform,
+				SDLK_f));
+			defs.emplace_back(makeKeyDef(
+				InputActionName::UseItem,
+				InputStateType::BeginPerform,
+				SDLK_u));
+			defs.emplace_back(makeKeyDef(
+				InputActionName::WorldMap,
+				InputStateType::BeginPerform,
+				SDLK_m));
+
+			// Debug.
+			defs.emplace_back(makeKeyDef(
+				InputActionName::DebugProfiler,
+				InputStateType::BeginPerform,
+				SDLK_F4));
+		}
+		else if (StringView::equals(mapName, InputActionMapName::MainMenu))
+		{
+			defs.emplace_back(makeKeyDef(
+				InputActionName::StartNewGame,
+				InputStateType::BeginPerform,
+				SDLK_s));
+			defs.emplace_back(makeKeyDef(
+				InputActionName::LoadGame,
+				InputStateType::BeginPerform,
+				SDLK_l));
+			defs.emplace_back(makeKeyDef(
+				InputActionName::ExitGame,
+				InputStateType::BeginPerform,
+				SDLK_e));
+			defs.emplace_back(makeKeyDef(
+				InputActionName::TestGame,
+				InputStateType::BeginPerform,
+				SDLK_f));
+		}
+		else
+		{
+			DebugLogError("Unrecognized default map name \"" + std::string(mapName) + "\".");
+		}
+
+		return map;
+	}
+}
 
 InputActionMap::InputActionMap()
 {
 	this->active = false;
+}
+
+void InputActionMap::init(const std::string &name, bool active)
+{
+	this->name = name;
+	this->active = active;
+}
+
+std::vector<InputActionMap> InputActionMap::loadDefaultMaps()
+{
+	std::vector<InputActionMap> maps;
+	for (const char *mapName : InputActionMapName::Names)
+	{
+		InputActionMap map = MakeInputActionMapFromDefault(mapName);
+		maps.emplace_back(std::move(map));
+	}
+
+	return maps;
 }

--- a/OpenTESArena/src/Input/InputActionMap.cpp
+++ b/OpenTESArena/src/Input/InputActionMap.cpp
@@ -146,6 +146,10 @@ namespace
 				InputStateType::BeginPerform,
 				SDLK_r));
 			defs.emplace_back(makeKeyDef(
+				InputActionName::Camp,
+				InputStateType::EndPerform, // @temp for testing fast forward with hotkey
+				SDLK_r));
+			defs.emplace_back(makeKeyDef(
 				InputActionName::CastMagic,
 				InputStateType::BeginPerform,
 				SDLK_c));

--- a/OpenTESArena/src/Input/InputActionMap.cpp
+++ b/OpenTESArena/src/Input/InputActionMap.cpp
@@ -55,6 +55,14 @@ namespace
 				InputActionName::Back,
 				InputStateType::BeginPerform,
 				SDLK_ESCAPE));
+
+			// @todo: support multiple input buttons like left click, right click, escape, space, enter, keypad enter, etc..
+			// The triggering of the Skip input action is the union of those physical inputs.
+			defs.emplace_back(makeKeyDef(
+				InputActionName::Skip,
+				InputStateType::BeginPerform,
+				SDLK_ESCAPE));
+
 			defs.emplace_back(makeKeyDef(
 				InputActionName::Screenshot,
 				InputStateType::BeginPerform,
@@ -63,6 +71,7 @@ namespace
 				InputActionName::Backspace,
 				InputStateType::BeginPerform,
 				SDLK_BACKSPACE)); // @todo: or SDLK_KP_BACKSPACE?
+
 			// Going to keep scroll up/down as pointer events since scrollable UI things need the pointer over them.
 		}
 		else if (StringView::equals(mapName, InputActionMapName::Automap))
@@ -96,15 +105,6 @@ namespace
 				InputActionName::CharacterSheet,
 				InputStateType::BeginPerform,
 				SDLK_TAB));
-		}
-		else if (StringView::equals(mapName, InputActionMapName::Cinematic))
-		{
-			// @todo: support multiple input buttons like left click, right click, escape, space, enter, keypad enter, etc..
-			// The triggering of the Skip input action is the union of those physical inputs.
-			defs.emplace_back(makeKeyDef(
-				InputActionName::Skip,
-				InputStateType::BeginPerform,
-				SDLK_ESCAPE));
 		}
 		else if (StringView::equals(mapName, InputActionMapName::GameWorld))
 		{

--- a/OpenTESArena/src/Input/InputActionMap.cpp
+++ b/OpenTESArena/src/Input/InputActionMap.cpp
@@ -152,7 +152,7 @@ namespace
 			defs.emplace_back(makeKeyDef(
 				InputActionName::CharacterSheet,
 				InputStateType::BeginPerform,
-				SDLK_TAB));
+				SDLK_TAB)); // @todo: and F1
 			defs.emplace_back(makeKeyDef(
 				InputActionName::Logbook,
 				InputStateType::BeginPerform,
@@ -173,6 +173,10 @@ namespace
 				InputActionName::Steal,
 				InputStateType::BeginPerform,
 				SDLK_p));
+			defs.emplace_back(makeKeyDef(
+				InputActionName::ToggleCompass,
+				InputStateType::BeginPerform,
+				SDLK_F8));
 			defs.emplace_back(makeKeyDef(
 				InputActionName::ToggleWeapon,
 				InputStateType::BeginPerform,

--- a/OpenTESArena/src/Input/InputActionMap.h
+++ b/OpenTESArena/src/Input/InputActionMap.h
@@ -9,11 +9,12 @@ struct InputActionMap
 {
 	std::string name;
 	std::vector<InputActionDefinition> defs;
+	bool allowedDuringTextEntry;
 	bool active;
 
 	InputActionMap();
 
-	void init(const std::string &name, bool active);
+	void init(const std::string &name, bool allowedDuringTextEntry, bool active);
 
 	static std::vector<InputActionMap> loadDefaultMaps();
 };

--- a/OpenTESArena/src/Input/InputActionMap.h
+++ b/OpenTESArena/src/Input/InputActionMap.h
@@ -7,10 +7,15 @@
 
 struct InputActionMap
 {
+	std::string name;
 	std::vector<InputActionDefinition> defs;
 	bool active;
 
 	InputActionMap();
+
+	void init(const std::string &name, bool active);
+
+	static std::vector<InputActionMap> loadDefaultMaps();
 };
 
 #endif

--- a/OpenTESArena/src/Input/InputActionMapName.h
+++ b/OpenTESArena/src/Input/InputActionMapName.h
@@ -10,6 +10,15 @@ namespace InputActionMapName
 	constexpr const char *CharacterCreation = "CharacterCreation"; // Save/reroll attributes.
 	constexpr const char *GameWorld = "GameWorld";
 	constexpr const char *MainMenu = "MainMenu"; // Load, new game, exit, test.
+
+	constexpr const char *Names[] =
+	{
+		Common,
+		Cinematic,
+		CharacterCreation,
+		GameWorld,
+		MainMenu
+	};
 }
 
 #endif

--- a/OpenTESArena/src/Input/InputActionMapName.h
+++ b/OpenTESArena/src/Input/InputActionMapName.h
@@ -9,6 +9,7 @@ namespace InputActionMapName
 
 	constexpr const char *Automap = "Automap";
 	constexpr const char *CharacterCreation = "CharacterCreation"; // Save/reroll attributes.
+	constexpr const char *CharacterSheet = "CharacterSheet";
 	constexpr const char *Cinematic = "Cinematic"; // Skip, etc..
 	constexpr const char *GameWorld = "GameWorld";
 	constexpr const char *Logbook = "Logbook";
@@ -21,6 +22,7 @@ namespace InputActionMapName
 
 		Automap,
 		CharacterCreation,
+		CharacterSheet,
 		Cinematic,
 		GameWorld,
 		Logbook,

--- a/OpenTESArena/src/Input/InputActionMapName.h
+++ b/OpenTESArena/src/Input/InputActionMapName.h
@@ -13,6 +13,7 @@ namespace InputActionMapName
 	constexpr const char *GameWorld = "GameWorld";
 	constexpr const char *Logbook = "Logbook";
 	constexpr const char *MainMenu = "MainMenu"; // Load, new game, exit, test.
+	constexpr const char *WorldMap = "WorldMap";
 
 	constexpr const char *Names[] =
 	{
@@ -23,7 +24,8 @@ namespace InputActionMapName
 		Cinematic,
 		GameWorld,
 		Logbook,
-		MainMenu
+		MainMenu,
+		WorldMap
 	};
 }
 

--- a/OpenTESArena/src/Input/InputActionMapName.h
+++ b/OpenTESArena/src/Input/InputActionMapName.h
@@ -11,7 +11,6 @@ namespace InputActionMapName
 	constexpr const char *CharacterCreation = "CharacterCreation"; // Save/reroll attributes.
 	constexpr const char *CharacterEquipment = "CharacterEquipment";
 	constexpr const char *CharacterSheet = "CharacterSheet";
-	constexpr const char *Cinematic = "Cinematic"; // Skip, etc..
 	constexpr const char *GameWorld = "GameWorld";
 	constexpr const char *Logbook = "Logbook";
 	constexpr const char *MainMenu = "MainMenu"; // Load, new game, exit, test.
@@ -25,7 +24,6 @@ namespace InputActionMapName
 		CharacterCreation,
 		CharacterEquipment,
 		CharacterSheet,
-		Cinematic,
 		GameWorld,
 		Logbook,
 		MainMenu,

--- a/OpenTESArena/src/Input/InputActionMapName.h
+++ b/OpenTESArena/src/Input/InputActionMapName.h
@@ -5,17 +5,21 @@
 
 namespace InputActionMapName
 {
-	constexpr const char *Common = "Common"; // Accept/cancel, etc..
-	constexpr const char *Cinematic = "Cinematic"; // Skip, etc..
+	constexpr const char *Common = "Common"; // Accept/cancel, etc.. Globally available to all UI.
+
+	constexpr const char *Automap = "Automap";
 	constexpr const char *CharacterCreation = "CharacterCreation"; // Save/reroll attributes.
+	constexpr const char *Cinematic = "Cinematic"; // Skip, etc..
 	constexpr const char *GameWorld = "GameWorld";
 	constexpr const char *MainMenu = "MainMenu"; // Load, new game, exit, test.
 
 	constexpr const char *Names[] =
 	{
 		Common,
-		Cinematic,
+
+		Automap,
 		CharacterCreation,
+		Cinematic,
 		GameWorld,
 		MainMenu
 	};

--- a/OpenTESArena/src/Input/InputActionMapName.h
+++ b/OpenTESArena/src/Input/InputActionMapName.h
@@ -9,6 +9,7 @@ namespace InputActionMapName
 
 	constexpr const char *Automap = "Automap";
 	constexpr const char *CharacterCreation = "CharacterCreation"; // Save/reroll attributes.
+	constexpr const char *CharacterEquipment = "CharacterEquipment";
 	constexpr const char *CharacterSheet = "CharacterSheet";
 	constexpr const char *Cinematic = "Cinematic"; // Skip, etc..
 	constexpr const char *GameWorld = "GameWorld";
@@ -22,6 +23,7 @@ namespace InputActionMapName
 
 		Automap,
 		CharacterCreation,
+		CharacterEquipment,
 		CharacterSheet,
 		Cinematic,
 		GameWorld,

--- a/OpenTESArena/src/Input/InputActionMapName.h
+++ b/OpenTESArena/src/Input/InputActionMapName.h
@@ -11,6 +11,7 @@ namespace InputActionMapName
 	constexpr const char *CharacterCreation = "CharacterCreation"; // Save/reroll attributes.
 	constexpr const char *Cinematic = "Cinematic"; // Skip, etc..
 	constexpr const char *GameWorld = "GameWorld";
+	constexpr const char *Logbook = "Logbook";
 	constexpr const char *MainMenu = "MainMenu"; // Load, new game, exit, test.
 
 	constexpr const char *Names[] =
@@ -21,6 +22,7 @@ namespace InputActionMapName
 		CharacterCreation,
 		Cinematic,
 		GameWorld,
+		Logbook,
 		MainMenu
 	};
 }

--- a/OpenTESArena/src/Input/InputActionMapName.h
+++ b/OpenTESArena/src/Input/InputActionMapName.h
@@ -1,0 +1,15 @@
+#ifndef INPUT_ACTION_MAP_NAME_H
+#define INPUT_ACTION_MAP_NAME_H
+
+// Names of input action maps that can be enabled/disabled throughout the game based on UI context.
+
+namespace InputActionMapName
+{
+	constexpr const char *Common = "Common"; // Accept/cancel, etc..
+	constexpr const char *Cinematic = "Cinematic"; // Skip, etc..
+	constexpr const char *CharacterCreation = "CharacterCreation"; // Save/reroll attributes.
+	constexpr const char *GameWorld = "GameWorld";
+	constexpr const char *MainMenu = "MainMenu"; // Load, new game, exit, test.
+}
+
+#endif

--- a/OpenTESArena/src/Input/InputActionName.h
+++ b/OpenTESArena/src/Input/InputActionName.h
@@ -7,7 +7,7 @@ namespace InputActionName
 {
 	// Common.
 	constexpr const char *Accept = "Accept";
-	constexpr const char *Cancel = "Cancel";
+	constexpr const char *Back = "Back"; // A.k.a. cancel.
 	constexpr const char *Skip = "Skip"; // Might be left click, right click, escape, space, enter, keypad enter, etc..
 	constexpr const char *Screenshot = "Screenshot";
 

--- a/OpenTESArena/src/Input/InputActionName.h
+++ b/OpenTESArena/src/Input/InputActionName.h
@@ -10,6 +10,7 @@ namespace InputActionName
 	constexpr const char *Back = "Back"; // A.k.a. cancel.
 	constexpr const char *Skip = "Skip"; // Might be left click, right click, escape, space, enter, keypad enter, etc..
 	constexpr const char *Screenshot = "Screenshot";
+	constexpr const char *Backspace = "Backspace";
 
 	// Game world.
 	constexpr const char *MoveForward = "MoveForward";

--- a/OpenTESArena/src/Input/InputActionName.h
+++ b/OpenTESArena/src/Input/InputActionName.h
@@ -33,6 +33,7 @@ namespace InputActionName
 	constexpr const char *PlayerPosition = "PlayerPosition";
 	constexpr const char *Status = "Status";
 	constexpr const char *Steal = "Steal";
+	constexpr const char *ToggleCompass = "ToggleCompass";
 	constexpr const char *ToggleWeapon = "ToggleWeapon";
 	constexpr const char *UseItem = "UseItem";
 	constexpr const char *WorldMap = "WorldMap";

--- a/OpenTESArena/src/Input/InputActionName.h
+++ b/OpenTESArena/src/Input/InputActionName.h
@@ -38,6 +38,7 @@ namespace InputActionName
 	constexpr const char *StartNewGame = "StartNewGame";
 	constexpr const char *LoadGame = "LoadGame";
 	constexpr const char *ExitGame = "ExitGame";
+	constexpr const char *TestGame = "TestGame";
 
 	// Character creation.
 	constexpr const char *SaveAttributes = "SaveAttributes";

--- a/OpenTESArena/src/Input/InputActionName.h
+++ b/OpenTESArena/src/Input/InputActionName.h
@@ -9,6 +9,7 @@ namespace InputActionName
 	constexpr const char *Accept = "Accept";
 	constexpr const char *Cancel = "Cancel";
 	constexpr const char *Skip = "Skip"; // Might be left click, right click, escape, space, enter, keypad enter, etc..
+	constexpr const char *Screenshot = "Screenshot";
 
 	// Game world.
 	constexpr const char *MoveForward = "MoveForward";
@@ -19,6 +20,7 @@ namespace InputActionName
 	constexpr const char *StrafeRight = "StrafeRight";
 	constexpr const char *Jump = "Jump";
 	constexpr const char *Activate = "Activate";
+	constexpr const char *Inspect = "Inspect";
 
 	// Game world interface.
 	constexpr const char *Automap = "Automap";

--- a/OpenTESArena/src/Input/InputManager.cpp
+++ b/OpenTESArena/src/Input/InputManager.cpp
@@ -154,7 +154,7 @@ void InputManager::TextInputListenerEntry::init(const TextInputCallback &callbac
 
 void InputManager::TextInputListenerEntry::reset()
 {
-	this->callback = [](const std::string&) { };
+	this->callback = [](const std::string_view&) { };
 	this->enabled = false;
 }
 
@@ -849,7 +849,7 @@ void InputManager::update(Game &game, double dt, const BufferView<const ButtonPr
 		}
 		else if (this->isTextInput(e))
 		{
-			const std::string text = e.text.text;
+			const std::string_view text = e.text.text;
 			for (const TextInputListenerEntry &entry : this->textInputListeners)
 			{
 				if (entry.enabled)

--- a/OpenTESArena/src/Input/InputManager.cpp
+++ b/OpenTESArena/src/Input/InputManager.cpp
@@ -133,6 +133,9 @@ void InputManager::init()
 {
 	// Add input action maps to be enabled/disabled as needed.
 	this->inputActionMaps = InputActionMap::loadDefaultMaps();
+
+	// Disable text input mode (for some reason it's on by default)?
+	SDL_StopTextInput();
 }
 
 bool InputManager::keyPressed(const SDL_Event &e, SDL_Keycode keycode) const

--- a/OpenTESArena/src/Input/InputManager.cpp
+++ b/OpenTESArena/src/Input/InputManager.cpp
@@ -27,7 +27,7 @@ void InputManager::MouseButtonChangedListenerEntry::init(const MouseButtonChange
 
 void InputManager::MouseButtonChangedListenerEntry::reset()
 {
-	this->callback = [](MouseButtonType, bool, const Int2&) { };
+	this->callback = [](MouseButtonType, const Int2&, bool) { };
 }
 
 void InputManager::MouseButtonHeldListenerEntry::init(const MouseButtonHeldCallback &callback)
@@ -37,7 +37,7 @@ void InputManager::MouseButtonHeldListenerEntry::init(const MouseButtonHeldCallb
 
 void InputManager::MouseButtonHeldListenerEntry::reset()
 {
-	this->callback = [](MouseButtonType, const Int2&) { };
+	this->callback = [](MouseButtonType, const Int2&, double) { };
 }
 
 void InputManager::MouseScrollChangedListenerEntry::init(const MouseScrollChangedCallback &callback)
@@ -395,7 +395,7 @@ void InputManager::cacheSdlEvents()
 	}
 }
 
-void InputManager::update()
+void InputManager::update(double dt)
 {
 	// @temp: need to allow panel SDL_Events to be processed twice for compatibility with the
 	// old event handling in Game::handleEvents().
@@ -502,7 +502,7 @@ void InputManager::update()
 
 				for (const MouseButtonChangedListenerEntry &entry : this->mouseButtonChangedListeners)
 				{
-					entry.callback(*buttonType, isButtonPress, mousePosition);
+					entry.callback(*buttonType, mousePosition, isButtonPress);
 				}
 
 				for (const InputActionMap &map : this->inputActionMaps)

--- a/OpenTESArena/src/Input/InputManager.cpp
+++ b/OpenTESArena/src/Input/InputManager.cpp
@@ -170,7 +170,7 @@ void InputManager::init()
 	this->inputActionMaps = InputActionMap::loadDefaultMaps();
 
 	// Disable text input mode (for some reason it's on by default)?
-	SDL_StopTextInput();
+	this->setTextInputMode(false);
 }
 
 bool InputManager::isKeyEvent(const SDL_Event &e) const
@@ -414,6 +414,18 @@ InputManager::ListenerID InputManager::addWindowResizedListener(const WindowResi
 {
 	return this->addListenerInternal(callback, ListenerType::WindowResized,
 		this->windowResizedListeners, this->freedWindowResizedListenerIndices);
+}
+
+void InputManager::setTextInputMode(bool active)
+{
+	if (active)
+	{
+		SDL_StartTextInput();
+	}
+	else
+	{
+		SDL_StopTextInput();
+	}
 }
 
 InputManager::ListenerID InputManager::addTextInputListener(const TextInputCallback &callback)

--- a/OpenTESArena/src/Input/InputManager.cpp
+++ b/OpenTESArena/src/Input/InputManager.cpp
@@ -438,6 +438,12 @@ void InputManager::cacheSdlEvents()
 	}
 }
 
+bool InputManager::isInTextEntryMode() const
+{
+	const SDL_bool inTextEntryMode = SDL_IsTextInputActive();
+	return inTextEntryMode == SDL_TRUE;
+}
+
 void InputManager::handleHeldInputs(uint32_t mouseState, const Int2 &mousePosition, double dt)
 {
 	auto handleHeldMouseButton = [this, mouseState, &mousePosition, dt](MouseButtonType buttonType)
@@ -463,7 +469,7 @@ void InputManager::handleHeldInputs(uint32_t mouseState, const Int2 &mousePositi
 
 	for (const InputActionMap &map : this->inputActionMaps)
 	{
-		if (map.active)
+		if (map.active && (!this->isInTextEntryMode() || map.allowedDuringTextEntry))
 		{
 			for (const InputActionDefinition &def : map.defs)
 			{
@@ -544,7 +550,7 @@ void InputManager::update(double dt)
 
 			for (const InputActionMap &map : this->inputActionMaps)
 			{
-				if (map.active)
+				if (map.active && (!this->isInTextEntryMode() || map.allowedDuringTextEntry))
 				{
 					for (const InputActionDefinition &def : map.defs)
 					{

--- a/OpenTESArena/src/Input/InputManager.cpp
+++ b/OpenTESArena/src/Input/InputManager.cpp
@@ -507,7 +507,7 @@ void InputManager::handleHeldInputs(uint32_t mouseState, const Int2 &mousePositi
 	}
 }
 
-void InputManager::update(double dt)
+void InputManager::update(double dt, const std::function<void()> &onFinishedProcessingEvent)
 {
 	// @temp: need to allow panel SDL_Events to be processed twice for compatibility with the
 	// old event handling in Game::handleEvents().
@@ -688,5 +688,7 @@ void InputManager::update(double dt)
 				entry.callback(this->mouseDelta.x, this->mouseDelta.y);
 			}
 		}
+
+		onFinishedProcessingEvent();
 	}
 }

--- a/OpenTESArena/src/Input/InputManager.cpp
+++ b/OpenTESArena/src/Input/InputManager.cpp
@@ -699,7 +699,10 @@ void InputManager::update(Game &game, double dt, const BufferView<const ButtonPr
 						if (isButtonActive)
 						{
 							const Int2 classicMousePos = game.getRenderer().nativeToOriginal(mousePosition);
-							const bool isValidMouseSelection = buttonProxy.rect.contains(classicMousePos);
+
+							DebugAssert(buttonProxy.rectFunc);
+							const Rect buttonRect = buttonProxy.rectFunc();
+							const bool isValidMouseSelection = buttonRect.contains(classicMousePos);
 							const bool matchesButtonType = *buttonType == buttonProxy.buttonType;
 							if (isValidMouseSelection && matchesButtonType)
 							{

--- a/OpenTESArena/src/Input/InputManager.cpp
+++ b/OpenTESArena/src/Input/InputManager.cpp
@@ -1,7 +1,17 @@
+#include <algorithm>
+
 #include "InputManager.h"
+
+#include "components/debug/Debug.h"
 
 InputManager::InputManager()
 	: mouseDelta(0, 0) { }
+
+void InputManager::init()
+{
+	// Add input action maps to be enabled/disabled as needed.
+	this->actionMaps = InputActionMap::loadDefaultMaps();
+}
 
 bool InputManager::keyPressed(const SDL_Event &e, SDL_Keycode keycode) const
 {
@@ -77,6 +87,27 @@ Int2 InputManager::getMousePosition() const
 Int2 InputManager::getMouseDelta() const
 {
 	return this->mouseDelta;
+}
+
+bool InputManager::setInputActionMapActive(const std::string &name, bool active)
+{
+	const auto iter = std::find_if(this->actionMaps.begin(), this->actionMaps.end(),
+		[&name](const InputActionMap &map)
+	{
+		return map.name == name;
+	});
+
+	if (iter != this->actionMaps.end())
+	{
+		InputActionMap &map = *iter;
+		map.active = active;
+		return true;
+	}
+	else
+	{
+		DebugLogWarning("Couldn't find input action map \"" + name + "\".");
+		return false;
+	}
 }
 
 void InputManager::setRelativeMouseMode(bool active)

--- a/OpenTESArena/src/Input/InputManager.h
+++ b/OpenTESArena/src/Input/InputManager.h
@@ -6,23 +6,22 @@
 #include <string_view>
 #include <vector>
 
-#include "SDL.h"
-
+#include "ApplicationEvents.h"
 #include "InputActionEvents.h"
 #include "InputActionMap.h"
+#include "PointerEvents.h"
 #include "../Math/Vector2.h"
 
-// A simple wrapper class for SDL2 input. 
+// Handles active input action maps, input listeners, and pointer input events.
 
-// This became a necessity after seeing that SDL_GetRelativeMouseState() can only be 
-// called once per frame, so its value must be stored somewhere.
+union SDL_Event;
 
 class InputManager
 {
 public:
 	using ListenerID = uint32_t;
 private:
-	struct ListenerEntry
+	struct InputActionListenerEntry
 	{
 		ListenerID id;
 		std::string actionName;
@@ -31,12 +30,73 @@ private:
 		void init(ListenerID id, const std::string_view &actionName, const InputActionCallback &callback);
 	};
 
-	std::vector<InputActionMap> actionMaps;
-	std::vector<ListenerEntry> listeners;
+	struct MouseButtonChangedListenerEntry
+	{
+		ListenerID id;
+		MouseButtonChangedCallback callback;
+
+		void init(ListenerID id, const MouseButtonChangedCallback &callback);
+	};
+
+	struct MouseButtonHeldListenerEntry
+	{
+		ListenerID id;
+		MouseButtonHeldCallback callback;
+
+		void init(ListenerID id, const MouseButtonHeldCallback &callback);
+	};
+
+	struct MouseScrollChangedListenerEntry
+	{
+		ListenerID id;
+		MouseScrollChangedCallback callback;
+
+		void init(ListenerID id, const MouseScrollChangedCallback &callback);
+	};
+
+	struct MouseMotionListenerEntry
+	{
+		ListenerID id;
+		MouseMotionCallback callback;
+
+		void init(ListenerID id, const MouseMotionCallback &callback);
+	};
+
+	struct ApplicationExitListenerEntry
+	{
+		ListenerID id;
+		ApplicationExitCallback callback;
+
+		void init(ListenerID id, const ApplicationExitCallback &callback);
+	};
+
+	struct WindowResizedListenerEntry
+	{
+		ListenerID id;
+		WindowResizedCallback callback;
+
+		void init(ListenerID id, const WindowResizedCallback &callback);
+	};
+
+	std::vector<InputActionMap> inputActionMaps;
+	std::vector<InputActionListenerEntry> inputActionListeners;
+	std::vector<MouseButtonChangedListenerEntry> mouseButtonChangedListeners;
+	std::vector<MouseButtonHeldListenerEntry> mouseButtonHeldListeners;
+	std::vector<MouseScrollChangedListenerEntry> mouseScrollChangedListeners;
+	std::vector<MouseMotionListenerEntry> mouseMotionListeners;
+	std::vector<ApplicationExitListenerEntry> applicationExitListeners;
+	std::vector<WindowResizedListenerEntry> windowResizedListeners;
 	Int2 mouseDelta;
 	ListenerID nextID;
 
-	std::optional<int> getListenerEntryIndex(ListenerID id, const std::string_view &actionName) const;
+	std::optional<int> getInputActionListenerEntryIndex(ListenerID id, const std::string_view &actionName) const;
+
+	template <typename EntryType>
+	static std::optional<int> getListenerEntryIndex(ListenerID id, const std::vector<EntryType> &listeners);
+	template <typename EntryType, typename CallbackType>
+	static void addListenerInternal(ListenerID id, CallbackType &&callback, std::vector<EntryType> &listeners);
+	template <typename EntryType>
+	static void removeListenerInternal(ListenerID id, std::vector<EntryType> &listeners);
 public:
 	InputManager();
 
@@ -61,8 +121,21 @@ public:
 
 	bool setInputActionMapActive(const std::string &name, bool active);
 
-	void addListener(ListenerID id, const std::string_view &actionName, const InputActionCallback &callback);
-	void removeListener(ListenerID id, const std::string_view &actionName);
+	void addInputActionListener(ListenerID id, const std::string_view &actionName, const InputActionCallback &callback);
+	void addMouseButtonChangedListener(ListenerID id, const MouseButtonChangedCallback &callback);
+	void addMouseButtonHeldListener(ListenerID id, const MouseButtonHeldCallback &callback);
+	void addMouseScrollChangedListener(ListenerID id, const MouseScrollChangedCallback &callback);
+	void addMouseMotionListener(ListenerID id, const MouseMotionCallback &callback);
+	void addApplicationExitListener(ListenerID id, const ApplicationExitCallback &callback);
+	void addWindowResizedListener(ListenerID id, const WindowResizedCallback &callback);
+
+	void removeInputActionListener(ListenerID id, const std::string_view &actionName);
+	void removeMouseButtonChangedListener(ListenerID id);
+	void removeMouseButtonHeldListener(ListenerID id);
+	void removeMouseScrollChangedListener(ListenerID id);
+	void removeMouseMotionListener(ListenerID id);
+	void removeApplicationExitListener(ListenerID id);
+	void removeWindowResizedListener(ListenerID id);
 
 	// Sets whether the mouse should move during motion events (for player camera).
 	void setRelativeMouseMode(bool active);

--- a/OpenTESArena/src/Input/InputManager.h
+++ b/OpenTESArena/src/Input/InputManager.h
@@ -14,6 +14,7 @@
 #include "InputActionEvents.h"
 #include "InputActionMap.h"
 #include "PointerEvents.h"
+#include "TextEvents.h"
 #include "../Math/Vector2.h"
 
 #include "components/utilities/BufferView.h"
@@ -35,7 +36,8 @@ private:
 		MouseScrollChanged,
 		MouseMotion,
 		ApplicationExit,
-		WindowResized
+		WindowResized,
+		TextInput
 	};
 
 	struct ListenerLookupEntry
@@ -111,6 +113,15 @@ private:
 		void reset();
 	};
 
+	struct TextInputListenerEntry
+	{
+		TextInputCallback callback;
+		bool enabled;
+
+		void init(const TextInputCallback &callback);
+		void reset();
+	};
+
 	std::vector<InputActionMap> inputActionMaps;
 
 	// Listener entry containers.
@@ -121,6 +132,7 @@ private:
 	std::vector<MouseMotionListenerEntry> mouseMotionListeners;
 	std::vector<ApplicationExitListenerEntry> applicationExitListeners;
 	std::vector<WindowResizedListenerEntry> windowResizedListeners;
+	std::vector<TextInputListenerEntry> textInputListeners;
 
 	// Look-up values for valid listener entries, shared by all listener containers.
 	std::unordered_map<ListenerID, ListenerLookupEntry> listenerLookupEntries;
@@ -133,6 +145,7 @@ private:
 	std::vector<int> freedMouseMotionListenerIndices;
 	std::vector<int> freedApplicationExitListenerIndices;
 	std::vector<int> freedWindowResizedListenerIndices;
+	std::vector<int> freedTextInputListenerIndices;
 
 	ListenerID nextListenerID;
 	std::vector<ListenerID> freedListenerIDs;
@@ -171,8 +184,9 @@ public:
 	bool mouseButtonIsUp(uint8_t button) const;
 	bool mouseWheeledUp(const SDL_Event &e) const;
 	bool mouseWheeledDown(const SDL_Event &e) const;
-	bool windowResized(const SDL_Event &e) const;
 	bool applicationExit(const SDL_Event &e) const;
+	bool windowResized(const SDL_Event &e) const;
+	bool isTextInput(const SDL_Event &e) const;
 	Int2 getMousePosition() const;
 	Int2 getMouseDelta() const;
 
@@ -189,6 +203,7 @@ public:
 	ListenerID addMouseMotionListener(const MouseMotionCallback &callback);
 	ListenerID addApplicationExitListener(const ApplicationExitCallback &callback);
 	ListenerID addWindowResizedListener(const WindowResizedCallback &callback);
+	ListenerID addTextInputListener(const TextInputCallback &callback);
 
 	void removeListener(ListenerID id);
 

--- a/OpenTESArena/src/Input/InputManager.h
+++ b/OpenTESArena/src/Input/InputManager.h
@@ -20,7 +20,7 @@
 class InputManager
 {
 public:
-	using ListenerID = int32_t;
+	using ListenerID = int;
 private:
 	struct InputActionListenerEntry
 	{
@@ -28,6 +28,7 @@ private:
 		InputActionCallback callback;
 
 		void init(const std::string_view &actionName, const InputActionCallback &callback);
+		void reset();
 	};
 
 	// Leave these as structs in the event that callback priorities become a thing.
@@ -36,6 +37,7 @@ private:
 		MouseButtonChangedCallback callback;
 
 		void init(const MouseButtonChangedCallback &callback);
+		void reset();
 	};
 
 	struct MouseButtonHeldListenerEntry
@@ -43,6 +45,7 @@ private:
 		MouseButtonHeldCallback callback;
 
 		void init(const MouseButtonHeldCallback &callback);
+		void reset();
 	};
 
 	struct MouseScrollChangedListenerEntry
@@ -50,6 +53,7 @@ private:
 		MouseScrollChangedCallback callback;
 
 		void init(const MouseScrollChangedCallback &callback);
+		void reset();
 	};
 
 	struct MouseMotionListenerEntry
@@ -57,6 +61,7 @@ private:
 		MouseMotionCallback callback;
 
 		void init(const MouseMotionCallback &callback);
+		void reset();
 	};
 
 	struct ApplicationExitListenerEntry
@@ -64,6 +69,7 @@ private:
 		ApplicationExitCallback callback;
 
 		void init(const ApplicationExitCallback &callback);
+		void reset();
 	};
 
 	struct WindowResizedListenerEntry
@@ -71,6 +77,7 @@ private:
 		WindowResizedCallback callback;
 
 		void init(const WindowResizedCallback &callback);
+		void reset();
 	};
 
 	std::vector<InputActionMap> inputActionMaps;

--- a/OpenTESArena/src/Input/InputManager.h
+++ b/OpenTESArena/src/Input/InputManager.h
@@ -46,6 +46,7 @@ private:
 	{
 		std::string actionName;
 		InputActionCallback callback;
+		bool enabled;
 
 		void init(const std::string_view &actionName, const InputActionCallback &callback);
 		void reset();
@@ -55,6 +56,7 @@ private:
 	struct MouseButtonChangedListenerEntry
 	{
 		MouseButtonChangedCallback callback;
+		bool enabled;
 
 		void init(const MouseButtonChangedCallback &callback);
 		void reset();
@@ -63,6 +65,7 @@ private:
 	struct MouseButtonHeldListenerEntry
 	{
 		MouseButtonHeldCallback callback;
+		bool enabled;
 
 		void init(const MouseButtonHeldCallback &callback);
 		void reset();
@@ -71,6 +74,7 @@ private:
 	struct MouseScrollChangedListenerEntry
 	{
 		MouseScrollChangedCallback callback;
+		bool enabled;
 
 		void init(const MouseScrollChangedCallback &callback);
 		void reset();
@@ -79,6 +83,7 @@ private:
 	struct MouseMotionListenerEntry
 	{
 		MouseMotionCallback callback;
+		bool enabled;
 
 		void init(const MouseMotionCallback &callback);
 		void reset();
@@ -87,6 +92,7 @@ private:
 	struct ApplicationExitListenerEntry
 	{
 		ApplicationExitCallback callback;
+		bool enabled;
 
 		void init(const ApplicationExitCallback &callback);
 		void reset();
@@ -95,6 +101,7 @@ private:
 	struct WindowResizedListenerEntry
 	{
 		WindowResizedCallback callback;
+		bool enabled;
 
 		void init(const WindowResizedCallback &callback);
 		void reset();
@@ -137,8 +144,6 @@ private:
 	template <typename EntryType, typename CallbackType>
 	ListenerID addListenerInternal(CallbackType &&callback, ListenerType listenerType, std::vector<EntryType> &listeners,
 		std::vector<int> &freedListenerIndices);
-	template <typename EntryType>
-	void removeListenerInternal(ListenerID id, std::vector<EntryType> &listeners, std::vector<int> &freedListenerIndices);
 
 	void cacheSdlEvents();
 	
@@ -181,13 +186,10 @@ public:
 	ListenerID addApplicationExitListener(const ApplicationExitCallback &callback);
 	ListenerID addWindowResizedListener(const WindowResizedCallback &callback);
 
-	void removeInputActionListener(ListenerID id);
-	void removeMouseButtonChangedListener(ListenerID id);
-	void removeMouseButtonHeldListener(ListenerID id);
-	void removeMouseScrollChangedListener(ListenerID id);
-	void removeMouseMotionListener(ListenerID id);
-	void removeApplicationExitListener(ListenerID id);
-	void removeWindowResizedListener(ListenerID id);
+	void removeListener(ListenerID id);
+
+	// Sets whether a valid listener can hear input callbacks.
+	void setListenerEnabled(ListenerID id, bool enabled);
 
 	// Sets whether the mouse should move during motion events (for player camera).
 	void setRelativeMouseMode(bool active);

--- a/OpenTESArena/src/Input/InputManager.h
+++ b/OpenTESArena/src/Input/InputManager.h
@@ -7,6 +7,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include "SDL_events.h"
+
 #include "ApplicationEvents.h"
 #include "InputActionEvents.h"
 #include "InputActionMap.h"
@@ -14,8 +16,6 @@
 #include "../Math/Vector2.h"
 
 // Handles active input action maps, input listeners, and pointer input events.
-
-union SDL_Event;
 
 class InputManager
 {
@@ -99,6 +99,8 @@ private:
 	ListenerID nextListenerID;
 	std::vector<ListenerID> freedListenerIDs;
 
+	std::vector<SDL_Event> cachedEvents; // @temp: only for compatibility with old event system until completely moved over.
+
 	Int2 mouseDelta;
 
 	ListenerID getNextListenerID();
@@ -128,6 +130,10 @@ public:
 	Int2 getMousePosition() const;
 	Int2 getMouseDelta() const;
 
+	// @temp until Game::handleEvents() is removed
+	int getEventCount() const;
+	const SDL_Event &getEvent(int index) const;
+
 	bool setInputActionMapActive(const std::string &name, bool active);
 
 	ListenerID addInputActionListener(const std::string_view &actionName, const InputActionCallback &callback);
@@ -149,7 +155,7 @@ public:
 	// Sets whether the mouse should move during motion events (for player camera).
 	void setRelativeMouseMode(bool active);
 
-	// Updates input values whose associated SDL functions should only be called once per frame.
+	// Handle input listener callbacks, etc..
 	void update();
 };
 

--- a/OpenTESArena/src/Input/InputManager.h
+++ b/OpenTESArena/src/Input/InputManager.h
@@ -23,6 +23,25 @@ class InputManager
 public:
 	using ListenerID = int;
 private:
+	enum class ListenerType
+	{
+		InputAction,
+		MouseButtonChanged,
+		MouseButtonHeld,
+		MouseScrollChanged,
+		MouseMotion,
+		ApplicationExit,
+		WindowResized
+	};
+
+	struct ListenerLookupEntry
+	{
+		ListenerType type; // The array the index points into.
+		int index;
+
+		void init(ListenerType type, int index);
+	};
+
 	struct InputActionListenerEntry
 	{
 		std::string actionName;
@@ -92,8 +111,8 @@ private:
 	std::vector<ApplicationExitListenerEntry> applicationExitListeners;
 	std::vector<WindowResizedListenerEntry> windowResizedListeners;
 
-	// Indices to valid listener entries, shared by all listener containers.
-	std::unordered_map<ListenerID, int> listenerIndices;
+	// Look-up values for valid listener entries, shared by all listener containers.
+	std::unordered_map<ListenerID, ListenerLookupEntry> listenerLookupEntries;
 
 	// Indices to listener entries that were used but can be reclaimed by a future registration.
 	std::vector<int> freedInputActionListenerIndices;
@@ -116,7 +135,7 @@ private:
 	bool isInTextEntryMode() const;
 
 	template <typename EntryType, typename CallbackType>
-	ListenerID addListenerInternal(CallbackType &&callback, std::vector<EntryType> &listeners,
+	ListenerID addListenerInternal(CallbackType &&callback, ListenerType listenerType, std::vector<EntryType> &listeners,
 		std::vector<int> &freedListenerIndices);
 	template <typename EntryType>
 	void removeListenerInternal(ListenerID id, std::vector<EntryType> &listeners, std::vector<int> &freedListenerIndices);

--- a/OpenTESArena/src/Input/InputManager.h
+++ b/OpenTESArena/src/Input/InputManager.h
@@ -20,7 +20,7 @@
 class InputManager
 {
 public:
-	using ListenerID = uint32_t;
+	using ListenerID = int32_t;
 private:
 	struct InputActionListenerEntry
 	{
@@ -110,15 +110,21 @@ private:
 		std::vector<int> &freedListenerIndices);
 	template <typename EntryType>
 	void removeListenerInternal(ListenerID id, std::vector<EntryType> &listeners, std::vector<int> &freedListenerIndices);
+
+	void cacheSdlEvents();
 public:
 	InputManager();
 
 	void init();
 
+	bool isKeyEvent(const SDL_Event &e) const;
 	bool keyPressed(const SDL_Event &e, SDL_Keycode keycode) const;
 	bool keyReleased(const SDL_Event &e, SDL_Keycode keycode) const;
 	bool keyIsDown(SDL_Scancode scancode) const;
 	bool keyIsUp(SDL_Scancode scancode) const;
+	bool isMouseButtonEvent(const SDL_Event &e) const;
+	bool isMouseWheelEvent(const SDL_Event &e) const;
+	bool isMouseMotionEvent(const SDL_Event &e) const;
 	bool mouseButtonPressed(const SDL_Event &e, uint8_t button) const;
 	bool mouseButtonReleased(const SDL_Event &e, uint8_t button) const;
 	bool mouseButtonIsDown(uint8_t button) const;

--- a/OpenTESArena/src/Input/InputManager.h
+++ b/OpenTESArena/src/Input/InputManager.h
@@ -160,7 +160,8 @@ private:
 	ListenerID addListenerInternal(CallbackType &&callback, ListenerType listenerType, std::vector<EntryType> &listeners,
 		std::vector<int> &freedListenerIndices);
 	
-	void handleHeldInputs(Game &game, const BufferView<const InputActionMap*> &activeMaps, uint32_t mouseState,
+	void handleHeldInputs(Game &game, const BufferView<const InputActionMap*> &activeMaps,
+		const BufferView<const InputActionListenerEntry*> &enabledInputActionListeners, uint32_t mouseState,
 		const Int2 &mousePosition, double dt);
 public:
 	InputManager();

--- a/OpenTESArena/src/Input/InputManager.h
+++ b/OpenTESArena/src/Input/InputManager.h
@@ -16,7 +16,11 @@
 #include "PointerEvents.h"
 #include "../Math/Vector2.h"
 
+#include "components/utilities/BufferView.h"
+
 // Handles active input action maps, input listeners, and pointer input events.
+
+struct ButtonProxy;
 
 class InputManager
 {
@@ -195,7 +199,8 @@ public:
 	void setRelativeMouseMode(bool active);
 
 	// Handle input listener callbacks, etc..
-	void update(Game &game, double dt, const std::function<void()> &onFinishedProcessingEvent);
+	void update(Game &game, double dt, const BufferView<const ButtonProxy> &buttonProxies,
+		const std::function<void()> &onFinishedProcessingEvent);
 };
 
 #endif

--- a/OpenTESArena/src/Input/InputManager.h
+++ b/OpenTESArena/src/Input/InputManager.h
@@ -213,6 +213,9 @@ public:
 	// Sets whether the mouse should move during motion events (for player camera).
 	void setRelativeMouseMode(bool active);
 
+	// Sets whether keyboard input is interpreted as text input or hotkeys.
+	void setTextInputMode(bool active);
+
 	// Handle input listener callbacks, etc..
 	void update(Game &game, double dt, const BufferView<const ButtonProxy> &buttonProxies,
 		const std::function<void()> &onFinishedProcessingEvent);

--- a/OpenTESArena/src/Input/InputManager.h
+++ b/OpenTESArena/src/Input/InputManager.h
@@ -160,7 +160,8 @@ private:
 	ListenerID addListenerInternal(CallbackType &&callback, ListenerType listenerType, std::vector<EntryType> &listeners,
 		std::vector<int> &freedListenerIndices);
 	
-	void handleHeldInputs(Game &game, uint32_t mouseState, const Int2 &mousePosition, double dt);
+	void handleHeldInputs(Game &game, const BufferView<const InputActionMap*> &activeMaps, uint32_t mouseState,
+		const Int2 &mousePosition, double dt);
 public:
 	InputManager();
 

--- a/OpenTESArena/src/Input/InputManager.h
+++ b/OpenTESArena/src/Input/InputManager.h
@@ -169,7 +169,7 @@ public:
 	void setRelativeMouseMode(bool active);
 
 	// Handle input listener callbacks, etc..
-	void update();
+	void update(double dt);
 };
 
 #endif

--- a/OpenTESArena/src/Input/InputManager.h
+++ b/OpenTESArena/src/Input/InputManager.h
@@ -112,6 +112,8 @@ private:
 
 	ListenerID getNextListenerID();
 
+	bool isInTextEntryMode() const;
+
 	template <typename EntryType, typename CallbackType>
 	ListenerID addListenerInternal(CallbackType &&callback, std::vector<EntryType> &listeners,
 		std::vector<int> &freedListenerIndices);

--- a/OpenTESArena/src/Input/InputManager.h
+++ b/OpenTESArena/src/Input/InputManager.h
@@ -2,9 +2,11 @@
 #define INPUT_MANAGER_H
 
 #include <cstdint>
+#include <vector>
 
 #include "SDL.h"
 
+#include "InputActionMap.h"
 #include "../Math/Vector2.h"
 
 // A simple wrapper class for SDL2 input. 
@@ -14,10 +16,13 @@
 
 class InputManager
 {
-private:	
+private:
+	std::vector<InputActionMap> actionMaps;
 	Int2 mouseDelta;
 public:
 	InputManager();
+
+	void init();
 
 	bool keyPressed(const SDL_Event &e, SDL_Keycode keycode) const;
 	bool keyReleased(const SDL_Event &e, SDL_Keycode keycode) const;
@@ -33,6 +38,8 @@ public:
 	bool applicationExit(const SDL_Event &e) const;
 	Int2 getMousePosition() const;
 	Int2 getMouseDelta() const;
+
+	bool setInputActionMapActive(const std::string &name, bool active);
 
 	// Sets whether the mouse should move during motion events (for player camera).
 	void setRelativeMouseMode(bool active);

--- a/OpenTESArena/src/Input/InputManager.h
+++ b/OpenTESArena/src/Input/InputManager.h
@@ -2,6 +2,7 @@
 #define INPUT_MANAGER_H
 
 #include <cstdint>
+#include <functional>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -173,7 +174,7 @@ public:
 	void setRelativeMouseMode(bool active);
 
 	// Handle input listener callbacks, etc..
-	void update(double dt);
+	void update(double dt, const std::function<void()> &onFinishedProcessingEvent);
 };
 
 #endif

--- a/OpenTESArena/src/Input/InputManager.h
+++ b/OpenTESArena/src/Input/InputManager.h
@@ -150,8 +150,6 @@ private:
 	ListenerID nextListenerID;
 	std::vector<ListenerID> freedListenerIDs;
 
-	std::vector<SDL_Event> cachedEvents; // @temp: only for compatibility with old event system until completely moved over.
-
 	Int2 mouseDelta;
 
 	ListenerID getNextListenerID();
@@ -161,8 +159,6 @@ private:
 	template <typename EntryType, typename CallbackType>
 	ListenerID addListenerInternal(CallbackType &&callback, ListenerType listenerType, std::vector<EntryType> &listeners,
 		std::vector<int> &freedListenerIndices);
-
-	void cacheSdlEvents();
 	
 	void handleHeldInputs(Game &game, uint32_t mouseState, const Int2 &mousePosition, double dt);
 public:
@@ -189,10 +185,6 @@ public:
 	bool isTextInput(const SDL_Event &e) const;
 	Int2 getMousePosition() const;
 	Int2 getMouseDelta() const;
-
-	// @temp until Game::handleEvents() is removed
-	int getEventCount() const;
-	const SDL_Event &getEvent(int index) const;
 
 	bool setInputActionMapActive(const std::string &name, bool active);
 

--- a/OpenTESArena/src/Input/InputManager.h
+++ b/OpenTESArena/src/Input/InputManager.h
@@ -2,10 +2,13 @@
 #define INPUT_MANAGER_H
 
 #include <cstdint>
+#include <string>
+#include <string_view>
 #include <vector>
 
 #include "SDL.h"
 
+#include "InputActionEvents.h"
 #include "InputActionMap.h"
 #include "../Math/Vector2.h"
 
@@ -16,13 +19,30 @@
 
 class InputManager
 {
+public:
+	using ListenerID = uint32_t;
 private:
+	struct ListenerEntry
+	{
+		ListenerID id;
+		std::string actionName;
+		InputActionCallback callback;
+
+		void init(ListenerID id, const std::string_view &actionName, const InputActionCallback &callback);
+	};
+
 	std::vector<InputActionMap> actionMaps;
+	std::vector<ListenerEntry> listeners;
 	Int2 mouseDelta;
+	ListenerID nextID;
+
+	std::optional<int> getListenerEntryIndex(ListenerID id, const std::string_view &actionName) const;
 public:
 	InputManager();
 
 	void init();
+
+	ListenerID nextListenerID();
 
 	bool keyPressed(const SDL_Event &e, SDL_Keycode keycode) const;
 	bool keyReleased(const SDL_Event &e, SDL_Keycode keycode) const;
@@ -40,6 +60,9 @@ public:
 	Int2 getMouseDelta() const;
 
 	bool setInputActionMapActive(const std::string &name, bool active);
+
+	void addListener(ListenerID id, const std::string_view &actionName, const InputActionCallback &callback);
+	void removeListener(ListenerID id, const std::string_view &actionName);
 
 	// Sets whether the mouse should move during motion events (for player camera).
 	void setRelativeMouseMode(bool active);

--- a/OpenTESArena/src/Input/InputManager.h
+++ b/OpenTESArena/src/Input/InputManager.h
@@ -119,6 +119,8 @@ private:
 	void removeListenerInternal(ListenerID id, std::vector<EntryType> &listeners, std::vector<int> &freedListenerIndices);
 
 	void cacheSdlEvents();
+	
+	void handleHeldInputs(uint32_t mouseState, const Int2 &mousePosition, double dt);
 public:
 	InputManager();
 

--- a/OpenTESArena/src/Input/InputManager.h
+++ b/OpenTESArena/src/Input/InputManager.h
@@ -123,7 +123,7 @@ private:
 
 	void cacheSdlEvents();
 	
-	void handleHeldInputs(uint32_t mouseState, const Int2 &mousePosition, double dt);
+	void handleHeldInputs(Game &game, uint32_t mouseState, const Int2 &mousePosition, double dt);
 public:
 	InputManager();
 
@@ -174,7 +174,7 @@ public:
 	void setRelativeMouseMode(bool active);
 
 	// Handle input listener callbacks, etc..
-	void update(double dt, const std::function<void()> &onFinishedProcessingEvent);
+	void update(Game &game, double dt, const std::function<void()> &onFinishedProcessingEvent);
 };
 
 #endif

--- a/OpenTESArena/src/Input/PointerEvents.h
+++ b/OpenTESArena/src/Input/PointerEvents.h
@@ -16,6 +16,7 @@ using MouseButtonHeldCallback = std::function<void(MouseButtonType type, const I
 using MouseScrollChangedCallback = std::function<void(MouseWheelScrollType type, const Int2 &position)>;
 
 // When the mouse cursor changes position on-screen.
-using MousePositionDeltaCallback = std::function<void(int dx, int dy)>;
+// @todo: need to clarify if this is physical mouse position delta or on-screen mouse position delta.
+using MouseMotionCallback = std::function<void(int dx, int dy)>;
 
 #endif

--- a/OpenTESArena/src/Input/PointerEvents.h
+++ b/OpenTESArena/src/Input/PointerEvents.h
@@ -6,17 +6,19 @@
 #include "PointerTypes.h"
 #include "../Math/Vector2.h"
 
+class Game;
+
 // When a mouse button is pressed or released.
-using MouseButtonChangedCallback = std::function<void(MouseButtonType type, const Int2 &position, bool pressed)>;
+using MouseButtonChangedCallback = std::function<void(Game &game, MouseButtonType type, const Int2 &position, bool pressed)>;
 
 // While a mouse button is held down.
-using MouseButtonHeldCallback = std::function<void(MouseButtonType type, const Int2 &position, double dt)>;
+using MouseButtonHeldCallback = std::function<void(Game &game, MouseButtonType type, const Int2 &position, double dt)>;
 
 // When a mouse scroll wheel moves up or down.
-using MouseScrollChangedCallback = std::function<void(MouseWheelScrollType type, const Int2 &position)>;
+using MouseScrollChangedCallback = std::function<void(Game &game, MouseWheelScrollType type, const Int2 &position)>;
 
 // When the mouse cursor changes position on-screen.
 // @todo: need to clarify if this is physical mouse position delta or on-screen mouse position delta.
-using MouseMotionCallback = std::function<void(int dx, int dy)>;
+using MouseMotionCallback = std::function<void(Game &game, int dx, int dy)>;
 
 #endif

--- a/OpenTESArena/src/Input/PointerEvents.h
+++ b/OpenTESArena/src/Input/PointerEvents.h
@@ -7,10 +7,10 @@
 #include "../Math/Vector2.h"
 
 // When a mouse button is pressed or released.
-using MouseButtonChangedCallback = std::function<void(MouseButtonType type, bool pressed, const Int2 &position)>;
+using MouseButtonChangedCallback = std::function<void(MouseButtonType type, const Int2 &position, bool pressed)>;
 
 // While a mouse button is held down.
-using MouseButtonHeldCallback = std::function<void(MouseButtonType type, const Int2 &position)>;
+using MouseButtonHeldCallback = std::function<void(MouseButtonType type, const Int2 &position, double dt)>;
 
 // When a mouse scroll wheel moves up or down.
 using MouseScrollChangedCallback = std::function<void(MouseWheelScrollType type, const Int2 &position)>;

--- a/OpenTESArena/src/Input/PointerEvents.h
+++ b/OpenTESArena/src/Input/PointerEvents.h
@@ -7,7 +7,7 @@
 #include "../Math/Vector2.h"
 
 // When a mouse button is pressed or released.
-using MouseButtonChangedCallback = std::function<void(MouseButtonType type, const Int2 &position, bool pressed)>;
+using MouseButtonChangedCallback = std::function<void(MouseButtonType type, bool pressed, const Int2 &position)>;
 
 // While a mouse button is held down.
 using MouseButtonHeldCallback = std::function<void(MouseButtonType type, const Int2 &position)>;

--- a/OpenTESArena/src/Input/TextEvents.h
+++ b/OpenTESArena/src/Input/TextEvents.h
@@ -1,0 +1,10 @@
+#ifndef TEXT_EVENTS_H
+#define TEXT_EVENTS_H
+
+#include <functional>
+#include <string>
+
+// When an alphanumeric key press or hold occurs during text entry mode.
+using TextInputCallback = std::function<void(const std::string &text)>;
+
+#endif

--- a/OpenTESArena/src/Input/TextEvents.h
+++ b/OpenTESArena/src/Input/TextEvents.h
@@ -2,9 +2,9 @@
 #define TEXT_EVENTS_H
 
 #include <functional>
-#include <string>
+#include <string_view>
 
 // When an alphanumeric key press or hold occurs during text entry mode.
-using TextInputCallback = std::function<void(const std::string &text)>;
+using TextInputCallback = std::function<void(const std::string_view &text)>;
 
 #endif

--- a/OpenTESArena/src/Interface/AutomapPanel.cpp
+++ b/OpenTESArena/src/Interface/AutomapPanel.cpp
@@ -66,23 +66,15 @@ bool AutomapPanel::init(const CoordDouble3 &playerCoord, const VoxelDouble2 &pla
 		AutomapUiView::BackToGameButtonHeight,
 		AutomapUiController::onBackToGameButtonSelected);
 
+	this->addButtonProxy(MouseButtonType::Left, this->backToGameButton.getRect(),
+		[&game]() { AutomapUiController::onBackToGameButtonSelected(game); });
+
 	auto &inputManager = game.getInputManager();
 	inputManager.setInputActionMapActive(InputActionMapName::Automap, true);
 
 	auto backToGameInputActionFunc = AutomapUiController::onBackToGameInputAction;
 	this->addInputActionListener(AutomapUiController::getInputActionName(), backToGameInputActionFunc);
 	this->addInputActionListener(AutomapUiController::getBackToGameInputActionName(), backToGameInputActionFunc);
-
-	this->addMouseButtonChangedListener(
-		[this](Game &game, MouseButtonType buttonType, const Int2 &position, bool pressed)
-	{
-		const Rect exitButtonRect(
-			this->backToGameButton.getX(),
-			this->backToGameButton.getY(),
-			this->backToGameButton.getWidth(),
-			this->backToGameButton.getHeight());
-		AutomapUiController::onMouseButtonChanged(game, buttonType, position, pressed, exitButtonRect);
-	});
 
 	this->addMouseButtonHeldListener(
 		[this](Game &game, MouseButtonType buttonType, const Int2 &position, double dt)

--- a/OpenTESArena/src/Interface/AutomapPanel.cpp
+++ b/OpenTESArena/src/Interface/AutomapPanel.cpp
@@ -69,29 +69,25 @@ bool AutomapPanel::init(const CoordDouble3 &playerCoord, const VoxelDouble2 &pla
 	auto &inputManager = game.getInputManager();
 	inputManager.setInputActionMapActive(InputActionMapName::Automap, true);
 
-	auto backToGameInputActionFunc = [&game](const InputActionCallbackValues &values)
-	{
-		AutomapUiController::onBackToGameInputAction(values, game);
-	};
-
+	auto backToGameInputActionFunc = AutomapUiController::onBackToGameInputAction;
 	this->addInputActionListener(AutomapUiController::getInputActionName(), backToGameInputActionFunc);
 	this->addInputActionListener(AutomapUiController::getBackToGameInputActionName(), backToGameInputActionFunc);
 
 	this->addMouseButtonChangedListener(
-		[this, &game](MouseButtonType buttonType, const Int2 &position, bool pressed)
+		[this](Game &game, MouseButtonType buttonType, const Int2 &position, bool pressed)
 	{
 		const Rect exitButtonRect(
 			this->backToGameButton.getX(),
 			this->backToGameButton.getY(),
 			this->backToGameButton.getWidth(),
 			this->backToGameButton.getHeight());
-		AutomapUiController::onMouseButtonChanged(buttonType, position, pressed, game, exitButtonRect);
+		AutomapUiController::onMouseButtonChanged(game, buttonType, position, pressed, exitButtonRect);
 	});
 
 	this->addMouseButtonHeldListener(
-		[this, &game](MouseButtonType buttonType, const Int2 &position, double dt)
+		[this](Game &game, MouseButtonType buttonType, const Int2 &position, double dt)
 	{
-		AutomapUiController::onMouseButtonHeld(buttonType, position, dt, game, &this->automapOffset);
+		AutomapUiController::onMouseButtonHeld(game, buttonType, position, dt, &this->automapOffset);
 	});
 
 	const VoxelInt3 playerVoxel = VoxelUtils::pointToVoxel(playerCoord.point);

--- a/OpenTESArena/src/Interface/AutomapPanel.cpp
+++ b/OpenTESArena/src/Interface/AutomapPanel.cpp
@@ -15,6 +15,7 @@
 #include "../Game/CardinalDirectionName.h"
 #include "../Game/Game.h"
 #include "../Game/Options.h"
+#include "../Input/InputActionMapName.h"
 #include "../Math/Rect.h"
 #include "../Math/Vector2.h"
 #include "../Media/Color.h"
@@ -38,6 +39,12 @@
 AutomapPanel::AutomapPanel(Game &game)
 	: Panel(game) { }
 
+AutomapPanel::~AutomapPanel()
+{
+	auto &inputManager = this->getGame().getInputManager();
+	inputManager.setInputActionMapActive(InputActionMapName::Automap, false);
+}
+
 bool AutomapPanel::init(const CoordDouble3 &playerCoord, const VoxelDouble2 &playerDirection,
 	const ChunkManager &chunkManager, const std::string &locationName)
 {
@@ -58,6 +65,34 @@ bool AutomapPanel::init(const CoordDouble3 &playerCoord, const VoxelDouble2 &pla
 		AutomapUiView::BackToGameButtonWidth,
 		AutomapUiView::BackToGameButtonHeight,
 		AutomapUiController::onBackToGameButtonSelected);
+
+	auto &inputManager = game.getInputManager();
+	inputManager.setInputActionMapActive(InputActionMapName::Automap, true);
+
+	auto backToGameInputActionFunc = [&game](const InputActionCallbackValues &values)
+	{
+		AutomapUiController::onBackToGameInputAction(values, game);
+	};
+
+	this->addInputActionListener(AutomapUiController::getInputActionName(), backToGameInputActionFunc);
+	this->addInputActionListener(AutomapUiController::getBackToGameInputActionName(), backToGameInputActionFunc);
+
+	this->addMouseButtonChangedListener(
+		[this, &game](MouseButtonType buttonType, const Int2 &position, bool pressed)
+	{
+		const Rect exitButtonRect(
+			this->backToGameButton.getX(),
+			this->backToGameButton.getY(),
+			this->backToGameButton.getWidth(),
+			this->backToGameButton.getHeight());
+		AutomapUiController::onMouseButtonChanged(buttonType, position, pressed, game, exitButtonRect);
+	});
+
+	this->addMouseButtonHeldListener(
+		[this, &game](MouseButtonType buttonType, const Int2 &position, double dt)
+	{
+		AutomapUiController::onMouseButtonHeld(buttonType, position, dt, game, &this->automapOffset);
+	});
 
 	const VoxelInt3 playerVoxel = VoxelUtils::pointToVoxel(playerCoord.point);
 	const CoordInt2 playerCoordXZ(playerCoord.chunk, VoxelInt2(playerVoxel.x, playerVoxel.z));
@@ -125,72 +160,6 @@ std::optional<CursorData> AutomapPanel::getCurrentCursor() const
 	return CursorData(*textureBuilderID, *paletteID, CursorAlignment::BottomLeft);
 }
 
-void AutomapPanel::handleEvent(const SDL_Event &e)
-{
-	const auto &inputManager = this->getGame().getInputManager();
-	bool escapePressed = inputManager.keyPressed(e, SDLK_ESCAPE);
-	bool nPressed = inputManager.keyPressed(e, SDLK_n);
-
-	if (escapePressed || nPressed)
-	{
-		this->backToGameButton.click(this->getGame());
-	}
-
-	bool leftClick = inputManager.mouseButtonPressed(e, SDL_BUTTON_LEFT);
-
-	if (leftClick)
-	{
-		const Int2 mousePosition = inputManager.getMousePosition();
-		const Int2 mouseOriginalPoint = this->getGame().getRenderer()
-			.nativeToOriginal(mousePosition);
-
-		// Check if "Exit" was clicked.
-		if (this->backToGameButton.contains(mouseOriginalPoint))
-		{
-			this->backToGameButton.click(this->getGame());
-		}
-	}
-
-	// @todo: text events if in text mode
-}
-
-void AutomapPanel::handleMouse(double dt)
-{
-	const auto &inputManager = this->getGame().getInputManager();
-	const bool leftClick = inputManager.mouseButtonIsDown(SDL_BUTTON_LEFT);
-
-	const Int2 mousePosition = inputManager.getMousePosition();
-	const Int2 mouseOriginalPoint = this->getGame().getRenderer()
-		.nativeToOriginal(mousePosition);
-
-	// Check if the LMB is held on one of the compass directions.
-	if (leftClick)
-	{
-		// @todo: move to AutomapUiController
-
-		const double scrollSpeed = AutomapUiView::ScrollSpeed * dt;
-
-		// Modify the automap offset based on input. The directions are reversed because
-		// to go right means to push the map left.
-		if (AutomapUiView::CompassRightRegion.contains(mouseOriginalPoint))
-		{
-			this->automapOffset = this->automapOffset - (Double2::UnitX * scrollSpeed);
-		}
-		else if (AutomapUiView::CompassLeftRegion.contains(mouseOriginalPoint))
-		{
-			this->automapOffset = this->automapOffset + (Double2::UnitX * scrollSpeed);
-		}
-		else if (AutomapUiView::CompassUpRegion.contains(mouseOriginalPoint))
-		{
-			this->automapOffset = this->automapOffset + (Double2::UnitY * scrollSpeed);
-		}
-		else if (AutomapUiView::CompassDownRegion.contains(mouseOriginalPoint))
-		{
-			this->automapOffset = this->automapOffset - (Double2::UnitY * scrollSpeed);
-		}
-	}
-}
-
 void AutomapPanel::drawTooltip(const std::string &text, Renderer &renderer)
 {
 	const Texture tooltip = TextureUtils::createTooltip(text, this->getGame().getFontLibrary(), renderer);
@@ -206,11 +175,6 @@ void AutomapPanel::drawTooltip(const std::string &text, Renderer &renderer)
 		(mouseY - 1) : (mouseY - tooltip.getHeight());
 
 	renderer.drawOriginal(tooltip, x, y);
-}
-
-void AutomapPanel::tick(double dt)
-{
-	this->handleMouse(dt);
 }
 
 void AutomapPanel::render(Renderer &renderer)

--- a/OpenTESArena/src/Interface/AutomapPanel.h
+++ b/OpenTESArena/src/Interface/AutomapPanel.h
@@ -41,20 +41,15 @@ private:
 	// XZ coordinate offset in automap space, stored as a real so scroll position can be sub-pixel.
 	Double2 automapOffset;
 
-	// Listen for when the LMB is held on a compass direction.
-	void handleMouse(double dt);
-
 	void drawTooltip(const std::string &text, Renderer &renderer);
 public:
 	AutomapPanel(Game &game);
-	~AutomapPanel() override = default;
+	~AutomapPanel() override;
 
 	bool init(const CoordDouble3 &playerCoord, const VoxelDouble2 &playerDirection,
 		const ChunkManager &chunkManager, const std::string &locationName);
 
 	virtual std::optional<CursorData> getCurrentCursor() const override;
-	virtual void handleEvent(const SDL_Event &e) override;
-	virtual void tick(double dt) override;
 	virtual void render(Renderer &renderer) override;
 };
 

--- a/OpenTESArena/src/Interface/AutomapUiController.cpp
+++ b/OpenTESArena/src/Interface/AutomapUiController.cpp
@@ -27,19 +27,6 @@ void AutomapUiController::onBackToGameInputAction(const InputActionCallbackValue
 	}
 }
 
-void AutomapUiController::onMouseButtonChanged(Game &game, MouseButtonType buttonType, const Int2 &position,
-	bool pressed, const Rect &exitButtonRect)
-{
-	if ((buttonType == MouseButtonType::Left) && pressed)
-	{
-		const Int2 classicPoint = game.getRenderer().nativeToOriginal(position);
-		if (exitButtonRect.contains(classicPoint))
-		{
-			AutomapUiController::onBackToGameButtonSelected(game);
-		}
-	}
-}
-
 void AutomapUiController::onMouseButtonHeld(Game &game, MouseButtonType buttonType, const Int2 &position,
 	double dt, Double2 *automapOffset)
 {

--- a/OpenTESArena/src/Interface/AutomapUiController.cpp
+++ b/OpenTESArena/src/Interface/AutomapUiController.cpp
@@ -1,8 +1,71 @@
 #include "AutomapUiController.h"
+#include "AutomapUiView.h"
 #include "GameWorldPanel.h"
 #include "../Game/Game.h"
+#include "../Input/InputActionName.h"
+
+std::string AutomapUiController::getInputActionName()
+{
+	return InputActionName::Automap;
+}
+
+std::string AutomapUiController::getBackToGameInputActionName()
+{
+	return InputActionName::Back;
+}
 
 void AutomapUiController::onBackToGameButtonSelected(Game &game)
 {
 	game.setPanel<GameWorldPanel>();
+}
+
+void AutomapUiController::onBackToGameInputAction(const InputActionCallbackValues &values, Game &game)
+{
+	if (values.performed)
+	{
+		AutomapUiController::onBackToGameButtonSelected(game);
+	}
+}
+
+void AutomapUiController::onMouseButtonChanged(MouseButtonType buttonType, const Int2 &position, bool pressed,
+	Game &game, const Rect &exitButtonRect)
+{
+	if ((buttonType == MouseButtonType::Left) && pressed)
+	{
+		const Int2 classicPoint = game.getRenderer().nativeToOriginal(position);
+		if (exitButtonRect.contains(classicPoint))
+		{
+			AutomapUiController::onBackToGameButtonSelected(game);
+		}
+	}
+}
+
+void AutomapUiController::onMouseButtonHeld(MouseButtonType buttonType, const Int2 &position, double dt,
+	Game &game, Double2 *automapOffset)
+{
+	// Listen for when the LMB is held on a compass direction.
+	if (buttonType == MouseButtonType::Left)
+	{
+		const Int2 originalPoint = game.getRenderer().nativeToOriginal(position);
+		const double scrollSpeed = AutomapUiView::ScrollSpeed * dt;
+
+		// Modify the automap offset based on input. The directions are reversed because
+		// to go right means to push the map left.
+		if (AutomapUiView::CompassRightRegion.contains(originalPoint))
+		{
+			*automapOffset = *automapOffset - (Double2::UnitX * scrollSpeed);
+		}
+		else if (AutomapUiView::CompassLeftRegion.contains(originalPoint))
+		{
+			*automapOffset = *automapOffset + (Double2::UnitX * scrollSpeed);
+		}
+		else if (AutomapUiView::CompassUpRegion.contains(originalPoint))
+		{
+			*automapOffset = *automapOffset + (Double2::UnitY * scrollSpeed);
+		}
+		else if (AutomapUiView::CompassDownRegion.contains(originalPoint))
+		{
+			*automapOffset = *automapOffset - (Double2::UnitY * scrollSpeed);
+		}
+	}
 }

--- a/OpenTESArena/src/Interface/AutomapUiController.cpp
+++ b/OpenTESArena/src/Interface/AutomapUiController.cpp
@@ -19,16 +19,16 @@ void AutomapUiController::onBackToGameButtonSelected(Game &game)
 	game.setPanel<GameWorldPanel>();
 }
 
-void AutomapUiController::onBackToGameInputAction(const InputActionCallbackValues &values, Game &game)
+void AutomapUiController::onBackToGameInputAction(const InputActionCallbackValues &values)
 {
 	if (values.performed)
 	{
-		AutomapUiController::onBackToGameButtonSelected(game);
+		AutomapUiController::onBackToGameButtonSelected(values.game);
 	}
 }
 
-void AutomapUiController::onMouseButtonChanged(MouseButtonType buttonType, const Int2 &position, bool pressed,
-	Game &game, const Rect &exitButtonRect)
+void AutomapUiController::onMouseButtonChanged(Game &game, MouseButtonType buttonType, const Int2 &position,
+	bool pressed, const Rect &exitButtonRect)
 {
 	if ((buttonType == MouseButtonType::Left) && pressed)
 	{
@@ -40,8 +40,8 @@ void AutomapUiController::onMouseButtonChanged(MouseButtonType buttonType, const
 	}
 }
 
-void AutomapUiController::onMouseButtonHeld(MouseButtonType buttonType, const Int2 &position, double dt,
-	Game &game, Double2 *automapOffset)
+void AutomapUiController::onMouseButtonHeld(Game &game, MouseButtonType buttonType, const Int2 &position,
+	double dt, Double2 *automapOffset)
 {
 	// Listen for when the LMB is held on a compass direction.
 	if (buttonType == MouseButtonType::Left)

--- a/OpenTESArena/src/Interface/AutomapUiController.h
+++ b/OpenTESArena/src/Interface/AutomapUiController.h
@@ -18,15 +18,15 @@ namespace AutomapUiController
 	std::string getBackToGameInputActionName();
 
 	void onBackToGameButtonSelected(Game &game);
-	void onBackToGameInputAction(const InputActionCallbackValues &values, Game &game);
+	void onBackToGameInputAction(const InputActionCallbackValues &values);
 
 	// @todo: this might be better handled by providing the input manager all the button + rect pairs on-screen
 	// so it can support some kind of "onButtonClicked()" functionality.
-	void onMouseButtonChanged(MouseButtonType buttonType, const Int2 &position, bool pressed,
-		Game &game, const Rect &exitButtonRect);
+	void onMouseButtonChanged(Game &game, MouseButtonType buttonType, const Int2 &position, bool pressed,
+		const Rect &exitButtonRect);
 
-	void onMouseButtonHeld(MouseButtonType buttonType, const Int2 &position, double dt,
-		Game &game, Double2 *automapOffset);
+	void onMouseButtonHeld(Game &game, MouseButtonType buttonType, const Int2 &position, double dt,
+		Double2 *automapOffset);
 }
 
 #endif

--- a/OpenTESArena/src/Interface/AutomapUiController.h
+++ b/OpenTESArena/src/Interface/AutomapUiController.h
@@ -20,11 +20,6 @@ namespace AutomapUiController
 	void onBackToGameButtonSelected(Game &game);
 	void onBackToGameInputAction(const InputActionCallbackValues &values);
 
-	// @todo: this might be better handled by providing the input manager all the button + rect pairs on-screen
-	// so it can support some kind of "onButtonClicked()" functionality.
-	void onMouseButtonChanged(Game &game, MouseButtonType buttonType, const Int2 &position, bool pressed,
-		const Rect &exitButtonRect);
-
 	void onMouseButtonHeld(Game &game, MouseButtonType buttonType, const Int2 &position, double dt,
 		Double2 *automapOffset);
 }

--- a/OpenTESArena/src/Interface/AutomapUiController.h
+++ b/OpenTESArena/src/Interface/AutomapUiController.h
@@ -1,11 +1,32 @@
 #ifndef AUTOMAP_UI_CONTROLLER_H
 #define AUTOMAP_UI_CONTROLLER_H
 
+#include <string>
+
+#include "../Math/Vector2.h"
+
 class Game;
+class Rect;
+
+struct InputActionCallbackValues;
+
+enum class MouseButtonType;
 
 namespace AutomapUiController
 {
+	std::string getInputActionName();
+	std::string getBackToGameInputActionName();
+
 	void onBackToGameButtonSelected(Game &game);
+	void onBackToGameInputAction(const InputActionCallbackValues &values, Game &game);
+
+	// @todo: this might be better handled by providing the input manager all the button + rect pairs on-screen
+	// so it can support some kind of "onButtonClicked()" functionality.
+	void onMouseButtonChanged(MouseButtonType buttonType, const Int2 &position, bool pressed,
+		Game &game, const Rect &exitButtonRect);
+
+	void onMouseButtonHeld(MouseButtonType buttonType, const Int2 &position, double dt,
+		Game &game, Double2 *automapOffset);
 }
 
 #endif

--- a/OpenTESArena/src/Interface/CharacterCreationUiController.cpp
+++ b/OpenTESArena/src/Interface/CharacterCreationUiController.cpp
@@ -17,6 +17,7 @@
 #include "../Game/CardinalDirection.h"
 #include "../Game/Game.h"
 #include "../UI/TextBox.h"
+#include "../UI/TextEntry.h"
 #include "../World/SkyUtils.h"
 #include "../WorldMap/LocationUtils.h"
 
@@ -108,24 +109,53 @@ void ChooseGenderUiController::onFemaleButtonSelected(Game &game)
 	game.setPanel<ChooseRacePanel>();
 }
 
-void ChooseNameUiController::onBackToChooseClassButtonSelected(Game &game)
+void ChooseNameUiController::onBackToChooseClassInputAction(const InputActionCallbackValues &values)
 {
-	SDL_StopTextInput();
+	if (values.performed)
+	{
+		SDL_StopTextInput();
 
-	auto &charCreationState = game.getCharacterCreationState();
-	charCreationState.setName(nullptr);
+		auto &game = values.game;
+		auto &charCreationState = game.getCharacterCreationState();
+		charCreationState.setName(nullptr);
 
-	game.setPanel<ChooseClassPanel>();
+		game.setPanel<ChooseClassPanel>();
+	}
 }
 
-void ChooseNameUiController::onAcceptButtonSelected(Game &game, const std::string &acceptedName)
+void ChooseNameUiController::onTextInput(const std::string_view &text, std::string &name, bool *outDirty)
 {
-	SDL_StopTextInput();
+	DebugAssert(outDirty != nullptr);
 
-	auto &charCreationState = game.getCharacterCreationState();
-	charCreationState.setName(acceptedName.c_str());
+	*outDirty = TextEntry::append(name, text, ChooseNameUiModel::isCharacterAccepted,
+		CharacterCreationState::MAX_NAME_LENGTH);
+}
 
-	game.setPanel<ChooseGenderPanel>();
+void ChooseNameUiController::onBackspaceInputAction(const InputActionCallbackValues &values, std::string &name, bool *outDirty)
+{
+	DebugAssert(outDirty != nullptr);
+
+	if (values.performed)
+	{
+		*outDirty = TextEntry::backspace(name);
+	}
+}
+
+void ChooseNameUiController::onAcceptInputAction(const InputActionCallbackValues &values, const std::string &name)
+{
+	if (values.performed)
+	{
+		if (name.size() > 0)
+		{
+			SDL_StopTextInput();
+
+			auto &game = values.game;
+			auto &charCreationState = game.getCharacterCreationState();
+			charCreationState.setName(name.c_str());
+
+			game.setPanel<ChooseGenderPanel>();
+		}
+	}
 }
 
 void ChooseRaceUiController::onBackToChooseGenderButtonSelected(Game &game)

--- a/OpenTESArena/src/Interface/CharacterCreationUiController.cpp
+++ b/OpenTESArena/src/Interface/CharacterCreationUiController.cpp
@@ -18,6 +18,8 @@
 #include "TextSubPanel.h"
 #include "../Game/CardinalDirection.h"
 #include "../Game/Game.h"
+#include "../Input/InputActionMapName.h"
+#include "../Input/InputActionName.h"
 #include "../UI/TextBox.h"
 #include "../UI/TextEntry.h"
 #include "../World/SkyUtils.h"
@@ -384,8 +386,14 @@ void ChooseAttributesUiController::onUnsavedDoneButtonSelected(Game &game, bool 
 	const MessageBoxSubPanel::ItemsProperties itemsProperties =
 		ChooseAttributesUiView::getMessageBoxItemsProperties(fontLibrary);
 
+	auto onClosed = [&game]()
+	{
+		auto &inputManager = game.getInputManager();
+		inputManager.setInputActionMapActive(InputActionMapName::CharacterCreation, false);
+	};
+
 	std::unique_ptr<MessageBoxSubPanel> panel = std::make_unique<MessageBoxSubPanel>(game);
-	if (!panel->init(backgroundProperties, titleRect, titleProperties, itemsProperties))
+	if (!panel->init(backgroundProperties, titleRect, titleProperties, itemsProperties, onClosed))
 	{
 		DebugCrash("Couldn't init save/reroll message box sub-panel.");
 	}
@@ -406,7 +414,7 @@ void ChooseAttributesUiController::onUnsavedDoneButtonSelected(Game &game, bool 
 		panel->addOverrideColor(0, entry.charIndex, entry.color);
 	}
 
-	panel->setItemHotkey(0, SDLK_s);
+	panel->setItemInputAction(0, InputActionName::SaveAttributes);
 
 	const std::string rerollText = ChooseAttributesUiModel::getMessageBoxRerollText(game);
 	panel->setItemText(1, rerollText);
@@ -422,7 +430,10 @@ void ChooseAttributesUiController::onUnsavedDoneButtonSelected(Game &game, bool 
 		panel->addOverrideColor(1, entry.charIndex, entry.color);
 	}
 
-	panel->setItemHotkey(1, SDLK_r);
+	panel->setItemInputAction(1, InputActionName::RerollAttributes);
+
+	auto &inputManager = game.getInputManager();
+	inputManager.setInputActionMapActive(InputActionMapName::CharacterCreation, true);
 
 	game.pushSubPanel(std::move(panel));
 }

--- a/OpenTESArena/src/Interface/CharacterCreationUiController.cpp
+++ b/OpenTESArena/src/Interface/CharacterCreationUiController.cpp
@@ -1,3 +1,5 @@
+#include <optional>
+
 #include "SDL.h"
 
 #include "CharacterCreationUiController.h"
@@ -158,14 +160,33 @@ void ChooseNameUiController::onAcceptInputAction(const InputActionCallbackValues
 	}
 }
 
-void ChooseRaceUiController::onBackToChooseGenderButtonSelected(Game &game)
+void ChooseRaceUiController::onBackToChooseGenderInputAction(const InputActionCallbackValues &values)
 {
-	game.setPanel<ChooseGenderPanel>();
+	if (values.performed)
+	{
+		auto &game = values.game;
+		game.setPanel<ChooseGenderPanel>();
+	}
 }
 
 void ChooseRaceUiController::onInitialPopUpButtonSelected(Game &game)
 {
 	game.popSubPanel();
+}
+
+void ChooseRaceUiController::onMouseButtonChanged(Game &game, MouseButtonType buttonType,
+	const Int2 &position, bool pressed)
+{
+	// Listen for clicks on the map, checking if the mouse is over a province mask.
+	if ((buttonType == MouseButtonType::Left) && pressed)
+	{
+		const Int2 originalPoint = game.getRenderer().nativeToOriginal(position);
+		const std::optional<int> provinceID = ChooseRaceUiModel::getProvinceID(game, originalPoint);
+		if (provinceID.has_value())
+		{
+			ChooseRaceUiController::onProvinceButtonSelected(game, *provinceID);
+		}
+	}
 }
 
 void ChooseRaceUiController::onProvinceButtonSelected(Game &game, int raceID)

--- a/OpenTESArena/src/Interface/CharacterCreationUiController.cpp
+++ b/OpenTESArena/src/Interface/CharacterCreationUiController.cpp
@@ -81,9 +81,13 @@ void ChooseClassUiController::onItemButtonSelected(Game &game, int charClassDefI
 	game.setPanel<ChooseNamePanel>();
 }
 
-void ChooseGenderUiController::onBackToChooseNameButtonSelected(Game &game)
+void ChooseGenderUiController::onBackToChooseNameInputAction(const InputActionCallbackValues &values)
 {
-	game.setPanel<ChooseNamePanel>();
+	if (values.performed)
+	{
+		auto &game = values.game;
+		game.setPanel<ChooseNamePanel>();
+	}
 }
 
 void ChooseGenderUiController::onMaleButtonSelected(Game &game)

--- a/OpenTESArena/src/Interface/CharacterCreationUiController.cpp
+++ b/OpenTESArena/src/Interface/CharacterCreationUiController.cpp
@@ -294,16 +294,12 @@ void ChooseRaceUiController::onProvinceConfirmedFourthButtonSelected(Game &game)
 	game.setPanel<ChooseAttributesPanel>();
 }
 
-void ChooseAttributesUiController::onBackToRaceSelectionButtonSelected(Game &game)
-{
-	game.setPanel<ChooseRacePanel>();
-}
-
 void ChooseAttributesUiController::onBackToRaceSelectionInputAction(const InputActionCallbackValues &values)
 {
 	if (values.performed)
 	{
-		ChooseAttributesUiController::onBackToRaceSelectionButtonSelected(values.game);
+		auto &game = values.game;
+		game.setPanel<ChooseRacePanel>();
 	}
 }
 

--- a/OpenTESArena/src/Interface/CharacterCreationUiController.cpp
+++ b/OpenTESArena/src/Interface/CharacterCreationUiController.cpp
@@ -16,6 +16,7 @@
 #include "MessageBoxSubPanel.h"
 #include "TextCinematicPanel.h"
 #include "TextSubPanel.h"
+#include "WorldMapUiModel.h"
 #include "../Game/CardinalDirection.h"
 #include "../Game/Game.h"
 #include "../Input/InputActionMapName.h"
@@ -184,8 +185,7 @@ void ChooseRaceUiController::onMouseButtonChanged(Game &game, MouseButtonType bu
 	// Listen for clicks on the map, checking if the mouse is over a province mask.
 	if ((buttonType == MouseButtonType::Left) && pressed)
 	{
-		const Int2 originalPoint = game.getRenderer().nativeToOriginal(position);
-		const std::optional<int> provinceID = ChooseRaceUiModel::getProvinceID(game, originalPoint);
+		const std::optional<int> provinceID = WorldMapUiModel::getMaskID(game, position, true, true);
 		if (provinceID.has_value())
 		{
 			ChooseRaceUiController::onProvinceButtonSelected(game, *provinceID);

--- a/OpenTESArena/src/Interface/CharacterCreationUiController.cpp
+++ b/OpenTESArena/src/Interface/CharacterCreationUiController.cpp
@@ -295,6 +295,14 @@ void ChooseAttributesUiController::onBackToRaceSelectionButtonSelected(Game &gam
 	game.setPanel<ChooseRacePanel>();
 }
 
+void ChooseAttributesUiController::onBackToRaceSelectionInputAction(const InputActionCallbackValues &values)
+{
+	if (values.performed)
+	{
+		ChooseAttributesUiController::onBackToRaceSelectionButtonSelected(values.game);
+	}
+}
+
 void ChooseAttributesUiController::onInitialPopUpSelected(Game &game)
 {
 	game.popSubPanel();

--- a/OpenTESArena/src/Interface/CharacterCreationUiController.cpp
+++ b/OpenTESArena/src/Interface/CharacterCreationUiController.cpp
@@ -117,9 +117,10 @@ void ChooseNameUiController::onBackToChooseClassInputAction(const InputActionCal
 {
 	if (values.performed)
 	{
-		SDL_StopTextInput();
-
 		auto &game = values.game;
+		auto &inputManager = game.getInputManager();
+		inputManager.setTextInputMode(false);
+
 		auto &charCreationState = game.getCharacterCreationState();
 		charCreationState.setName(nullptr);
 
@@ -151,9 +152,10 @@ void ChooseNameUiController::onAcceptInputAction(const InputActionCallbackValues
 	{
 		if (name.size() > 0)
 		{
-			SDL_StopTextInput();
-
 			auto &game = values.game;
+			auto &inputManager = game.getInputManager();
+			inputManager.setTextInputMode(false);
+
 			auto &charCreationState = game.getCharacterCreationState();
 			charCreationState.setName(name.c_str());
 

--- a/OpenTESArena/src/Interface/CharacterCreationUiController.cpp
+++ b/OpenTESArena/src/Interface/CharacterCreationUiController.cpp
@@ -54,9 +54,13 @@ void ChooseClassCreationUiController::onSelectButtonSelected(Game &game)
 	game.setPanel<ChooseClassPanel>();
 }
 
-void ChooseClassUiController::onBackToChooseClassCreationButtonSelected(Game &game)
+void ChooseClassUiController::onBackToChooseClassCreationInputAction(const InputActionCallbackValues &values)
 {
-	game.setPanel<ChooseClassCreationPanel>();
+	if (values.performed)
+	{
+		auto &game = values.game;
+		game.setPanel<ChooseClassCreationPanel>();
+	}
 }
 
 void ChooseClassUiController::onUpButtonSelected(ListBox &listBox)

--- a/OpenTESArena/src/Interface/CharacterCreationUiController.cpp
+++ b/OpenTESArena/src/Interface/CharacterCreationUiController.cpp
@@ -22,22 +22,26 @@
 
 #include "components/utilities/String.h"
 
-void ChooseClassCreationUiController::onBackToMainMenuButtonSelected(Game &game)
+void ChooseClassCreationUiController::onBackToMainMenuInputAction(const InputActionCallbackValues &values)
 {
-	game.setCharacterCreationState(nullptr);
-	game.setPanel<MainMenuPanel>();
-
-	const MusicLibrary &musicLibrary = game.getMusicLibrary();
-	const MusicDefinition *musicDef = musicLibrary.getRandomMusicDefinition(
-		MusicDefinition::Type::MainMenu, game.getRandom());
-
-	if (musicDef == nullptr)
+	if (values.performed)
 	{
-		DebugLogWarning("Missing main menu music.");
-	}
+		auto &game = values.game;
+		game.setCharacterCreationState(nullptr);
+		game.setPanel<MainMenuPanel>();
 
-	AudioManager &audioManager = game.getAudioManager();
-	audioManager.setMusic(musicDef);
+		const MusicLibrary &musicLibrary = game.getMusicLibrary();
+		const MusicDefinition *musicDef = musicLibrary.getRandomMusicDefinition(
+			MusicDefinition::Type::MainMenu, game.getRandom());
+
+		if (musicDef == nullptr)
+		{
+			DebugLogWarning("Missing main menu music.");
+		}
+
+		AudioManager &audioManager = game.getAudioManager();
+		audioManager.setMusic(musicDef);
+	}
 }
 
 void ChooseClassCreationUiController::onGenerateButtonSelected(Game &game)

--- a/OpenTESArena/src/Interface/CharacterCreationUiController.h
+++ b/OpenTESArena/src/Interface/CharacterCreationUiController.h
@@ -33,8 +33,10 @@ namespace ChooseGenderUiController
 
 namespace ChooseNameUiController
 {
-	void onBackToChooseClassButtonSelected(Game &game);
-	void onAcceptButtonSelected(Game &game, const std::string &acceptedName);
+	void onBackToChooseClassInputAction(const InputActionCallbackValues &values);
+	void onTextInput(const std::string_view &text, std::string &name, bool *outDirty);
+	void onBackspaceInputAction(const InputActionCallbackValues &values, std::string &name, bool *outDirty);
+	void onAcceptInputAction(const InputActionCallbackValues &values, const std::string &name);
 }
 
 namespace ChooseRaceUiController

--- a/OpenTESArena/src/Interface/CharacterCreationUiController.h
+++ b/OpenTESArena/src/Interface/CharacterCreationUiController.h
@@ -26,7 +26,7 @@ namespace ChooseClassUiController
 
 namespace ChooseGenderUiController
 {
-	void onBackToChooseNameButtonSelected(Game &game);
+	void onBackToChooseNameInputAction(const InputActionCallbackValues &values);
 	void onMaleButtonSelected(Game &game);
 	void onFemaleButtonSelected(Game &game);
 }

--- a/OpenTESArena/src/Interface/CharacterCreationUiController.h
+++ b/OpenTESArena/src/Interface/CharacterCreationUiController.h
@@ -18,7 +18,7 @@ namespace ChooseClassCreationUiController
 
 namespace ChooseClassUiController
 {
-	void onBackToChooseClassCreationButtonSelected(Game &game);
+	void onBackToChooseClassCreationInputAction(const InputActionCallbackValues &values);
 	void onUpButtonSelected(ListBox &listBox);
 	void onDownButtonSelected(ListBox &listBox);
 	void onItemButtonSelected(Game &game, int charClassDefID);

--- a/OpenTESArena/src/Interface/CharacterCreationUiController.h
+++ b/OpenTESArena/src/Interface/CharacterCreationUiController.h
@@ -3,8 +3,12 @@
 
 #include <string>
 
+#include "../Math/Vector2.h"
+
 class Game;
 class ListBox;
+
+enum class MouseButtonType;
 
 struct InputActionCallbackValues;
 
@@ -41,8 +45,9 @@ namespace ChooseNameUiController
 
 namespace ChooseRaceUiController
 {
-	void onBackToChooseGenderButtonSelected(Game &game);
+	void onBackToChooseGenderInputAction(const InputActionCallbackValues &values);
 	void onInitialPopUpButtonSelected(Game &game);
+	void onMouseButtonChanged(Game &game, MouseButtonType buttonType, const Int2 &position, bool pressed);
 	void onProvinceButtonSelected(Game &game, int raceID);
 	void onProvinceConfirmButtonSelected(Game &game, int raceID);
 	void onProvinceCancelButtonSelected(Game &game);

--- a/OpenTESArena/src/Interface/CharacterCreationUiController.h
+++ b/OpenTESArena/src/Interface/CharacterCreationUiController.h
@@ -6,6 +6,8 @@
 class Game;
 class ListBox;
 
+struct InputActionCallbackValues;
+
 namespace ChooseClassCreationUiController
 {
 	void onBackToMainMenuButtonSelected(Game &game);
@@ -50,6 +52,8 @@ namespace ChooseRaceUiController
 namespace ChooseAttributesUiController
 {
 	void onBackToRaceSelectionButtonSelected(Game &game);
+	void onBackToRaceSelectionInputAction(const InputActionCallbackValues &values);
+
 	void onInitialPopUpSelected(Game &game);
 	void onSaveButtonSelected(Game &game, bool *attributesAreSaved);
 	void onRerollButtonSelected(Game &game);

--- a/OpenTESArena/src/Interface/CharacterCreationUiController.h
+++ b/OpenTESArena/src/Interface/CharacterCreationUiController.h
@@ -52,7 +52,6 @@ namespace ChooseRaceUiController
 
 namespace ChooseAttributesUiController
 {
-	void onBackToRaceSelectionButtonSelected(Game &game);
 	void onBackToRaceSelectionInputAction(const InputActionCallbackValues &values);
 
 	void onInitialPopUpSelected(Game &game);

--- a/OpenTESArena/src/Interface/CharacterCreationUiController.h
+++ b/OpenTESArena/src/Interface/CharacterCreationUiController.h
@@ -10,7 +10,8 @@ struct InputActionCallbackValues;
 
 namespace ChooseClassCreationUiController
 {
-	void onBackToMainMenuButtonSelected(Game &game);
+	void onBackToMainMenuInputAction(const InputActionCallbackValues &values);
+
 	void onGenerateButtonSelected(Game &game);
 	void onSelectButtonSelected(Game &game);
 }

--- a/OpenTESArena/src/Interface/CharacterCreationUiModel.cpp
+++ b/OpenTESArena/src/Interface/CharacterCreationUiModel.cpp
@@ -361,39 +361,6 @@ std::string ChooseRaceUiModel::getProvinceTooltipText(Game &game, int provinceID
 	return "Land of the " + raceName;
 }
 
-std::optional<int> ChooseRaceUiModel::getProvinceID(Game &game, const Int2 &originalPosition)
-{
-	const auto &worldMapMasks =game.getBinaryAssetLibrary().getWorldMapMasks();
-	const int maskCount = static_cast<int>(worldMapMasks.size());
-	for (int maskID = 0; maskID < maskCount; maskID++)
-	{
-		// Ignore the center province and the "Exit" button.
-		constexpr int exitButtonID = 9;
-		if ((maskID == LocationUtils::CENTER_PROVINCE_ID) || (maskID == exitButtonID))
-		{
-			continue;
-		}
-
-		const WorldMapMask &mapMask = worldMapMasks.at(maskID);
-		const Rect &maskRect = mapMask.getRect();
-
-		if (maskRect.contains(originalPosition))
-		{
-			// See if the pixel is set in the bitmask.
-			const bool success = mapMask.get(originalPosition.x, originalPosition.y);
-
-			if (success)
-			{
-				// Return the mask's ID.
-				return maskID;
-			}
-		}
-	}
-
-	// No province mask found at the given location.
-	return std::nullopt;
-}
-
 std::string ChooseRaceUiModel::getProvinceConfirmedFirstText(Game &game)
 {
 	const auto &binaryAssetLibrary = game.getBinaryAssetLibrary();

--- a/OpenTESArena/src/Interface/CharacterCreationUiModel.h
+++ b/OpenTESArena/src/Interface/CharacterCreationUiModel.h
@@ -56,7 +56,6 @@ namespace ChooseRaceUiModel
 	std::string getProvinceConfirmYesText(Game &game);
 	std::string getProvinceConfirmNoText(Game &game);
 	std::string getProvinceTooltipText(Game &game, int provinceID);
-	std::optional<int> getProvinceID(Game &game, const Int2 &originalPosition);
 	std::string getProvinceConfirmedFirstText(Game &game);
 	std::string getProvinceConfirmedSecondText(Game &game);
 	std::string getProvinceConfirmedThirdText(Game &game);

--- a/OpenTESArena/src/Interface/CharacterEquipmentPanel.cpp
+++ b/OpenTESArena/src/Interface/CharacterEquipmentPanel.cpp
@@ -7,6 +7,7 @@
 #include "InventoryUiModel.h"
 #include "InventoryUiView.h"
 #include "../Game/Game.h"
+#include "../Input/InputActionMapName.h"
 #include "../Input/InputActionName.h"
 #include "../UI/CursorData.h"
 
@@ -14,6 +15,12 @@
 
 CharacterEquipmentPanel::CharacterEquipmentPanel(Game &game)
 	: Panel(game) { }
+
+CharacterEquipmentPanel::~CharacterEquipmentPanel()
+{
+	auto &inputManager = this->getGame().getInputManager();
+	inputManager.setInputActionMapActive(InputActionMapName::CharacterEquipment, false);
+}
 
 bool CharacterEquipmentPanel::init()
 {
@@ -111,9 +118,12 @@ bool CharacterEquipmentPanel::init()
 	this->addButtonProxy(MouseButtonType::Left, this->scrollUpButton.getRect(),
 		[this, &game]() { this->scrollUpButton.click(this->inventoryListBox); });
 
+	auto &inputManager = game.getInputManager();
+	inputManager.setInputActionMapActive(InputActionMapName::CharacterEquipment, true);
+
 	auto backToStatsInputActionFunc = CharacterSheetUiController::onBackToStatsInputAction;
 	this->addInputActionListener(InputActionName::Back, backToStatsInputActionFunc);
-	this->addInputActionListener(InputActionName::CharacterSheet, backToStatsInputActionFunc); // @todo: make sure input action map is active
+	this->addInputActionListener(InputActionName::CharacterSheet, backToStatsInputActionFunc);
 
 	this->addMouseScrollChangedListener([this](Game &game, MouseWheelScrollType type, const Int2 &position)
 	{

--- a/OpenTESArena/src/Interface/CharacterEquipmentPanel.h
+++ b/OpenTESArena/src/Interface/CharacterEquipmentPanel.h
@@ -23,7 +23,6 @@ public:
 	bool init();
 
 	virtual std::optional<CursorData> getCurrentCursor() const override;
-	virtual void handleEvent(const SDL_Event &e) override;
 	virtual void render(Renderer &renderer) override;
 };
 

--- a/OpenTESArena/src/Interface/CharacterEquipmentPanel.h
+++ b/OpenTESArena/src/Interface/CharacterEquipmentPanel.h
@@ -18,7 +18,7 @@ private:
 	Button<ListBox&> scrollDownButton, scrollUpButton;
 public:
 	CharacterEquipmentPanel(Game &game);
-	~CharacterEquipmentPanel() override = default;
+	~CharacterEquipmentPanel() override;
 
 	bool init();
 

--- a/OpenTESArena/src/Interface/CharacterPanel.cpp
+++ b/OpenTESArena/src/Interface/CharacterPanel.cpp
@@ -5,6 +5,7 @@
 #include "CharacterSheetUiModel.h"
 #include "CharacterSheetUiView.h"
 #include "../Game/Game.h"
+#include "../Input/InputActionMapName.h"
 #include "../Input/InputActionName.h"
 #include "../UI/CursorData.h"
 
@@ -12,6 +13,12 @@
 
 CharacterPanel::CharacterPanel(Game &game)
 	: Panel(game) { }
+
+CharacterPanel::~CharacterPanel()
+{
+	auto &inputManager = this->getGame().getInputManager();
+	inputManager.setInputActionMapActive(InputActionMapName::CharacterSheet, false);
+}
 
 bool CharacterPanel::init()
 {
@@ -63,9 +70,12 @@ bool CharacterPanel::init()
 	this->addButtonProxy(MouseButtonType::Left, this->nextPageButton.getRect(),
 		[this, &game]() { this->nextPageButton.click(game); });
 
+	auto &inputManager = game.getInputManager();
+	inputManager.setInputActionMapActive(InputActionMapName::CharacterSheet, true);
+
 	auto doneInputActionFunc = CharacterSheetUiController::onDoneInputAction;
 	this->addInputActionListener(InputActionName::Back, doneInputActionFunc);
-	this->addInputActionListener(InputActionName::CharacterSheet, doneInputActionFunc); // @todo: make sure input action map is active
+	this->addInputActionListener(InputActionName::CharacterSheet, doneInputActionFunc);
 
 	return true;
 }

--- a/OpenTESArena/src/Interface/CharacterPanel.cpp
+++ b/OpenTESArena/src/Interface/CharacterPanel.cpp
@@ -5,6 +5,7 @@
 #include "CharacterSheetUiModel.h"
 #include "CharacterSheetUiView.h"
 #include "../Game/Game.h"
+#include "../Input/InputActionName.h"
 #include "../UI/CursorData.h"
 
 #include "components/debug/Debug.h"
@@ -57,42 +58,21 @@ bool CharacterPanel::init()
 		CharacterSheetUiView::NextPageButtonHeight,
 		CharacterSheetUiController::onNextPageButtonSelected);
 
+	this->addButtonProxy(MouseButtonType::Left, this->doneButton.getRect(),
+		[this, &game]() { this->doneButton.click(game); });
+	this->addButtonProxy(MouseButtonType::Left, this->nextPageButton.getRect(),
+		[this, &game]() { this->nextPageButton.click(game); });
+
+	auto doneInputActionFunc = CharacterSheetUiController::onDoneInputAction;
+	this->addInputActionListener(InputActionName::Back, doneInputActionFunc);
+	this->addInputActionListener(InputActionName::CharacterSheet, doneInputActionFunc); // @todo: make sure input action map is active
+
 	return true;
 }
 
 std::optional<CursorData> CharacterPanel::getCurrentCursor() const
 {
 	return this->getDefaultCursor();
-}
-
-void CharacterPanel::handleEvent(const SDL_Event &e)
-{
-	auto &game = this->getGame();
-	const auto &inputManager = game.getInputManager();
-	bool escapePressed = inputManager.keyPressed(e, SDLK_ESCAPE);
-	bool tabPressed = inputManager.keyPressed(e, SDLK_TAB);
-
-	if (escapePressed || tabPressed)
-	{
-		this->doneButton.click(game);
-	}
-
-	bool leftClick = inputManager.mouseButtonPressed(e, SDL_BUTTON_LEFT);
-
-	if (leftClick)
-	{
-		const Int2 mousePosition = inputManager.getMousePosition();
-		const Int2 mouseOriginalPoint = game.getRenderer().nativeToOriginal(mousePosition);
-
-		if (this->doneButton.contains(mouseOriginalPoint))
-		{
-			this->doneButton.click(game);
-		}
-		else if (this->nextPageButton.contains(mouseOriginalPoint))
-		{
-			this->nextPageButton.click(game);
-		}
-	}
 }
 
 void CharacterPanel::render(Renderer &renderer)

--- a/OpenTESArena/src/Interface/CharacterPanel.h
+++ b/OpenTESArena/src/Interface/CharacterPanel.h
@@ -19,7 +19,7 @@ private:
 	Button<Game&> doneButton, nextPageButton;
 public:
 	CharacterPanel(Game &game);
-	~CharacterPanel() override = default;
+	~CharacterPanel() override;
 
 	bool init();
 

--- a/OpenTESArena/src/Interface/CharacterPanel.h
+++ b/OpenTESArena/src/Interface/CharacterPanel.h
@@ -24,7 +24,6 @@ public:
 	bool init();
 
 	virtual std::optional<CursorData> getCurrentCursor() const override;
-	virtual void handleEvent(const SDL_Event &e) override;
 	virtual void render(Renderer &renderer) override;
 };
 

--- a/OpenTESArena/src/Interface/CharacterSheetUiController.cpp
+++ b/OpenTESArena/src/Interface/CharacterSheetUiController.cpp
@@ -10,6 +10,14 @@ void CharacterSheetUiController::onDoneButtonSelected(Game &game)
 	game.setPanel<GameWorldPanel>();
 }
 
+void CharacterSheetUiController::onDoneInputAction(const InputActionCallbackValues &values)
+{
+	if (values.performed)
+	{
+		CharacterSheetUiController::onDoneButtonSelected(values.game);
+	}
+}
+
 void CharacterSheetUiController::onNextPageButtonSelected(Game &game)
 {
 	game.setPanel<CharacterEquipmentPanel>();

--- a/OpenTESArena/src/Interface/CharacterSheetUiController.cpp
+++ b/OpenTESArena/src/Interface/CharacterSheetUiController.cpp
@@ -20,6 +20,14 @@ void CharacterSheetUiController::onBackToStatsButtonSelected(Game &game)
 	game.setPanel<CharacterPanel>();
 }
 
+void CharacterSheetUiController::onBackToStatsInputAction(const InputActionCallbackValues &values)
+{
+	if (values.performed)
+	{
+		CharacterSheetUiController::onBackToStatsButtonSelected(values.game);
+	}
+}
+
 void CharacterSheetUiController::onSpellbookButtonSelected(Game &game)
 {
 	// Nothing yet.

--- a/OpenTESArena/src/Interface/CharacterSheetUiController.h
+++ b/OpenTESArena/src/Interface/CharacterSheetUiController.h
@@ -9,6 +9,8 @@ struct InputActionCallbackValues;
 namespace CharacterSheetUiController
 {
 	void onDoneButtonSelected(Game &game);
+	void onDoneInputAction(const InputActionCallbackValues &values);
+
 	void onNextPageButtonSelected(Game &game);
 	
 	void onBackToStatsButtonSelected(Game &game);

--- a/OpenTESArena/src/Interface/CharacterSheetUiController.h
+++ b/OpenTESArena/src/Interface/CharacterSheetUiController.h
@@ -4,11 +4,16 @@
 class Game;
 class ListBox;
 
+struct InputActionCallbackValues;
+
 namespace CharacterSheetUiController
 {
 	void onDoneButtonSelected(Game &game);
 	void onNextPageButtonSelected(Game &game);
+	
 	void onBackToStatsButtonSelected(Game &game);
+	void onBackToStatsInputAction(const InputActionCallbackValues &values);
+
 	void onSpellbookButtonSelected(Game &game);
 	void onDropButtonSelected(Game &game, int itemIndex);
 	void onInventoryScrollDownButtonSelected(ListBox &listBox);

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
@@ -11,6 +11,7 @@
 #include "ChooseAttributesPanel.h"
 #include "TextSubPanel.h"
 #include "../Game/Game.h"
+#include "../Input/InputActionName.h"
 #include "../UI/CursorData.h"
 
 ChooseAttributesPanel::ChooseAttributesPanel(Game &game)
@@ -61,6 +62,30 @@ bool ChooseAttributesPanel::init()
 		ChooseAttributesUiView::PortraitButtonHeight,
 		ChooseAttributesUiController::onPortraitButtonSelected);
 
+	this->addButtonProxy(MouseButtonType::Left, this->doneButton.getRect(),
+		[this, &game]() { this->doneButton.click(game, &this->attributesAreSaved); });
+	this->addButtonProxy(MouseButtonType::Left, this->portraitButton.getRect(),
+		[this, &game]()
+	{
+		if (this->attributesAreSaved)
+		{
+			// Increment the portrait ID.
+			this->portraitButton.click(game, true);
+		}
+	});
+
+	this->addButtonProxy(MouseButtonType::Right, this->portraitButton.getRect(),
+		[this, &game]()
+	{
+		if (this->attributesAreSaved)
+		{
+			// Decrement the portrait ID.
+			this->portraitButton.click(game, false);
+		}
+	});
+
+	this->addInputActionListener(InputActionName::Back, ChooseAttributesUiController::onBackToRaceSelectionInputAction);
+
 	auto &charCreationState = game.getCharacterCreationState();
 	charCreationState.setPortraitIndex(0);
 
@@ -95,46 +120,6 @@ bool ChooseAttributesPanel::init()
 std::optional<CursorData> ChooseAttributesPanel::getCurrentCursor() const
 {
 	return this->getDefaultCursor();
-}
-
-void ChooseAttributesPanel::handleEvent(const SDL_Event &e)
-{
-	const auto &inputManager = this->getGame().getInputManager();
-	bool escapePressed = inputManager.keyPressed(e, SDLK_ESCAPE);
-
-	if (escapePressed)
-	{
-		this->backToRaceButton.click(this->getGame());
-	}
-
-	bool leftClick = inputManager.mouseButtonPressed(e, SDL_BUTTON_LEFT);
-	bool rightClick = inputManager.mouseButtonPressed(e, SDL_BUTTON_RIGHT);
-		
-	const Int2 mousePosition = inputManager.getMousePosition();
-	const Int2 mouseOriginalPoint = this->getGame().getRenderer()
-		.nativeToOriginal(mousePosition);
-
-	if (leftClick)
-	{
-		if (this->doneButton.contains(mouseOriginalPoint))
-		{
-			this->doneButton.click(this->getGame(), &this->attributesAreSaved);
-		}
-		else if (this->portraitButton.contains(mouseOriginalPoint) && this->attributesAreSaved)
-		{
-			// Pass 'true' to increment the portrait ID.
-			this->portraitButton.click(this->getGame(), true);
-		}
-	}
-
-	if (rightClick)
-	{
-		if (this->portraitButton.contains(mouseOriginalPoint) && this->attributesAreSaved)
-		{
-			// Pass 'false' to decrement the portrait ID.
-			this->portraitButton.click(this->getGame(), false);
-		}
-	}	
 }
 
 void ChooseAttributesPanel::render(Renderer &renderer)

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
@@ -50,7 +50,6 @@ bool ChooseAttributesPanel::init()
 		return false;
 	}
 
-	this->backToRaceButton = Button<Game&>(ChooseAttributesUiController::onBackToRaceSelectionButtonSelected);
 	this->doneButton = Button<Game&, bool*>(
 		CharacterSheetUiView::DoneButtonCenterPoint,
 		CharacterSheetUiView::DoneButtonWidth,

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.h
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.h
@@ -22,7 +22,6 @@ class ChooseAttributesPanel : public Panel
 {
 private:
 	TextBox nameTextBox, raceTextBox, classTextBox;
-	Button<Game&> backToRaceButton;
 	Button<Game&, bool*> doneButton;
 	Button<Game&, bool> portraitButton;
 	bool attributesAreSaved; // Whether attributes have been saved and the player portrait can now be changed.

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.h
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.h
@@ -33,7 +33,6 @@ public:
 	bool init();
 
 	virtual std::optional<CursorData> getCurrentCursor() const override;
-	virtual void handleEvent(const SDL_Event &e) override;
 	virtual void render(Renderer &renderer) override;
 };
 

--- a/OpenTESArena/src/Interface/ChooseClassCreationPanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseClassCreationPanel.cpp
@@ -10,6 +10,7 @@
 #include "../Assets/ExeData.h"
 #include "../Game/Game.h"
 #include "../Game/Options.h"
+#include "../Input/InputActionName.h"
 #include "../Math/Vector2.h"
 #include "../Media/Color.h"
 #include "../Media/TextureManager.h"
@@ -66,7 +67,6 @@ bool ChooseClassCreationPanel::init()
 		return false;
 	}
 
-	this->backToMainMenuButton = Button<Game&>(ChooseClassCreationUiController::onBackToMainMenuButtonSelected);
 	this->generateButton = Button<Game&>(
 		ChooseClassCreationUiView::GenerateButtonCenterPoint,
 		ChooseClassCreationUiView::GenerateButtonWidth,
@@ -78,41 +78,19 @@ bool ChooseClassCreationPanel::init()
 		ChooseClassCreationUiView::SelectButtonHeight,
 		ChooseClassCreationUiController::onSelectButtonSelected);
 
+	this->addButtonProxy(MouseButtonType::Left, this->generateButton.getRect(),
+		[this, &game]() { this->generateButton.click(game); });
+	this->addButtonProxy(MouseButtonType::Left, this->selectButton.getRect(),
+		[this, &game]() { this->selectButton.click(game); });
+
+	this->addInputActionListener(InputActionName::Back, ChooseClassCreationUiController::onBackToMainMenuInputAction);
+
 	return true;
 }
 
 std::optional<CursorData> ChooseClassCreationPanel::getCurrentCursor() const
 {
 	return this->getDefaultCursor();
-}
-
-void ChooseClassCreationPanel::handleEvent(const SDL_Event &e)
-{
-	const auto &inputManager = this->getGame().getInputManager();
-	bool escapePressed = inputManager.keyPressed(e, SDLK_ESCAPE);
-
-	if (escapePressed)
-	{
-		this->backToMainMenuButton.click(this->getGame());
-	}
-
-	bool leftClick = inputManager.mouseButtonPressed(e, SDL_BUTTON_LEFT);
-
-	if (leftClick)
-	{
-		const Int2 mousePosition = inputManager.getMousePosition();
-		const Int2 mouseOriginalPoint = this->getGame().getRenderer()
-			.nativeToOriginal(mousePosition);
-
-		if (this->generateButton.contains(mouseOriginalPoint))
-		{
-			this->generateButton.click(this->getGame());
-		}
-		else if (this->selectButton.contains(mouseOriginalPoint))
-		{
-			this->selectButton.click(this->getGame());
-		}
-	}
 }
 
 void ChooseClassCreationPanel::drawTooltip(const std::string &text, Renderer &renderer)

--- a/OpenTESArena/src/Interface/ChooseClassCreationPanel.h
+++ b/OpenTESArena/src/Interface/ChooseClassCreationPanel.h
@@ -15,7 +15,7 @@ class ChooseClassCreationPanel : public Panel
 private:
 	Texture parchment;
 	TextBox titleTextBox, generateTextBox, selectTextBox;
-	Button<Game&> backToMainMenuButton, generateButton, selectButton;
+	Button<Game&> generateButton, selectButton;
 
 	void drawTooltip(const std::string &text, Renderer &renderer);
 public:
@@ -25,7 +25,6 @@ public:
 	bool init();
 
 	virtual std::optional<CursorData> getCurrentCursor() const override;
-	virtual void handleEvent(const SDL_Event &e) override;
 	virtual void render(Renderer &renderer) override;
 };
 

--- a/OpenTESArena/src/Interface/ChooseClassPanel.h
+++ b/OpenTESArena/src/Interface/ChooseClassPanel.h
@@ -25,7 +25,6 @@ class ChooseClassPanel : public Panel
 private:
 	TextBox titleTextBox;
 	ListBox classesListBox;
-	Button<Game&> backToClassCreationButton;
 	Button<ListBox&> upButton, downButton;
 	std::unordered_map<int, Texture> tooltipTextures;
 	std::vector<CharacterClassDefinition> charClasses;
@@ -38,7 +37,6 @@ public:
 	bool init();
 
 	virtual std::optional<CursorData> getCurrentCursor() const override;
-	virtual void handleEvent(const SDL_Event &e) override;
 	virtual void render(Renderer &renderer) override;
 };
 

--- a/OpenTESArena/src/Interface/ChooseGenderPanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseGenderPanel.cpp
@@ -10,6 +10,7 @@
 #include "../Assets/ExeData.h"
 #include "../Game/Game.h"
 #include "../Game/Options.h"
+#include "../Input/InputActionName.h"
 #include "../Math/Vector2.h"
 #include "../Media/Color.h"
 #include "../Media/TextureManager.h"
@@ -65,7 +66,6 @@ bool ChooseGenderPanel::init()
 		return false;
 	}
 
-	this->backToNameButton = Button<Game&>(ChooseGenderUiController::onBackToChooseNameButtonSelected);
 	this->maleButton = Button<Game&>(
 		ChooseGenderUiView::MaleButtonCenter,
 		ChooseGenderUiView::MaleButtonWidth,
@@ -77,40 +77,19 @@ bool ChooseGenderPanel::init()
 		ChooseGenderUiView::FemaleButtonHeight,
 		ChooseGenderUiController::onFemaleButtonSelected);
 
+	this->addButtonProxy(MouseButtonType::Left, this->maleButton.getRect(),
+		[this, &game]() { this->maleButton.click(game); });
+	this->addButtonProxy(MouseButtonType::Left, this->femaleButton.getRect(),
+		[this, &game]() { this->femaleButton.click(game); });
+
+	this->addInputActionListener(InputActionName::Back, ChooseGenderUiController::onBackToChooseNameInputAction);
+
 	return true;
 }
 
 std::optional<CursorData> ChooseGenderPanel::getCurrentCursor() const
 {
 	return this->getDefaultCursor();
-}
-
-void ChooseGenderPanel::handleEvent(const SDL_Event &e)
-{
-	const auto &inputManager = this->getGame().getInputManager();
-	const bool escapePressed = inputManager.keyPressed(e, SDLK_ESCAPE);
-
-	if (escapePressed)
-	{
-		this->backToNameButton.click(this->getGame());
-	}
-
-	const bool leftClick = inputManager.mouseButtonPressed(e, SDL_BUTTON_LEFT);
-
-	if (leftClick)
-	{
-		const Int2 mousePosition = inputManager.getMousePosition();
-		const Int2 mouseOriginalPoint = this->getGame().getRenderer().nativeToOriginal(mousePosition);
-
-		if (this->maleButton.contains(mouseOriginalPoint))
-		{
-			this->maleButton.click(this->getGame());
-		}
-		else if (this->femaleButton.contains(mouseOriginalPoint))
-		{
-			this->femaleButton.click(this->getGame());
-		}
-	}
 }
 
 void ChooseGenderPanel::render(Renderer &renderer)

--- a/OpenTESArena/src/Interface/ChooseGenderPanel.h
+++ b/OpenTESArena/src/Interface/ChooseGenderPanel.h
@@ -13,7 +13,7 @@ class ChooseGenderPanel : public Panel
 private:
 	Texture parchment;
 	TextBox titleTextBox, maleTextBox, femaleTextBox;
-	Button<Game&> backToNameButton, maleButton, femaleButton;
+	Button<Game&> maleButton, femaleButton;
 public:
 	ChooseGenderPanel(Game &game);
 	~ChooseGenderPanel() override = default;
@@ -21,7 +21,6 @@ public:
 	bool init();
 
 	virtual std::optional<CursorData> getCurrentCursor() const override;
-	virtual void handleEvent(const SDL_Event &e) override;
 	virtual void render(Renderer &renderer) override;
 };
 

--- a/OpenTESArena/src/Interface/ChooseNamePanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseNamePanel.cpp
@@ -15,6 +15,7 @@
 #include "../Game/CharacterCreationState.h"
 #include "../Game/Game.h"
 #include "../Game/Options.h"
+#include "../Input/InputActionName.h"
 #include "../Math/Vector2.h"
 #include "../Media/Color.h"
 #include "../Media/TextureManager.h"
@@ -46,26 +47,50 @@ bool ChooseNamePanel::init()
 
 	const auto &fontLibrary = game.getFontLibrary();
 	const std::string titleText = ChooseNameUiModel::getTitleText(game);
-	const TextBox::InitInfo titleTextBoxInitInfo =
-		ChooseNameUiView::getTitleTextBoxInitInfo(titleText, fontLibrary);
+	const TextBox::InitInfo titleTextBoxInitInfo = ChooseNameUiView::getTitleTextBoxInitInfo(titleText, fontLibrary);
 	if (!this->titleTextBox.init(titleTextBoxInitInfo, titleText, renderer))
 	{
 		DebugLogError("Couldn't init title text box.");
 		return false;
 	}
 
-	const TextBox::InitInfo entryTextBoxInitInfo =
-		ChooseNameUiView::getEntryTextBoxInitInfo(fontLibrary);
+	const TextBox::InitInfo entryTextBoxInitInfo = ChooseNameUiView::getEntryTextBoxInitInfo(fontLibrary);
 	if (!this->entryTextBox.init(entryTextBoxInitInfo, renderer))
 	{
 		DebugLogError("Couldn't init entry text box.");
 		return false;
 	}
 
-	this->backToClassButton = Button<Game&>(ChooseNameUiController::onBackToChooseClassButtonSelected);
-	this->acceptButton = Button<Game&, const std::string&>(ChooseNameUiController::onAcceptButtonSelected);
+	this->addInputActionListener(InputActionName::Back, ChooseNameUiController::onBackToChooseClassInputAction);
+	this->addInputActionListener(InputActionName::Accept,
+		[this](const InputActionCallbackValues &values)
+	{
+		ChooseNameUiController::onAcceptInputAction(values, this->name);
+	});
 
-	// Activate SDL text input (handled in handleEvent()).
+	this->addInputActionListener(InputActionName::Backspace,
+		[this](const InputActionCallbackValues &values)
+	{
+		bool dirty;
+		ChooseNameUiController::onBackspaceInputAction(values, this->name, &dirty);
+
+		if (dirty)
+		{
+			this->entryTextBox.setText(this->name);
+		}
+	});
+
+	this->addTextInputListener([this](const std::string_view &text)
+	{
+		bool dirty;
+		ChooseNameUiController::onTextInput(text, this->name, &dirty);
+
+		if (dirty)
+		{
+			this->entryTextBox.setText(this->name);
+		}
+	});
+
 	SDL_StartTextInput();
 
 	return true;
@@ -74,37 +99,6 @@ bool ChooseNamePanel::init()
 std::optional<CursorData> ChooseNamePanel::getCurrentCursor() const
 {
 	return this->getDefaultCursor();
-}
-
-void ChooseNamePanel::handleEvent(const SDL_Event &e)
-{
-	auto &game = this->getGame();
-	const auto &inputManager = game.getInputManager();
-	const bool escapePressed = inputManager.keyPressed(e, SDLK_ESCAPE);
-	const bool enterPressed = inputManager.keyPressed(e, SDLK_RETURN) || inputManager.keyPressed(e, SDLK_KP_ENTER);
-	const bool backspacePressed = inputManager.keyPressed(e, SDLK_BACKSPACE) ||
-		inputManager.keyPressed(e, SDLK_KP_BACKSPACE);
-
-	if (escapePressed)
-	{
-		this->backToClassButton.click(this->getGame());
-	}
-	else if (enterPressed && (this->name.size() > 0))
-	{
-		// Accept the given name.
-		this->acceptButton.click(this->getGame(), this->name);
-	}
-	else
-	{
-		// Listen for SDL text input and changes in text.
-		const bool textChanged = TextEntry::updateText(this->name, e, backspacePressed,
-			ChooseNameUiModel::isCharacterAccepted, CharacterCreationState::MAX_NAME_LENGTH);
-
-		if (textChanged)
-		{
-			this->entryTextBox.setText(this->name);
-		}
-	}
 }
 
 void ChooseNamePanel::render(Renderer &renderer)

--- a/OpenTESArena/src/Interface/ChooseNamePanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseNamePanel.cpp
@@ -91,7 +91,8 @@ bool ChooseNamePanel::init()
 		}
 	});
 
-	SDL_StartTextInput();
+	auto &inputManager = game.getInputManager();
+	inputManager.setTextInputMode(true);
 
 	return true;
 }

--- a/OpenTESArena/src/Interface/ChooseNamePanel.h
+++ b/OpenTESArena/src/Interface/ChooseNamePanel.h
@@ -4,7 +4,6 @@
 #include <string>
 
 #include "Panel.h"
-#include "../UI/Button.h"
 #include "../UI/TextBox.h"
 #include "../UI/Texture.h"
 
@@ -15,8 +14,6 @@ class ChooseNamePanel : public Panel
 private:
 	Texture parchment;
 	TextBox titleTextBox, entryTextBox;
-	Button<Game&> backToClassButton;
-	Button<Game&, const std::string&> acceptButton;
 	std::string name;
 public:
 	ChooseNamePanel(Game &game);
@@ -25,7 +22,6 @@ public:
 	bool init();
 
 	virtual std::optional<CursorData> getCurrentCursor() const override;
-	virtual void handleEvent(const SDL_Event &e) override;
 	virtual void render(Renderer &renderer) override;
 };
 

--- a/OpenTESArena/src/Interface/ChooseRacePanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseRacePanel.cpp
@@ -6,6 +6,7 @@
 #include "ChooseRacePanel.h"
 #include "TextSubPanel.h"
 #include "../Game/Game.h"
+#include "../Input/InputActionName.h"
 #include "../UI/CursorData.h"
 
 ChooseRacePanel::ChooseRacePanel(Game &game)
@@ -15,8 +16,8 @@ bool ChooseRacePanel::init()
 {
 	auto &game = this->getGame();
 
-	this->backToGenderButton = Button<Game&>(ChooseRaceUiController::onBackToChooseGenderButtonSelected);
-	this->selectProvinceButton = Button<Game&, int>(ChooseRaceUiController::onProvinceButtonSelected);
+	this->addInputActionListener(InputActionName::Back, ChooseRaceUiController::onBackToChooseGenderInputAction);
+	this->addMouseButtonChangedListener(ChooseRaceUiController::onMouseButtonChanged);
 
 	// Push the initial text sub-panel.
 	// @todo: allocate std::function for unravelling the map with "push initial parchment sub-panel" on finished,
@@ -61,34 +62,6 @@ std::unique_ptr<Panel> ChooseRacePanel::getInitialSubPanel(Game &game)
 std::optional<CursorData> ChooseRacePanel::getCurrentCursor() const
 {
 	return this->getDefaultCursor();
-}
-
-void ChooseRacePanel::handleEvent(const SDL_Event &e)
-{
-	auto &game = this->getGame();
-	const auto &inputManager = game.getInputManager();
-	bool escapePressed = inputManager.keyPressed(e, SDLK_ESCAPE);
-	bool leftClick = inputManager.mouseButtonPressed(e, SDL_BUTTON_LEFT);
-	bool rightClick = inputManager.mouseButtonPressed(e, SDL_BUTTON_RIGHT);
-
-	// Interact with the map screen.
-	if (escapePressed)
-	{
-		this->backToGenderButton.click(game);
-	}
-	else if (leftClick)
-	{
-		const Int2 mousePosition = inputManager.getMousePosition();
-		const Int2 originalPoint = game.getRenderer().nativeToOriginal(mousePosition);
-
-		// Listen for clicks on the map, checking if the mouse is over a province mask.
-		const std::optional<int> provinceID = ChooseRaceUiModel::getProvinceID(game, originalPoint);
-		if (provinceID.has_value())
-		{
-			// Choose the selected province.
-			this->selectProvinceButton.click(game, *provinceID);
-		}
-	}
 }
 
 void ChooseRacePanel::drawProvinceTooltip(int provinceID, Renderer &renderer)

--- a/OpenTESArena/src/Interface/ChooseRacePanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseRacePanel.cpp
@@ -5,6 +5,7 @@
 #include "CharacterCreationUiView.h"
 #include "ChooseRacePanel.h"
 #include "TextSubPanel.h"
+#include "WorldMapUiModel.h"
 #include "../Game/Game.h"
 #include "../Input/InputActionName.h"
 #include "../UI/CursorData.h"
@@ -130,11 +131,8 @@ void ChooseRacePanel::renderSecondary(Renderer &renderer)
 	const auto &inputManager = game.getInputManager();
 	const Int2 mousePosition = inputManager.getMousePosition();
 
-	// Draw hovered province tooltip.
-	const Int2 originalPoint = game.getRenderer().nativeToOriginal(mousePosition);
-
 	// Draw tooltip if the mouse is in a province.
-	const std::optional<int> provinceID = ChooseRaceUiModel::getProvinceID(game, originalPoint);
+	const std::optional<int> provinceID = WorldMapUiModel::getMaskID(game, mousePosition, true, true);
 	if (provinceID.has_value())
 	{
 		this->drawProvinceTooltip(*provinceID, renderer);

--- a/OpenTESArena/src/Interface/ChooseRacePanel.h
+++ b/OpenTESArena/src/Interface/ChooseRacePanel.h
@@ -6,7 +6,6 @@
 
 #include "Panel.h"
 #include "../Math/Vector2.h"
-#include "../UI/Button.h"
 #include "../UI/Texture.h"
 
 class Renderer;
@@ -14,9 +13,6 @@ class Renderer;
 class ChooseRacePanel : public Panel
 {
 private:
-	Button<Game&> backToGenderButton;
-	Button<Game&, int> selectProvinceButton;
-
 	void drawProvinceTooltip(int provinceID, Renderer &renderer);	
 public:
 	ChooseRacePanel(Game &game);
@@ -28,7 +24,6 @@ public:
 	static std::unique_ptr<Panel> getInitialSubPanel(Game &game);
 
 	virtual std::optional<CursorData> getCurrentCursor() const override;
-	virtual void handleEvent(const SDL_Event &e) override;
 	virtual void render(Renderer &renderer) override;
 	virtual void renderSecondary(Renderer &renderer) override;
 };

--- a/OpenTESArena/src/Interface/CinematicPanel.cpp
+++ b/OpenTESArena/src/Interface/CinematicPanel.cpp
@@ -3,6 +3,7 @@
 #include "../Input/InputActionMapName.h"
 #include "../Input/InputActionName.h"
 #include "../Media/TextureManager.h"
+#include "../Rendering/ArenaRenderUtils.h"
 #include "../Rendering/Renderer.h"
 #include "../UI/Texture.h"
 
@@ -22,17 +23,26 @@ bool CinematicPanel::init(const std::string &paletteName, const std::string &seq
 	auto &inputManager = game.getInputManager();
 	inputManager.setInputActionMapActive(InputActionMapName::Cinematic, true);
 
+	this->skipButton = Button<Game&>(
+		0,
+		0,
+		ArenaRenderUtils::SCREEN_WIDTH,
+		ArenaRenderUtils::SCREEN_HEIGHT,
+		onFinished);
+
+	this->addButtonProxy(MouseButtonType::Left, this->skipButton.getRect(),
+		[this, &game]() { this->skipButton.click(game); });
+
 	this->addInputActionListener(InputActionName::Skip,
 		[this](const InputActionCallbackValues &values)
 	{
 		if (values.performed)
 		{
 			auto &game = values.game;
-			this->onFinished(game);
+			this->skipButton.click(game);
 		}
 	});
 
-	this->onFinished = onFinished;
 	this->paletteTextureAssetRef = TextureAssetReference(std::string(paletteName));
 	this->sequenceFilename = sequenceName;
 	this->secondsPerImage = secondsPerImage;
@@ -71,7 +81,7 @@ void CinematicPanel::tick(double dt)
 	if (this->imageIndex >= textureCount)
 	{
 		this->imageIndex = textureCount - 1;
-		this->onFinished(game);
+		this->skipButton.click(game);
 	}
 }
 

--- a/OpenTESArena/src/Interface/CinematicPanel.cpp
+++ b/OpenTESArena/src/Interface/CinematicPanel.cpp
@@ -10,18 +10,10 @@
 CinematicPanel::CinematicPanel(Game &game)
 	: Panel(game) { }
 
-CinematicPanel::~CinematicPanel()
-{
-	auto &inputManager = this->getGame().getInputManager();
-	inputManager.setInputActionMapActive(InputActionMapName::Cinematic, false);
-}
-
 bool CinematicPanel::init(const std::string &paletteName, const std::string &sequenceName,
 	double secondsPerImage, const OnFinishedFunction &onFinished)
 {
 	auto &game = this->getGame();
-	auto &inputManager = game.getInputManager();
-	inputManager.setInputActionMapActive(InputActionMapName::Cinematic, true);
 
 	this->skipButton = Button<Game&>(
 		0,

--- a/OpenTESArena/src/Interface/CinematicPanel.h
+++ b/OpenTESArena/src/Interface/CinematicPanel.h
@@ -27,7 +27,7 @@ private:
 	TextureAssetReference getCurrentSequenceTextureAssetRef();
 public:
 	CinematicPanel(Game &game);
-	~CinematicPanel() override;
+	~CinematicPanel() override = default;
 
 	bool init(const std::string &paletteName, const std::string &sequenceName, double secondsPerImage,
 		const OnFinishedFunction &onFinished);

--- a/OpenTESArena/src/Interface/CinematicPanel.h
+++ b/OpenTESArena/src/Interface/CinematicPanel.h
@@ -6,7 +6,6 @@
 
 #include "Panel.h"
 #include "../Assets/TextureAssetReference.h"
-#include "../UI/Button.h"
 
 // Designed for sets of images (i.e., videos) that play one after another and
 // eventually lead to another panel. Skipping is available, too.
@@ -16,8 +15,10 @@ class Renderer;
 
 class CinematicPanel : public Panel
 {
+public:
+	using OnFinishedFunction = std::function<void(Game&)>;
 private:
-	Button<Game&> skipButton;
+	OnFinishedFunction onFinished;
 	TextureAssetReference paletteTextureAssetRef;
 	std::string sequenceFilename;
 	double secondsPerImage, currentSeconds;
@@ -26,12 +27,11 @@ private:
 	TextureAssetReference getCurrentSequenceTextureAssetRef();
 public:
 	CinematicPanel(Game &game);
-	~CinematicPanel() override = default;
+	~CinematicPanel() override;
 
 	bool init(const std::string &paletteName, const std::string &sequenceName, double secondsPerImage,
-		const std::function<void(Game&)> &endingAction);
+		const OnFinishedFunction &onFinished);
 
-	virtual void handleEvent(const SDL_Event &e) override;
 	virtual void tick(double dt) override;
 	virtual void render(Renderer &renderer) override;
 };

--- a/OpenTESArena/src/Interface/CinematicPanel.h
+++ b/OpenTESArena/src/Interface/CinematicPanel.h
@@ -18,7 +18,7 @@ class CinematicPanel : public Panel
 public:
 	using OnFinishedFunction = std::function<void(Game&)>;
 private:
-	OnFinishedFunction onFinished;
+	Button<Game&> skipButton;
 	TextureAssetReference paletteTextureAssetRef;
 	std::string sequenceFilename;
 	double secondsPerImage, currentSeconds;

--- a/OpenTESArena/src/Interface/GameWorldPanel.cpp
+++ b/OpenTESArena/src/Interface/GameWorldPanel.cpp
@@ -247,10 +247,11 @@ bool GameWorldPanel::init()
 	this->addInputActionListener(InputActionName::Camp,
 		[this](const InputActionCallbackValues &values)
 	{
-		if (values.performed)
-		{
-			this->campButton.click();
-		}
+		Game &game = values.game;
+		GameState &gameState = game.getGameState();
+
+		// @todo: make this click the button eventually when not needed for testing.
+		gameState.setIsCamping(values.performed);
 	});
 
 	this->addInputActionListener(InputActionName::Automap,
@@ -447,9 +448,8 @@ void GameWorldPanel::tick(double dt)
 
 	// Tick the game world clock time.
 	auto &gameState = game.getGameState();
-	const bool debugFastForwardClock = inputManager.keyIsDown(SDL_SCANCODE_R); // @todo: camp button
 	const Clock oldClock = gameState.getClock();
-	gameState.tick(debugFastForwardClock ? (dt * 250.0) : dt, game);
+	gameState.tick(dt, game);
 	const Clock newClock = gameState.getClock();
 
 	Renderer &renderer = game.getRenderer();

--- a/OpenTESArena/src/Interface/GameWorldPanel.cpp
+++ b/OpenTESArena/src/Interface/GameWorldPanel.cpp
@@ -13,6 +13,8 @@
 #include "../Game/Game.h"
 #include "../GameLogic/MapLogicController.h"
 #include "../GameLogic/PlayerLogicController.h"
+#include "../Input/InputActionMapName.h"
+#include "../Input/InputActionName.h"
 #include "../Media/PortraitFile.h"
 #include "../UI/CursorData.h"
 #include "../World/MapType.h"
@@ -21,6 +23,22 @@
 
 GameWorldPanel::GameWorldPanel(Game &game)
 	: Panel(game) { }
+
+GameWorldPanel::~GameWorldPanel()
+{
+	auto &game = this->getGame();
+	auto &inputManager = game.getInputManager();
+	inputManager.setInputActionMapActive(InputActionMapName::GameWorld, false);
+
+	// If in modern mode, disable free-look.
+	const auto &options = game.getOptions();
+	const bool modernInterface = options.getGraphics_ModernInterface();
+
+	if (modernInterface)
+	{
+		GameWorldUiModel::setFreeLookActive(game, false);
+	}
+}
 
 bool GameWorldPanel::init()
 {
@@ -114,13 +132,166 @@ bool GameWorldPanel::init()
 		GameWorldUiView::ScrollDownButtonWidth,
 		GameWorldUiView::ScrollDownButtonHeight,
 		GameWorldUiController::onScrollDownButtonSelected);
-	this->pauseButton = Button<Game&>(GameWorldUiController::onPauseButtonSelected);
 	this->mapButton = Button<Game&, bool>(
 		GameWorldUiView::MapButtonX,
 		GameWorldUiView::MapButtonY,
 		GameWorldUiView::MapButtonWidth,
 		GameWorldUiView::MapButtonHeight,
 		GameWorldUiController::onMapButtonSelected);
+
+	auto &player = game.getGameState().getPlayer();
+
+	this->addButtonProxy(MouseButtonType::Left, this->characterSheetButton.getRect(),
+		[this, &game]() { this->characterSheetButton.click(game); });
+	this->addButtonProxy(MouseButtonType::Left, this->drawWeaponButton.getRect(),
+		[this, &player]() { this->drawWeaponButton.click(player); });
+	this->addButtonProxy(MouseButtonType::Left, this->stealButton.getRect(),
+		[this]() { this->stealButton.click(); });
+	this->addButtonProxy(MouseButtonType::Left, this->statusButton.getRect(),
+		[this, &game]() { this->statusButton.click(game); });
+	this->addButtonProxy(MouseButtonType::Left, this->magicButton.getRect(),
+		[this]() { this->magicButton.click(); });
+	this->addButtonProxy(MouseButtonType::Left, this->logbookButton.getRect(),
+		[this, &game]() { this->logbookButton.click(game); });
+	this->addButtonProxy(MouseButtonType::Left, this->useItemButton.getRect(),
+		[this]() { this->useItemButton.click(); });
+	this->addButtonProxy(MouseButtonType::Left, this->campButton.getRect(),
+		[this]() { this->campButton.click(); });
+	this->addButtonProxy(MouseButtonType::Left, this->scrollUpButton.getRect(),
+		[this]() { this->scrollUpButton.click(*this); });
+	this->addButtonProxy(MouseButtonType::Left, this->scrollDownButton.getRect(),
+		[this]() { this->scrollDownButton.click(*this); });
+	this->addButtonProxy(MouseButtonType::Left, this->mapButton.getRect(),
+		[this, &game]() { this->mapButton.click(game, true); });
+	this->addButtonProxy(MouseButtonType::Right, this->mapButton.getRect(),
+		[this, &game]() { this->mapButton.click(game, false); });
+
+	auto &inputManager = game.getInputManager();
+	inputManager.setInputActionMapActive(InputActionMapName::GameWorld, true);
+
+	this->addInputActionListener(InputActionName::Activate,
+		[this](const InputActionCallbackValues &values)
+	{
+		GameWorldUiController::onActivateInputAction(values, this->actionText);
+	});
+
+	this->addInputActionListener(InputActionName::Inspect,
+		[this](const InputActionCallbackValues &values)
+	{
+		GameWorldUiController::onInspectInputAction(values, this->actionText);
+	});
+
+	this->addInputActionListener(InputActionName::CharacterSheet,
+		[this, &game](const InputActionCallbackValues &values)
+	{
+		if (values.performed)
+		{
+			this->characterSheetButton.click(game);
+		}
+	});
+
+	this->addInputActionListener(InputActionName::ToggleWeapon,
+		[this, &player](const InputActionCallbackValues &values)
+	{
+		if (values.performed)
+		{
+			this->drawWeaponButton.click(player);
+		}
+	});
+
+	this->addInputActionListener(InputActionName::Steal,
+		[this](const InputActionCallbackValues &values)
+	{
+		if (values.performed)
+		{
+			this->stealButton.click();
+		}
+	});
+
+	this->addInputActionListener(InputActionName::Status,
+		[this, &game](const InputActionCallbackValues &values)
+	{
+		if (values.performed)
+		{
+			this->statusButton.click(game);
+		}
+	});
+
+	this->addInputActionListener(InputActionName::CastMagic,
+		[this](const InputActionCallbackValues &values)
+	{
+		if (values.performed)
+		{
+			this->magicButton.click();
+		}
+	});
+
+	this->addInputActionListener(InputActionName::Logbook,
+		[this, &game](const InputActionCallbackValues &values)
+	{
+		if (values.performed)
+		{
+			this->logbookButton.click(game);
+		}
+	});
+
+	this->addInputActionListener(InputActionName::UseItem,
+		[this](const InputActionCallbackValues &values)
+	{
+		if (values.performed)
+		{
+			this->useItemButton.click();
+		}
+	});
+
+	this->addInputActionListener(InputActionName::Camp,
+		[this](const InputActionCallbackValues &values)
+	{
+		if (values.performed)
+		{
+			this->campButton.click();
+		}
+	});
+
+	this->addInputActionListener(InputActionName::Automap,
+		[this, &game](const InputActionCallbackValues &values)
+	{
+		if (values.performed)
+		{
+			this->mapButton.click(game, true);
+		}
+	});
+
+	this->addInputActionListener(InputActionName::WorldMap,
+		[this, &game](const InputActionCallbackValues &values)
+	{
+		if (values.performed)
+		{
+			this->mapButton.click(game, false);
+		}
+	});
+
+	this->addInputActionListener(InputActionName::ToggleCompass, GameWorldUiController::onToggleCompassInputAction);
+	this->addInputActionListener(InputActionName::PlayerPosition,
+		[this](const InputActionCallbackValues &values)
+	{
+		GameWorldUiController::onPlayerPositionInputAction(values, this->actionText);
+	});
+
+	this->addInputActionListener(InputActionName::PauseMenu, GameWorldUiController::onPauseInputAction);
+	this->addInputActionListener(InputActionName::DebugProfiler, GameWorldUiController::onDebugInputAction);
+
+	this->addMouseButtonChangedListener([this](Game &game, MouseButtonType type, const Int2 &position, bool pressed)
+	{
+		const Rect &centerCursorRegion = this->nativeCursorRegions[GameWorldUiView::CursorMiddleIndex];
+		GameWorldUiController::onMouseButtonChanged(game, type, position, pressed, centerCursorRegion, this->actionText);
+	});
+
+	this->addMouseButtonHeldListener([this](Game &game, MouseButtonType type, const Int2 &position, double dt)
+	{
+		const Rect &centerCursorRegion = this->nativeCursorRegions[GameWorldUiView::CursorMiddleIndex];
+		GameWorldUiController::onMouseButtonHeld(game, type, position, dt, centerCursorRegion);
+	});
 
 	// Set all of the cursor regions relative to the current window.
 	const Int2 screenDims = game.getRenderer().getWindowDimensions();
@@ -138,19 +309,6 @@ bool GameWorldPanel::init()
 	}
 
 	return true;
-}
-
-GameWorldPanel::~GameWorldPanel()
-{
-	// If in modern mode, disable free-look.
-	auto &game = this->getGame();
-	const auto &options = game.getOptions();
-	const bool modernInterface = options.getGraphics_ModernInterface();
-
-	if (modernInterface)
-	{
-		GameWorldUiModel::setFreeLookActive(game, false);
-	}
 }
 
 std::optional<CursorData> GameWorldPanel::getCurrentCursor() const
@@ -200,192 +358,6 @@ std::optional<CursorData> GameWorldPanel::getCurrentCursor() const
 
 		// Not in any of the arrow regions.
 		return this->getDefaultCursor();
-	}
-}
-
-void GameWorldPanel::handleEvent(const SDL_Event &e)
-{
-	auto &game = this->getGame();
-	auto &options = game.getOptions();
-	auto &player = game.getGameState().getPlayer();
-	const auto &inputManager = game.getInputManager();
-	const bool escapePressed = inputManager.keyPressed(e, SDLK_ESCAPE);
-	const bool f4Pressed = inputManager.keyPressed(e, SDLK_F4);
-
-	if (escapePressed)
-	{
-		this->pauseButton.click(game);
-	}
-	else if (f4Pressed)
-	{
-		// Increment or wrap profiler level.
-		const int oldProfilerLevel = options.getMisc_ProfilerLevel();
-		const int newProfilerLevel = (oldProfilerLevel < Options::MAX_PROFILER_LEVEL) ?
-			(oldProfilerLevel + 1) : Options::MIN_PROFILER_LEVEL;
-		options.setMisc_ProfilerLevel(newProfilerLevel);
-	}
-
-	// Listen for hotkeys.
-	const bool drawWeaponHotkeyPressed = inputManager.keyPressed(e, SDLK_f);
-	const bool automapHotkeyPressed = inputManager.keyPressed(e, SDLK_n);
-	const bool logbookHotkeyPressed = inputManager.keyPressed(e, SDLK_l);
-	const bool sheetHotkeyPressed = inputManager.keyPressed(e, SDLK_TAB) || inputManager.keyPressed(e, SDLK_F1);
-	const bool statusHotkeyPressed = inputManager.keyPressed(e, SDLK_v);
-	const bool worldMapHotkeyPressed = inputManager.keyPressed(e, SDLK_m);
-	const bool toggleCompassHotkeyPressed = inputManager.keyPressed(e, SDLK_F8);
-
-	if (drawWeaponHotkeyPressed)
-	{
-		this->drawWeaponButton.click(player);
-	}
-	else if (automapHotkeyPressed)
-	{
-		const bool goToAutomap = true;
-		this->mapButton.click(game, goToAutomap);
-	}
-	else if (logbookHotkeyPressed)
-	{
-		this->logbookButton.click(game);
-	}
-	else if (sheetHotkeyPressed)
-	{
-		this->characterSheetButton.click(game);
-	}
-	else if (statusHotkeyPressed)
-	{
-		this->statusButton.click(game);
-	}
-	else if (worldMapHotkeyPressed)
-	{
-		const bool goToAutomap = false;
-		this->mapButton.click(game, goToAutomap);
-	}
-	else if (toggleCompassHotkeyPressed)
-	{
-		// Toggle compass display.
-		options.setMisc_ShowCompass(!options.getMisc_ShowCompass());
-	}
-
-	// Player's XY coordinate hotkey.
-	const bool f2Pressed = inputManager.keyPressed(e, SDLK_F2);
-
-	if (f2Pressed)
-	{
-		// Refresh player coordinates display (probably intended for debugging in the original game).
-		// These coordinates are in Arena's coordinate system.
-		const std::string text = GameWorldUiModel::getPlayerPositionText(game);
-		this->actionText.setText(text);
-
-		auto &gameState = game.getGameState();
-		gameState.setActionTextDuration(text);
-	}
-
-	const bool leftClick = inputManager.mouseButtonPressed(e, SDL_BUTTON_LEFT);
-	const bool rightClick = inputManager.mouseButtonPressed(e, SDL_BUTTON_RIGHT);
-
-	// @temp: hold this key down to make clicks cause voxels to fade.
-	const bool debugFadeVoxel = inputManager.keyIsDown(SDL_SCANCODE_G);
-
-	const auto &renderer = game.getRenderer();
-
-	// Handle input events based on which player interface mode is active.
-	const bool modernInterface = game.getOptions().getGraphics_ModernInterface();
-	if (!modernInterface)
-	{
-		// Get mouse position relative to letterbox coordinates.
-		const Int2 mousePosition = inputManager.getMousePosition();
-		const Int2 originalPosition = renderer.nativeToOriginal(mousePosition);
-
-		const Rect &centerCursorRegion = this->nativeCursorRegions.at(4);
-
-		if (leftClick)
-		{
-			// Was an interface button clicked?
-			if (this->characterSheetButton.contains(originalPosition))
-			{
-				this->characterSheetButton.click(game);
-			}
-			else if (this->drawWeaponButton.contains(originalPosition))
-			{
-				this->drawWeaponButton.click(player);
-			}
-			else if (this->mapButton.contains(originalPosition))
-			{
-				const bool goToAutomap = true;
-				this->mapButton.click(game, goToAutomap);
-			}
-			else if (this->stealButton.contains(originalPosition))
-			{
-				this->stealButton.click();
-			}
-			else if (this->statusButton.contains(originalPosition))
-			{
-				this->statusButton.click(game);
-			}
-			else if (this->magicButton.contains(originalPosition))
-			{
-				this->magicButton.click();
-			}
-			else if (this->logbookButton.contains(originalPosition))
-			{
-				this->logbookButton.click(game);
-			}
-			else if (this->useItemButton.contains(originalPosition))
-			{
-				this->useItemButton.click();
-			}
-			else if (this->campButton.contains(originalPosition))
-			{
-				this->campButton.click();
-			}
-			else
-			{
-				// Check for left clicks in the game world.
-				if (centerCursorRegion.contains(mousePosition))
-				{
-					const bool primaryClick = true;
-					PlayerLogicController::handleClickInWorld(game, mousePosition, primaryClick, debugFadeVoxel, this->actionText);
-				}
-			}
-		}
-		else if (rightClick)
-		{
-			if (this->mapButton.contains(originalPosition))
-			{
-				this->mapButton.click(game, false);
-			}
-			else
-			{
-				// Check for right clicks in the game world.
-				if (centerCursorRegion.contains(mousePosition))
-				{
-					const bool primaryClick = false;
-					PlayerLogicController::handleClickInWorld(game, mousePosition, primaryClick, false, this->actionText);
-				}
-			}
-		}
-	}
-	else
-	{
-		// Check modern mode input events.
-		const bool ePressed = inputManager.keyPressed(e, SDLK_e);
-
-		// Any clicks will be at the center of the window.
-		const Int2 windowDims = renderer.getWindowDimensions();
-		const Int2 nativeCenter = windowDims / 2;
-
-		if (ePressed)
-		{
-			// Activate (left click in classic mode).
-			const bool primaryClick = true;
-			PlayerLogicController::handleClickInWorld(game, nativeCenter, primaryClick, debugFadeVoxel, this->actionText);
-		}
-		else if (leftClick)
-		{
-			// Read (right click in classic mode).
-			const bool primaryClick = false;
-			PlayerLogicController::handleClickInWorld(game, nativeCenter, primaryClick, false, this->actionText);
-		}
 	}
 }
 

--- a/OpenTESArena/src/Interface/GameWorldPanel.cpp
+++ b/OpenTESArena/src/Interface/GameWorldPanel.cpp
@@ -436,14 +436,11 @@ void GameWorldPanel::tick(double dt)
 	auto &game = this->getGame();
 	DebugAssert(game.gameStateIsActive());
 
-	// Get the relative mouse state.
-	const auto &inputManager = game.getInputManager();
-	const Int2 mouseDelta = inputManager.getMouseDelta();
-
 	// Handle input for player motion.
 	const BufferView<const Rect> nativeCursorRegionsView(
 		this->nativeCursorRegions.data(), static_cast<int>(this->nativeCursorRegions.size()));
-	PlayerLogicController::handlePlayerTurning(game, dt, mouseDelta, nativeCursorRegionsView);
+	const Double2 playerTurnDeltaXY = PlayerLogicController::makeTurningAngularValues(game, dt, nativeCursorRegionsView);
+	PlayerLogicController::turnPlayer(game, playerTurnDeltaXY.x, playerTurnDeltaXY.y);
 	PlayerLogicController::handlePlayerMovement(game, dt, nativeCursorRegionsView);
 
 	// Tick the game world clock time.
@@ -528,6 +525,8 @@ void GameWorldPanel::tick(double dt)
 	const CoordDouble3 newPlayerCoord = player.getPosition();
 
 	// Handle input for the player's attack.
+	const auto &inputManager = game.getInputManager();
+	const Int2 mouseDelta = inputManager.getMouseDelta();
 	PlayerLogicController::handlePlayerAttack(game, mouseDelta);
 
 	MapInstance &mapInst = gameState.getActiveMapInst();

--- a/OpenTESArena/src/Interface/GameWorldPanel.cpp
+++ b/OpenTESArena/src/Interface/GameWorldPanel.cpp
@@ -391,6 +391,8 @@ void GameWorldPanel::handleEvent(const SDL_Event &e)
 
 void GameWorldPanel::onPauseChanged(bool paused)
 {
+	Panel::onPauseChanged(paused);
+
 	auto &game = this->getGame();
 
 	// If in modern mode, set free-look to the given value.

--- a/OpenTESArena/src/Interface/GameWorldPanel.h
+++ b/OpenTESArena/src/Interface/GameWorldPanel.h
@@ -28,7 +28,7 @@ class GameWorldPanel : public Panel
 {
 private:
 	TextBox playerNameTextBox, triggerText, actionText, effectText;
-	Button<Game&> characterSheetButton, statusButton, logbookButton, pauseButton;
+	Button<Game&> characterSheetButton, statusButton, logbookButton;
 	Button<Player&> drawWeaponButton;
 	Button<> stealButton, magicButton, useItemButton, campButton;
 	Button<GameWorldPanel&> scrollUpButton, scrollDownButton;
@@ -47,7 +47,6 @@ public:
 	bool init();
 
 	virtual std::optional<CursorData> getCurrentCursor() const override;
-	virtual void handleEvent(const SDL_Event &e) override;
 	virtual void onPauseChanged(bool paused) override;
 	virtual void resize(int windowWidth, int windowHeight) override;
 	virtual void tick(double dt) override;

--- a/OpenTESArena/src/Interface/GameWorldUiController.h
+++ b/OpenTESArena/src/Interface/GameWorldUiController.h
@@ -1,25 +1,44 @@
 #ifndef GAME_WORLD_UI_CONTROLLER_H
 #define GAME_WORLD_UI_CONTROLLER_H
 
+#include "../Math/Vector2.h"
+
 class Game;
 class GameWorldPanel;
 class Player;
+class Rect;
+class TextBox;
+
+enum class MouseButtonType;
+
+struct InputActionCallbackValues;
 
 namespace GameWorldUiController
 {
+	void onActivate(Game &game, const Int2 &screenPoint, TextBox &actionText);
+	void onActivateInputAction(const InputActionCallbackValues &values, TextBox &actionText);
+	void onInspect(Game &game, const Int2 &screenPoint, TextBox &actionText);
+	void onInspectInputAction(const InputActionCallbackValues &values, TextBox &actionText);
+	void onMouseButtonChanged(Game &game, MouseButtonType type, const Int2 &position, bool pressed,
+		const Rect &centerCursorRegion, TextBox &actionText);
+	void onMouseButtonHeld(Game &game, MouseButtonType type, const Int2 &position, double dt,
+		const Rect &centerCursorRegion);
 	void onCharacterSheetButtonSelected(Game &game);
 	void onWeaponButtonSelected(Player &player);
 	void onStealButtonSelected();
 	void onStatusButtonSelected(Game &game);
 	void onStatusPopUpSelected(Game &game);
 	void onMagicButtonSelected();
+	void onMapButtonSelected(Game &game, bool goToAutomap);
 	void onLogbookButtonSelected(Game &game);
 	void onUseItemButtonSelected();
 	void onCampButtonSelected();
 	void onScrollUpButtonSelected(GameWorldPanel &panel);
 	void onScrollDownButtonSelected(GameWorldPanel &panel);
-	void onPauseButtonSelected(Game &game);
-	void onMapButtonSelected(Game &game, bool goToAutomap);
+	void onToggleCompassInputAction(const InputActionCallbackValues &values);
+	void onPlayerPositionInputAction(const InputActionCallbackValues &values, TextBox &actionText);
+	void onPauseInputAction(const InputActionCallbackValues &values);
+	void onDebugInputAction(const InputActionCallbackValues &values);
 }
 
 #endif

--- a/OpenTESArena/src/Interface/GameWorldUiView.cpp
+++ b/OpenTESArena/src/Interface/GameWorldUiView.cpp
@@ -349,6 +349,13 @@ TextureAssetReference GameWorldUiView::getDefaultPaletteTextureAssetRef()
 	return TextureAssetReference(std::string(ArenaPaletteName::Default));
 }
 
+Int2 GameWorldUiView::getNativeWindowCenter(const Renderer &renderer)
+{
+	const Int2 windowDims = renderer.getWindowDimensions();
+	const Int2 nativeCenter = windowDims / 2;
+	return nativeCenter;
+}
+
 // @temp: keep until 3D-DDA ray casting is fully correct (i.e. entire ground is red dots for
 // levels where ceilingScale < 1.0, and same with ceiling blue dots).
 void GameWorldUiView::DEBUG_ColorRaycastPixel(Game &game)

--- a/OpenTESArena/src/Interface/GameWorldUiView.h
+++ b/OpenTESArena/src/Interface/GameWorldUiView.h
@@ -202,6 +202,9 @@ namespace GameWorldUiView
 
 	TextureAssetReference getDefaultPaletteTextureAssetRef();
 
+	// Gets the pixel coordinate of the center of the window. Does not handle classic vs. modern mode.
+	Int2 getNativeWindowCenter(const Renderer &renderer);
+
 	void DEBUG_ColorRaycastPixel(Game &game);
 	void DEBUG_PhysicsRaycast(Game &game);
 	void DEBUG_DrawProfiler(Game &game, Renderer &renderer);

--- a/OpenTESArena/src/Interface/ImagePanel.cpp
+++ b/OpenTESArena/src/Interface/ImagePanel.cpp
@@ -2,38 +2,54 @@
 
 #include "ImagePanel.h"
 #include "../Game/Game.h"
+#include "../Input/InputActionMapName.h"
+#include "../Input/InputActionName.h"
 #include "../Media/TextureManager.h"
+#include "../Rendering/ArenaRenderUtils.h"
 #include "../Rendering/Renderer.h"
 #include "../UI/Texture.h"
 
 ImagePanel::ImagePanel(Game &game)
 	: Panel(game) { }
 
+ImagePanel::~ImagePanel()
+{
+	auto &inputManager = this->getGame().getInputManager();
+	inputManager.setInputActionMapActive(InputActionMapName::Cinematic, false);
+}
+
 bool ImagePanel::init(const std::string &paletteName, const std::string &textureName,
 	double secondsToDisplay, const std::function<void(Game&)> &endingAction)
 {
-	this->skipButton = Button<Game&>(endingAction);
+	auto &game = this->getGame();
+	auto &inputManager = game.getInputManager();
+	inputManager.setInputActionMapActive(InputActionMapName::Cinematic, true);
+
+	// Fullscreen button.
+	this->skipButton = Button<Game&>(
+		0,
+		0,
+		ArenaRenderUtils::SCREEN_WIDTH,
+		ArenaRenderUtils::SCREEN_HEIGHT,
+		endingAction);
+
+	this->addButtonProxy(MouseButtonType::Left, this->skipButton.getRect(),
+		[this, &game]() { this->skipButton.click(game); });
+
+	this->addInputActionListener(InputActionName::Skip,
+		[this, &game](const InputActionCallbackValues &values)
+	{
+		if (values.performed)
+		{
+			this->skipButton.click(game);
+		}
+	});
+
 	this->paletteName = paletteName;
 	this->textureName = textureName;
 	this->secondsToDisplay = secondsToDisplay;
 	this->currentSeconds = 0.0;
 	return true;
-}
-
-void ImagePanel::handleEvent(const SDL_Event &e)
-{
-	const auto &inputManager = this->getGame().getInputManager();
-	const bool leftClick = inputManager.mouseButtonPressed(e, SDL_BUTTON_LEFT);
-	
-	const bool spacePressed = inputManager.keyPressed(e, SDLK_SPACE);
-	const bool enterPressed = inputManager.keyPressed(e, SDLK_RETURN) || inputManager.keyPressed(e, SDLK_KP_ENTER);
-	const bool escapePressed = inputManager.keyPressed(e, SDLK_ESCAPE);
-	const bool skipHotkeyPressed = spacePressed || enterPressed || escapePressed;
-
-	if (leftClick || skipHotkeyPressed)
-	{
-		this->skipButton.click(this->getGame());
-	}	
 }
 
 void ImagePanel::tick(double dt)

--- a/OpenTESArena/src/Interface/ImagePanel.cpp
+++ b/OpenTESArena/src/Interface/ImagePanel.cpp
@@ -12,18 +12,10 @@
 ImagePanel::ImagePanel(Game &game)
 	: Panel(game) { }
 
-ImagePanel::~ImagePanel()
-{
-	auto &inputManager = this->getGame().getInputManager();
-	inputManager.setInputActionMapActive(InputActionMapName::Cinematic, false);
-}
-
 bool ImagePanel::init(const std::string &paletteName, const std::string &textureName,
 	double secondsToDisplay, const std::function<void(Game&)> &endingAction)
 {
 	auto &game = this->getGame();
-	auto &inputManager = game.getInputManager();
-	inputManager.setInputActionMapActive(InputActionMapName::Cinematic, true);
 
 	// Fullscreen button.
 	this->skipButton = Button<Game&>(

--- a/OpenTESArena/src/Interface/ImagePanel.h
+++ b/OpenTESArena/src/Interface/ImagePanel.h
@@ -21,7 +21,7 @@ private:
 	double secondsToDisplay, currentSeconds;
 public:
 	ImagePanel(Game &game);
-	~ImagePanel() override;
+	~ImagePanel() override = default;
 
 	bool init(const std::string &paletteName, const std::string &textureName, double secondsToDisplay,
 		const std::function<void(Game&)> &endingAction);

--- a/OpenTESArena/src/Interface/ImagePanel.h
+++ b/OpenTESArena/src/Interface/ImagePanel.h
@@ -21,12 +21,11 @@ private:
 	double secondsToDisplay, currentSeconds;
 public:
 	ImagePanel(Game &game);
-	~ImagePanel() override = default;
+	~ImagePanel() override;
 
 	bool init(const std::string &paletteName, const std::string &textureName, double secondsToDisplay,
 		const std::function<void(Game&)> &endingAction);
 
-	virtual void handleEvent(const SDL_Event &e) override;
 	virtual void tick(double dt) override;
 	virtual void render(Renderer &renderer) override;
 };

--- a/OpenTESArena/src/Interface/ImageSequencePanel.cpp
+++ b/OpenTESArena/src/Interface/ImageSequencePanel.cpp
@@ -16,12 +16,6 @@
 ImageSequencePanel::ImageSequencePanel(Game &game)
 	: Panel(game) { }
 
-ImageSequencePanel::~ImageSequencePanel()
-{
-	auto &inputManager = this->getGame().getInputManager();
-	inputManager.setInputActionMapActive(InputActionMapName::Cinematic, false);
-}
-
 bool ImageSequencePanel::init(const std::vector<std::string> &paletteNames,
 	const std::vector<std::string> &textureNames, const std::vector<double> &imageDurations,
 	const OnFinishedFunction &onFinished)
@@ -41,8 +35,6 @@ bool ImageSequencePanel::init(const std::vector<std::string> &paletteNames,
 	}
 
 	auto &game = this->getGame();
-	auto &inputManager = game.getInputManager();
-	inputManager.setInputActionMapActive(InputActionMapName::Cinematic, true);
 
 	this->skipButton = Button<Game&>(0, 0, ArenaRenderUtils::SCREEN_WIDTH, ArenaRenderUtils::SCREEN_HEIGHT,
 		[this](Game &game)

--- a/OpenTESArena/src/Interface/ImageSequencePanel.cpp
+++ b/OpenTESArena/src/Interface/ImageSequencePanel.cpp
@@ -24,7 +24,7 @@ ImageSequencePanel::~ImageSequencePanel()
 
 bool ImageSequencePanel::init(const std::vector<std::string> &paletteNames,
 	const std::vector<std::string> &textureNames, const std::vector<double> &imageDurations,
-	const std::function<void(Game&)> &onFinished)
+	const OnFinishedFunction &onFinished)
 {
 	if (paletteNames.size() != textureNames.size())
 	{

--- a/OpenTESArena/src/Interface/ImageSequencePanel.cpp
+++ b/OpenTESArena/src/Interface/ImageSequencePanel.cpp
@@ -4,8 +4,11 @@
 
 #include "ImageSequencePanel.h"
 #include "../Game/Game.h"
+#include "../Input/InputActionMapName.h"
+#include "../Input/InputActionName.h"
 #include "../Media/TextureManager.h"
 #include "../UI/Texture.h"
+#include "../Rendering/ArenaRenderUtils.h"
 #include "../Rendering/Renderer.h"
 
 #include "components/debug/Debug.h"
@@ -13,9 +16,15 @@
 ImageSequencePanel::ImageSequencePanel(Game &game)
 	: Panel(game) { }
 
+ImageSequencePanel::~ImageSequencePanel()
+{
+	auto &inputManager = this->getGame().getInputManager();
+	inputManager.setInputActionMapActive(InputActionMapName::Cinematic, false);
+}
+
 bool ImageSequencePanel::init(const std::vector<std::string> &paletteNames,
 	const std::vector<std::string> &textureNames, const std::vector<double> &imageDurations,
-	const std::function<void(Game&)> &endingAction)
+	const std::function<void(Game&)> &onFinished)
 {
 	if (paletteNames.size() != textureNames.size())
 	{
@@ -31,28 +40,12 @@ bool ImageSequencePanel::init(const std::vector<std::string> &paletteNames,
 		return false;
 	}
 
-	this->skipButton = Button<Game&>(endingAction);
-	this->paletteNames = paletteNames;
-	this->textureNames = textureNames;
-	this->imageDurations = imageDurations;
-	this->currentSeconds = 0.0;
-	this->imageIndex = 0;
-	return true;
-}
+	auto &game = this->getGame();
+	auto &inputManager = game.getInputManager();
+	inputManager.setInputActionMapActive(InputActionMapName::Cinematic, true);
 
-void ImageSequencePanel::handleEvent(const SDL_Event &e)
-{
-	const auto &inputManager = this->getGame().getInputManager();
-	const bool leftClick = inputManager.mouseButtonPressed(e, SDL_BUTTON_LEFT);
-	const bool skipAllHotkeyPressed = inputManager.keyPressed(e, SDLK_ESCAPE);
-	const bool skipOneHotkeyPressed = inputManager.keyPressed(e, SDLK_SPACE) ||
-		inputManager.keyPressed(e, SDLK_RETURN) || inputManager.keyPressed(e, SDLK_KP_ENTER);
-
-	if (skipAllHotkeyPressed)
-	{
-		this->skipButton.click(this->getGame());
-	}
-	else if (leftClick || skipOneHotkeyPressed)
+	this->skipButton = Button<Game&>(0, 0, ArenaRenderUtils::SCREEN_WIDTH, ArenaRenderUtils::SCREEN_HEIGHT,
+		[this](Game &game)
 	{
 		this->currentSeconds = 0.0;
 
@@ -61,9 +54,29 @@ void ImageSequencePanel::handleEvent(const SDL_Event &e)
 
 		if (this->imageIndex == imageCount)
 		{
-			this->skipButton.click(this->getGame());
+			this->onFinished(game);
 		}
-	}	
+	});
+
+	this->addButtonProxy(MouseButtonType::Left, this->skipButton.getRect(),
+		[this, &game]() { this->skipButton.click(game); });
+
+	this->addInputActionListener(InputActionName::Skip,
+		[this, &game](const InputActionCallbackValues &values)
+	{
+		if (values.performed)
+		{
+			this->onFinished(game);
+		}
+	});
+
+	this->onFinished = onFinished;
+	this->paletteNames = paletteNames;
+	this->textureNames = textureNames;
+	this->imageDurations = imageDurations;
+	this->currentSeconds = 0.0;
+	this->imageIndex = 0;
+	return true;
 }
 
 void ImageSequencePanel::tick(double dt)
@@ -84,7 +97,7 @@ void ImageSequencePanel::tick(double dt)
 			// Check if the last image is now over.
 			if (this->imageIndex == imageCount)
 			{
-				this->skipButton.click(this->getGame());
+				this->onFinished(this->getGame());
 			}
 		}
 	}

--- a/OpenTESArena/src/Interface/ImageSequencePanel.h
+++ b/OpenTESArena/src/Interface/ImageSequencePanel.h
@@ -27,7 +27,7 @@ private:
 	int imageIndex;
 public:
 	ImageSequencePanel(Game &game);
-	~ImageSequencePanel() override;
+	~ImageSequencePanel() override = default;
 
 	bool init(const std::vector<std::string> &paletteNames, const std::vector<std::string> &textureNames,
 		const std::vector<double> &imageDurations, const OnFinishedFunction &onFinished);

--- a/OpenTESArena/src/Interface/ImageSequencePanel.h
+++ b/OpenTESArena/src/Interface/ImageSequencePanel.h
@@ -15,8 +15,11 @@
 
 class ImageSequencePanel : public Panel
 {
+public:
+	using OnFinishedFunction = std::function<void(Game&)>;
 private:
 	Button<Game&> skipButton;
+	OnFinishedFunction onFinished;
 	std::vector<std::string> paletteNames;
 	std::vector<std::string> textureNames;
 	std::vector<double> imageDurations;
@@ -24,12 +27,11 @@ private:
 	int imageIndex;
 public:
 	ImageSequencePanel(Game &game);
-	~ImageSequencePanel() override = default;
+	~ImageSequencePanel() override;
 
 	bool init(const std::vector<std::string> &paletteNames, const std::vector<std::string> &textureNames,
-		const std::vector<double> &imageDurations, const std::function<void(Game&)> &endingAction);
+		const std::vector<double> &imageDurations, const OnFinishedFunction &onFinished);
 
-	virtual void handleEvent(const SDL_Event &e) override;
 	virtual void tick(double dt) override;
 	virtual void render(Renderer &renderer) override;
 };

--- a/OpenTESArena/src/Interface/LoadSavePanel.h
+++ b/OpenTESArena/src/Interface/LoadSavePanel.h
@@ -16,8 +16,6 @@ public:
 	enum class Type { Load, Save };
 private:
 	std::vector<TextBox> saveTextBoxes;
-	Button<Game&, int> confirmButton;
-	Button<Game&> backButton;
 	LoadSavePanel::Type type;
 public:
 	LoadSavePanel(Game &game);
@@ -26,7 +24,6 @@ public:
 	bool init(LoadSavePanel::Type type);
 
 	virtual std::optional<CursorData> getCurrentCursor() const override;
-	virtual void handleEvent(const SDL_Event &e) override;
 	virtual void render(Renderer &renderer) override;
 };
 

--- a/OpenTESArena/src/Interface/LoadSaveUiController.cpp
+++ b/OpenTESArena/src/Interface/LoadSaveUiController.cpp
@@ -38,14 +38,18 @@ void LoadSaveUiController::onEntryButtonSelected(Game &game, int index)
 	game.pushSubPanel<TextSubPanel>(textBoxInitInfo, text, popUpFunction, std::move(texture), center);
 }
 
-void LoadSaveUiController::onBackButtonSelected(Game &game)
+void LoadSaveUiController::onBackInputAction(const InputActionCallbackValues &values)
 {
-	if (game.gameStateIsActive())
+	if (values.performed)
 	{
-		game.setPanel<PauseMenuPanel>();
-	}
-	else
-	{
-		game.setPanel<MainMenuPanel>();
+		Game &game = values.game;
+		if (game.gameStateIsActive())
+		{
+			game.setPanel<PauseMenuPanel>();
+		}
+		else
+		{
+			game.setPanel<MainMenuPanel>();
+		}
 	}
 }

--- a/OpenTESArena/src/Interface/LoadSaveUiController.h
+++ b/OpenTESArena/src/Interface/LoadSaveUiController.h
@@ -3,10 +3,12 @@
 
 class Game;
 
+struct InputActionCallbackValues;
+
 namespace LoadSaveUiController
 {
 	void onEntryButtonSelected(Game &game, int index);
-	void onBackButtonSelected(Game &game);
+	void onBackInputAction(const InputActionCallbackValues &values);
 }
 
 #endif

--- a/OpenTESArena/src/Interface/LoadSaveUiModel.cpp
+++ b/OpenTESArena/src/Interface/LoadSaveUiModel.cpp
@@ -46,6 +46,19 @@ std::vector<LoadSaveUiModel::Entry> LoadSaveUiModel::getSaveEntries(Game &game)
 	return entries;
 }
 
+Rect LoadSaveUiModel::getSlotRect(int index)
+{
+	constexpr int clickWidth = 316;
+	constexpr int clickHeight = 13;
+	constexpr int ySpacing = 1;
+
+	return Rect(
+		2,
+		2 + ((clickHeight + ySpacing) * index),
+		clickWidth,
+		clickHeight);
+}
+
 std::optional<int> LoadSaveUiModel::getClickedIndex(const Int2 &originalPoint)
 {
 	constexpr int x = 2;

--- a/OpenTESArena/src/Interface/LoadSaveUiModel.h
+++ b/OpenTESArena/src/Interface/LoadSaveUiModel.h
@@ -8,6 +8,7 @@
 #include "../Math/Vector2.h"
 
 class Game;
+class Rect;
 
 namespace LoadSaveUiModel
 {
@@ -24,6 +25,9 @@ namespace LoadSaveUiModel
 
 	std::string getSavesPath(Game &game);
 	std::vector<Entry> getSaveEntries(Game &game);
+
+	// Gets the classic space UI rect of a save slot.
+	Rect getSlotRect(int index);
 
 	// Returns the index of a save's clicked area, if any.
 	std::optional<int> getClickedIndex(const Int2 &originalPoint);

--- a/OpenTESArena/src/Interface/LogbookPanel.h
+++ b/OpenTESArena/src/Interface/LogbookPanel.h
@@ -14,12 +14,11 @@ private:
 	Button<Game&> backButton;
 public:
 	LogbookPanel(Game &game);
-	~LogbookPanel() override = default;
+	~LogbookPanel() override;
 
 	bool init();
 
 	virtual std::optional<CursorData> getCurrentCursor() const override;
-	virtual void handleEvent(const SDL_Event &e) override;
 	virtual void render(Renderer &renderer) override;
 };
 

--- a/OpenTESArena/src/Interface/MainMenuPanel.h
+++ b/OpenTESArena/src/Interface/MainMenuPanel.h
@@ -33,12 +33,11 @@ private:
 	void renderTestUI(Renderer &renderer);
 public:
 	MainMenuPanel(Game &game);
-	~MainMenuPanel() override = default;
+	~MainMenuPanel() override;
 
 	bool init();
 
 	virtual std::optional<CursorData> getCurrentCursor() const override;
-	virtual void handleEvent(const SDL_Event &e) override;
 	virtual void render(Renderer &renderer) override;
 };
 

--- a/OpenTESArena/src/Interface/MainQuestSplashPanel.cpp
+++ b/OpenTESArena/src/Interface/MainQuestSplashPanel.cpp
@@ -3,6 +3,7 @@
 #include "MainQuestSplashUiModel.h"
 #include "MainQuestSplashUiView.h"
 #include "../Game/Game.h"
+#include "../Input/InputActionName.h"
 #include "../UI/CursorData.h"
 
 #include "components/utilities/String.h"
@@ -32,6 +33,18 @@ bool MainQuestSplashPanel::init(int provinceID)
 		MainQuestSplashUiView::ExitButtonHeight,
 		MainQuestSplashUiController::onExitButtonSelected);
 
+	this->addButtonProxy(MouseButtonType::Left, this->exitButton.getRect(),
+		[this, &game]() { this->exitButton.click(game); });
+
+	this->addInputActionListener(InputActionName::Back,
+		[this, &game](const InputActionCallbackValues &values)
+	{
+		if (values.performed)
+		{
+			this->exitButton.click(game);
+		}
+	});
+
 	// Get the texture filename of the staff dungeon splash image.
 	this->splashTextureAssetRef = TextureAssetReference(MainQuestSplashUiModel::getSplashFilename(game, provinceID));
 
@@ -41,25 +54,6 @@ bool MainQuestSplashPanel::init(int provinceID)
 std::optional<CursorData> MainQuestSplashPanel::getCurrentCursor() const
 {
 	return this->getDefaultCursor();
-}
-
-void MainQuestSplashPanel::handleEvent(const SDL_Event &e)
-{
-	// When the exit button is clicked, go to the game world panel.
-	const auto &inputManager = this->getGame().getInputManager();
-	const bool leftClick = inputManager.mouseButtonPressed(e, SDL_BUTTON_LEFT);
-
-	if (leftClick)
-	{
-		const Int2 mousePosition = inputManager.getMousePosition();
-		const Int2 originalPoint = this->getGame().getRenderer()
-			.nativeToOriginal(mousePosition);
-
-		if (this->exitButton.contains(originalPoint))
-		{
-			this->exitButton.click(this->getGame());
-		}
-	}
 }
 
 void MainQuestSplashPanel::render(Renderer &renderer)

--- a/OpenTESArena/src/Interface/MainQuestSplashPanel.h
+++ b/OpenTESArena/src/Interface/MainQuestSplashPanel.h
@@ -21,7 +21,6 @@ public:
 	bool init(int provinceID);
 
 	virtual std::optional<CursorData> getCurrentCursor() const override;
-	virtual void handleEvent(const SDL_Event &e) override;
 	virtual void render(Renderer &renderer) override;
 };
 

--- a/OpenTESArena/src/Interface/MessageBoxSubPanel.h
+++ b/OpenTESArena/src/Interface/MessageBoxSubPanel.h
@@ -59,6 +59,7 @@ public:
 	};
 
 	using ItemCallback = std::function<void()>;
+	using OnClosedFunction = std::function<void()>;
 private:
 	struct Item
 	{
@@ -66,7 +67,7 @@ private:
 		Texture backgroundTexture;
 		TextBox textBox;
 		ItemCallback callback;
-		std::optional<SDL_Keycode> hotkey;
+		std::string inputActionName; // Empty if no hotkey for this button.
 		bool isCancelButton;
 
 		Item();
@@ -78,23 +79,24 @@ private:
 	Texture titleBackgroundTexture;
 	TextBox titleTextBox;
 	Buffer<Item> items;
+	OnClosedFunction onClosed;
 public:
 	MessageBoxSubPanel(Game &game);
-	~MessageBoxSubPanel() override = default;
+	~MessageBoxSubPanel() override;
 
 	bool init(const BackgroundProperties &backgroundProperties, const Rect &titleRect,
-		const TitleProperties &titleProperties, const ItemsProperties &itemsProperties);
+		const TitleProperties &titleProperties, const ItemsProperties &itemsProperties,
+		const OnClosedFunction &onClosed = OnClosedFunction());
 
 	void setTitleText(const std::string_view &text);
 	void setItemText(int itemIndex, const std::string_view &text);
 	void setItemCallback(int itemIndex, const ItemCallback &callback, bool isCancelButton);
-	void setItemHotkey(int itemIndex, const std::optional<SDL_Keycode> &keycode);
+	void setItemInputAction(int itemIndex, const std::string &inputActionName);
 
 	void addOverrideColor(int itemIndex, int charIndex, const Color &overrideColor);
 	void clearOverrideColors(int itemIndex);
 
 	virtual std::optional<CursorData> getCurrentCursor() const override;
-	virtual void handleEvent(const SDL_Event &e) override;
 	virtual void render(Renderer &renderer) override;
 };
 

--- a/OpenTESArena/src/Interface/OptionsPanel.cpp
+++ b/OpenTESArena/src/Interface/OptionsPanel.cpp
@@ -14,6 +14,7 @@
 #include "../Game/GameState.h"
 #include "../Game/Options.h"
 #include "../Game/PlayerInterface.h"
+#include "../Input/InputActionName.h"
 #include "../Media/Color.h"
 #include "../Media/TextureManager.h"
 #include "../Rendering/ArenaRenderUtils.h"
@@ -146,6 +147,7 @@ bool OptionsPanel::init()
 	initTabTextBox(this->miscTextBox, 3, OptionsUiModel::MISC_TAB_NAME);
 	initTabTextBox(this->devTextBox, 4, OptionsUiModel::DEV_TAB_NAME);
 
+	// Button proxies are added later.
 	this->backToPauseMenuButton = Button<Game&>(
 		OptionsUiView::BackToPauseMenuButtonCenterPoint,
 		OptionsUiView::BackToPauseMenuButtonWidth,
@@ -153,6 +155,15 @@ bool OptionsPanel::init()
 		OptionsUiController::onBackToPauseMenuButtonSelected);
 	this->tabButton = Button<OptionsPanel&, OptionsUiModel::Tab*, OptionsUiModel::Tab>(
 		OptionsUiController::onTabButtonSelected);
+
+	this->addInputActionListener(InputActionName::Back,
+		[this](const InputActionCallbackValues &values)
+	{
+		if (values.performed)
+		{
+			this->backToPauseMenuButton.click(values.game);
+		}
+	});
 
 	// Create graphics options.
 	this->graphicsOptions.emplace_back(OptionsUiModel::makeWindowModeOption(game));

--- a/OpenTESArena/src/Interface/OptionsPanel.h
+++ b/OpenTESArena/src/Interface/OptionsPanel.h
@@ -57,11 +57,10 @@ public:
 
 	bool init();
 
-	// Regenerates all option text boxes in the current tab (public for UiController function).
-	void updateVisibleOptionTextBoxes();
+	// Regenerates all options in the current tab (public for UiController function).
+	void updateVisibleOptions();
 
 	virtual std::optional<CursorData> getCurrentCursor() const override;
-	virtual void handleEvent(const SDL_Event &e) override;
 	virtual void render(Renderer &renderer) override;
 };
 

--- a/OpenTESArena/src/Interface/OptionsUiController.cpp
+++ b/OpenTESArena/src/Interface/OptionsUiController.cpp
@@ -17,6 +17,6 @@ void OptionsUiController::onTabButtonSelected(OptionsPanel &panel, OptionsUiMode
 	if (!tabsAreEqual)
 	{
 		*currentTab = newTab;
-		panel.updateVisibleOptionTextBoxes();
+		panel.updateVisibleOptions();
 	}
 }

--- a/OpenTESArena/src/Interface/Panel.cpp
+++ b/OpenTESArena/src/Interface/Panel.cpp
@@ -67,12 +67,6 @@ std::optional<CursorData> Panel::getCurrentCursor() const
 	return std::nullopt;
 }
 
-void Panel::handleEvent(const SDL_Event &e)
-{
-	// Do nothing by default.
-	static_cast<void>(e);
-}
-
 BufferView<const ButtonProxy> Panel::getButtonProxies() const
 {
 	return BufferView<const ButtonProxy>(this->buttonProxies.data(), static_cast<int>(this->buttonProxies.size()));

--- a/OpenTESArena/src/Interface/Panel.cpp
+++ b/OpenTESArena/src/Interface/Panel.cpp
@@ -32,27 +32,27 @@ Panel::~Panel()
 	// Free all the input listener IDs.
 	for (const InputManager::ListenerID listenerID : this->inputActionListenerIDs)
 	{
-		inputManager.removeInputActionListener(listenerID);
+		inputManager.removeListener(listenerID);
 	}
 
 	for (const InputManager::ListenerID listenerID : this->mouseButtonChangedListenerIDs)
 	{
-		inputManager.removeMouseButtonChangedListener(listenerID);
+		inputManager.removeListener(listenerID);
 	}
 
 	for (const InputManager::ListenerID listenerID : this->mouseButtonHeldListenerIDs)
 	{
-		inputManager.removeMouseButtonHeldListener(listenerID);
+		inputManager.removeListener(listenerID);
 	}
 
 	for (const InputManager::ListenerID listenerID : this->mouseScrollChangedListenerIDs)
 	{
-		inputManager.removeMouseScrollChangedListener(listenerID);
+		inputManager.removeListener(listenerID);
 	}
 
 	for (const InputManager::ListenerID listenerID : this->mouseMotionListenerIDs)
 	{
-		inputManager.removeMouseMotionListener(listenerID);
+		inputManager.removeListener(listenerID);
 	}
 }
 

--- a/OpenTESArena/src/Interface/Panel.cpp
+++ b/OpenTESArena/src/Interface/Panel.cpp
@@ -159,10 +159,17 @@ void Panel::addMouseMotionListener(const MouseMotionCallback &callback)
 	this->mouseMotionListenerIDs.emplace_back(inputManager.addMouseMotionListener(callback));
 }
 
-void Panel::addButtonProxy(MouseButtonType buttonType, const Rect &rect, const std::function<void()> &callback,
-	const std::function<bool()> &isActiveFunc)
+void Panel::addButtonProxy(MouseButtonType buttonType, const ButtonProxy::RectFunction &rectFunc,
+	const ButtonProxy::Callback &callback, const ButtonProxy::ActiveFunction &isActiveFunc)
 {
-	this->buttonProxies.emplace_back(ButtonProxy(buttonType, rect, callback, isActiveFunc));
+	this->buttonProxies.emplace_back(buttonType, rectFunc, callback, isActiveFunc);
+}
+
+void Panel::addButtonProxy(MouseButtonType buttonType, const Rect &rect, const ButtonProxy::Callback &callback,
+	const ButtonProxy::ActiveFunction &isActiveFunc)
+{
+	auto rectFunc = [rect]() { return rect; };
+	this->addButtonProxy(buttonType, rectFunc, callback, isActiveFunc);
 }
 
 void Panel::clearButtonProxies()

--- a/OpenTESArena/src/Interface/Panel.cpp
+++ b/OpenTESArena/src/Interface/Panel.cpp
@@ -1,5 +1,3 @@
-#include <vector>
-
 #include "SDL.h"
 
 #include "CinematicPanel.h"
@@ -25,10 +23,37 @@
 #include "components/vfs/manager.hpp"
 
 Panel::Panel(Game &game)
-	: game(game)
+	: game(game) { }
+
+Panel::~Panel()
 {
-	InputManager &inputManager = game.getInputManager();
-	this->listenerID = inputManager.nextListenerID();
+	InputManager &inputManager = this->game.getInputManager();
+
+	// Free all the input listener IDs.
+	for (const InputManager::ListenerID listenerID : this->inputActionListenerIDs)
+	{
+		inputManager.removeInputActionListener(listenerID);
+	}
+
+	for (const InputManager::ListenerID listenerID : this->mouseButtonChangedListenerIDs)
+	{
+		inputManager.removeMouseButtonChangedListener(listenerID);
+	}
+
+	for (const InputManager::ListenerID listenerID : this->mouseButtonHeldListenerIDs)
+	{
+		inputManager.removeMouseButtonHeldListener(listenerID);
+	}
+
+	for (const InputManager::ListenerID listenerID : this->mouseScrollChangedListenerIDs)
+	{
+		inputManager.removeMouseScrollChangedListener(listenerID);
+	}
+
+	for (const InputManager::ListenerID listenerID : this->mouseMotionListenerIDs)
+	{
+		inputManager.removeMouseMotionListener(listenerID);
+	}
 }
 
 std::optional<CursorData> Panel::getCurrentCursor() const
@@ -59,11 +84,6 @@ void Panel::resize(int windowWidth, int windowHeight)
 Game &Panel::getGame() const
 {
 	return this->game;
-}
-
-InputManager::ListenerID Panel::getListenerID() const
-{
-	return this->listenerID;
 }
 
 CursorData Panel::getDefaultCursor() const

--- a/OpenTESArena/src/Interface/Panel.cpp
+++ b/OpenTESArena/src/Interface/Panel.cpp
@@ -160,9 +160,9 @@ void Panel::addMouseMotionListener(const MouseMotionCallback &callback)
 }
 
 void Panel::addButtonProxy(MouseButtonType buttonType, const Rect &rect, const std::function<void()> &callback,
-	const std::function<bool()> &isActive)
+	const std::function<bool()> &isActiveFunc)
 {
-	this->buttonProxies.emplace_back(ButtonProxy(buttonType, rect, callback, isActive));
+	this->buttonProxies.emplace_back(ButtonProxy(buttonType, rect, callback, isActiveFunc));
 }
 
 void Panel::clearButtonProxies()

--- a/OpenTESArena/src/Interface/Panel.cpp
+++ b/OpenTESArena/src/Interface/Panel.cpp
@@ -110,6 +110,36 @@ CursorData Panel::getDefaultCursor() const
 	return CursorData(*textureBuilderID, *paletteID, CursorAlignment::TopLeft);
 }
 
+void Panel::addInputActionListener(const std::string_view &actionName, const InputActionCallback &callback)
+{
+	auto &inputManager = this->game.getInputManager();
+	this->inputActionListenerIDs.emplace_back(inputManager.addInputActionListener(actionName, callback));
+}
+
+void Panel::addMouseButtonChangedListener(const MouseButtonChangedCallback &callback)
+{
+	auto &inputManager = this->game.getInputManager();
+	this->mouseButtonChangedListenerIDs.emplace_back(inputManager.addMouseButtonChangedListener(callback));
+}
+
+void Panel::addMouseButtonHeldListener(const MouseButtonHeldCallback &callback)
+{
+	auto &inputManager = this->game.getInputManager();
+	this->mouseButtonHeldListenerIDs.emplace_back(inputManager.addMouseButtonHeldListener(callback));
+}
+
+void Panel::addMouseScrollChangedListener(const MouseScrollChangedCallback &callback)
+{
+	auto &inputManager = this->game.getInputManager();
+	this->mouseScrollChangedListenerIDs.emplace_back(inputManager.addMouseScrollChangedListener(callback));
+}
+
+void Panel::addMouseMotionListener(const MouseMotionCallback &callback)
+{
+	auto &inputManager = this->game.getInputManager();
+	this->mouseMotionListenerIDs.emplace_back(inputManager.addMouseMotionListener(callback));
+}
+
 void Panel::tick(double dt)
 {
 	// Do nothing by default.

--- a/OpenTESArena/src/Interface/Panel.cpp
+++ b/OpenTESArena/src/Interface/Panel.cpp
@@ -68,6 +68,11 @@ void Panel::handleEvent(const SDL_Event &e)
 	static_cast<void>(e);
 }
 
+BufferView<const ButtonProxy> Panel::getButtonProxies() const
+{
+	return BufferView<const ButtonProxy>(this->buttonProxies.data(), static_cast<int>(this->buttonProxies.size()));
+}
+
 void Panel::onPauseChanged(bool paused)
 {
 	InputManager &inputManager = this->game.getInputManager();
@@ -152,6 +157,17 @@ void Panel::addMouseMotionListener(const MouseMotionCallback &callback)
 {
 	auto &inputManager = this->game.getInputManager();
 	this->mouseMotionListenerIDs.emplace_back(inputManager.addMouseMotionListener(callback));
+}
+
+void Panel::addButtonProxy(MouseButtonType buttonType, const Rect &rect, const std::function<void()> &callback,
+	const std::function<bool()> &isActive)
+{
+	this->buttonProxies.emplace_back(ButtonProxy(buttonType, rect, callback, isActive));
+}
+
+void Panel::clearButtonProxies()
+{
+	this->buttonProxies.clear();
 }
 
 void Panel::tick(double dt)

--- a/OpenTESArena/src/Interface/Panel.cpp
+++ b/OpenTESArena/src/Interface/Panel.cpp
@@ -70,8 +70,22 @@ void Panel::handleEvent(const SDL_Event &e)
 
 void Panel::onPauseChanged(bool paused)
 {
-	// Do nothing by default.
-	static_cast<void>(paused);
+	InputManager &inputManager = this->game.getInputManager();
+
+	auto setListenersEnabled = [paused, &inputManager](std::vector<InputManager::ListenerID> &listenerIDs)
+	{
+		for (const InputManager::ListenerID listenerID : listenerIDs)
+		{
+			inputManager.setListenerEnabled(listenerID, !paused);
+		}
+	};
+
+	// Update listener active states so paused panels aren't hearing input callbacks.
+	setListenersEnabled(this->inputActionListenerIDs);
+	setListenersEnabled(this->mouseButtonChangedListenerIDs);
+	setListenersEnabled(this->mouseButtonHeldListenerIDs);
+	setListenersEnabled(this->mouseScrollChangedListenerIDs);
+	setListenersEnabled(this->mouseMotionListenerIDs);
 }
 
 void Panel::resize(int windowWidth, int windowHeight)

--- a/OpenTESArena/src/Interface/Panel.cpp
+++ b/OpenTESArena/src/Interface/Panel.cpp
@@ -25,7 +25,11 @@
 #include "components/vfs/manager.hpp"
 
 Panel::Panel(Game &game)
-	: game(game) { }
+	: game(game)
+{
+	InputManager &inputManager = game.getInputManager();
+	this->listenerID = inputManager.nextListenerID();
+}
 
 std::optional<CursorData> Panel::getCurrentCursor() const
 {
@@ -55,6 +59,11 @@ void Panel::resize(int windowWidth, int windowHeight)
 Game &Panel::getGame() const
 {
 	return this->game;
+}
+
+InputManager::ListenerID Panel::getListenerID() const
+{
+	return this->listenerID;
 }
 
 CursorData Panel::getDefaultCursor() const

--- a/OpenTESArena/src/Interface/Panel.cpp
+++ b/OpenTESArena/src/Interface/Panel.cpp
@@ -54,6 +54,11 @@ Panel::~Panel()
 	{
 		inputManager.removeListener(listenerID);
 	}
+
+	for (const InputManager::ListenerID listenerID : this->textInputListenerIDs)
+	{
+		inputManager.removeListener(listenerID);
+	}
 }
 
 std::optional<CursorData> Panel::getCurrentCursor() const
@@ -91,6 +96,7 @@ void Panel::onPauseChanged(bool paused)
 	setListenersEnabled(this->mouseButtonHeldListenerIDs);
 	setListenersEnabled(this->mouseScrollChangedListenerIDs);
 	setListenersEnabled(this->mouseMotionListenerIDs);
+	setListenersEnabled(this->textInputListenerIDs);
 }
 
 void Panel::resize(int windowWidth, int windowHeight)
@@ -157,6 +163,12 @@ void Panel::addMouseMotionListener(const MouseMotionCallback &callback)
 {
 	auto &inputManager = this->game.getInputManager();
 	this->mouseMotionListenerIDs.emplace_back(inputManager.addMouseMotionListener(callback));
+}
+
+void Panel::addTextInputListener(const TextInputCallback &callback)
+{
+	auto &inputManager = this->game.getInputManager();
+	this->textInputListenerIDs.emplace_back(inputManager.addTextInputListener(callback));
 }
 
 void Panel::addButtonProxy(MouseButtonType buttonType, const ButtonProxy::RectFunction &rectFunc,

--- a/OpenTESArena/src/Interface/Panel.h
+++ b/OpenTESArena/src/Interface/Panel.h
@@ -43,6 +43,7 @@ protected:
 	std::vector<InputManager::ListenerID> mouseButtonHeldListenerIDs;
 	std::vector<InputManager::ListenerID> mouseScrollChangedListenerIDs;
 	std::vector<InputManager::ListenerID> mouseMotionListenerIDs;
+	std::vector<InputManager::ListenerID> textInputListenerIDs;
 
 	std::vector<ButtonProxy> buttonProxies;
 
@@ -56,6 +57,7 @@ protected:
 	void addMouseButtonHeldListener(const MouseButtonHeldCallback &callback);
 	void addMouseScrollChangedListener(const MouseScrollChangedCallback &callback);
 	void addMouseMotionListener(const MouseMotionCallback &callback);
+	void addTextInputListener(const TextInputCallback &callback);
 
 	// Adds a button proxy for a dynamic button (i.e. ListBox items).
 	void addButtonProxy(MouseButtonType buttonType, const ButtonProxy::RectFunction &rectFunc,

--- a/OpenTESArena/src/Interface/Panel.h
+++ b/OpenTESArena/src/Interface/Panel.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <string>
 
+#include "../Input/InputManager.h"
 #include "../Math/Vector2.h"
 #include "../Media/TextureManager.h"
 #include "../Media/TextureUtils.h"
@@ -33,8 +34,10 @@ class Panel
 {
 private:
 	Game &game;
+	InputManager::ListenerID listenerID;
 protected:
 	Game &getGame() const;
+	InputManager::ListenerID getListenerID() const;
 
 	// Default cursor used by most panels.
 	CursorData getDefaultCursor() const;

--- a/OpenTESArena/src/Interface/Panel.h
+++ b/OpenTESArena/src/Interface/Panel.h
@@ -76,10 +76,6 @@ public:
 	// least one cursor defined.
 	virtual std::optional<CursorData> getCurrentCursor() const;
 
-	// Handles panel-specific events. Application events like closing and resizing
-	// are handled by the game loop.
-	virtual void handleEvent(const SDL_Event &e);
-
 	// Returns button proxies for ease of iteration and finding out which button is clicked in a frame
 	// so its callback can be called.
 	virtual BufferView<const ButtonProxy> getButtonProxies() const;

--- a/OpenTESArena/src/Interface/Panel.h
+++ b/OpenTESArena/src/Interface/Panel.h
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "../Input/InputManager.h"
 #include "../Math/Vector2.h"
@@ -34,16 +35,21 @@ class Panel
 {
 private:
 	Game &game;
-	InputManager::ListenerID listenerID;
 protected:
+	// Allocated input listener IDs that must be freed when the panel is done with them.
+	std::vector<InputManager::ListenerID> inputActionListenerIDs;
+	std::vector<InputManager::ListenerID> mouseButtonChangedListenerIDs;
+	std::vector<InputManager::ListenerID> mouseButtonHeldListenerIDs;
+	std::vector<InputManager::ListenerID> mouseScrollChangedListenerIDs;
+	std::vector<InputManager::ListenerID> mouseMotionListenerIDs;
+
 	Game &getGame() const;
-	InputManager::ListenerID getListenerID() const;
 
 	// Default cursor used by most panels.
 	CursorData getDefaultCursor() const;
 public:
 	Panel(Game &game);
-	virtual ~Panel() = default;
+	virtual ~Panel();
 
 	// Gets the panel's active mouse cursor and alignment, if any. Override this if the panel has at
 	// least one cursor defined.

--- a/OpenTESArena/src/Interface/Panel.h
+++ b/OpenTESArena/src/Interface/Panel.h
@@ -57,8 +57,14 @@ protected:
 	void addMouseScrollChangedListener(const MouseScrollChangedCallback &callback);
 	void addMouseMotionListener(const MouseMotionCallback &callback);
 
-	void addButtonProxy(MouseButtonType buttonType, const Rect &rect, const std::function<void()> &callback,
-		const std::function<bool()> &isActiveFunc = std::function<bool()>());
+	// Adds a button proxy for a dynamic button (i.e. ListBox items).
+	void addButtonProxy(MouseButtonType buttonType, const ButtonProxy::RectFunction &rectFunc,
+		const ButtonProxy::Callback &callback, const ButtonProxy::ActiveFunction &isActiveFunc = ButtonProxy::ActiveFunction());
+
+	// Adds a button proxy for a static button.
+	void addButtonProxy(MouseButtonType buttonType, const Rect &rect, const ButtonProxy::Callback &callback,
+		const ButtonProxy::ActiveFunction &isActiveFunc = ButtonProxy::ActiveFunction());
+
 	void clearButtonProxies();
 public:
 	Panel(Game &game);

--- a/OpenTESArena/src/Interface/Panel.h
+++ b/OpenTESArena/src/Interface/Panel.h
@@ -58,7 +58,7 @@ protected:
 	void addMouseMotionListener(const MouseMotionCallback &callback);
 
 	void addButtonProxy(MouseButtonType buttonType, const Rect &rect, const std::function<void()> &callback,
-		const std::function<bool()> &isActive = std::function<bool()>());
+		const std::function<bool()> &isActiveFunc = std::function<bool()>());
 	void clearButtonProxies();
 public:
 	Panel(Game &game);

--- a/OpenTESArena/src/Interface/Panel.h
+++ b/OpenTESArena/src/Interface/Panel.h
@@ -10,23 +10,23 @@
 #include "../Math/Vector2.h"
 #include "../Media/TextureManager.h"
 #include "../Media/TextureUtils.h"
+#include "../UI/Button.h"
 
-// Each panel interprets user input and draws to the screen. There is only one panel 
-// active at a time, and it is owned by the Game.
+#include "components/utilities/BufferView.h"
 
-// How might "continued" text boxes work? Arena has some pop-up text boxes that have
-// multiple screens based on the amount of text, and even some buttons like "yes/no" on
-// the last screen. I think I'll just replace them with scrolled text boxes. The buttons
-// can be separate interface objects (no need for a "ScrollableButtonedTextBox").
+// Each panel interprets user input and draws to the screen. There is only one panel active at
+// a time, and it is owned by the Game, although there can be any number of sub-panels.
 
 class Color;
 class CursorData;
 class FontLibrary;
 class Game;
+class Rect;
 class Renderer;
 class Texture;
 
 enum class CursorAlignment;
+enum class MouseButtonType;
 
 struct SDL_Texture;
 
@@ -44,6 +44,8 @@ protected:
 	std::vector<InputManager::ListenerID> mouseScrollChangedListenerIDs;
 	std::vector<InputManager::ListenerID> mouseMotionListenerIDs;
 
+	std::vector<ButtonProxy> buttonProxies;
+
 	Game &getGame() const;
 
 	// Default cursor used by most panels.
@@ -54,6 +56,10 @@ protected:
 	void addMouseButtonHeldListener(const MouseButtonHeldCallback &callback);
 	void addMouseScrollChangedListener(const MouseScrollChangedCallback &callback);
 	void addMouseMotionListener(const MouseMotionCallback &callback);
+
+	void addButtonProxy(MouseButtonType buttonType, const Rect &rect, const std::function<void()> &callback,
+		const std::function<bool()> &isActive = std::function<bool()>());
+	void clearButtonProxies();
 public:
 	Panel(Game &game);
 	virtual ~Panel();
@@ -65,6 +71,10 @@ public:
 	// Handles panel-specific events. Application events like closing and resizing
 	// are handled by the game loop.
 	virtual void handleEvent(const SDL_Event &e);
+
+	// Returns button proxies for ease of iteration and finding out which button is clicked in a frame
+	// so its callback can be called.
+	virtual BufferView<const ButtonProxy> getButtonProxies() const;
 
 	// Called when a sub-panel above this panel is pushed (added) or popped (removed).
 	virtual void onPauseChanged(bool paused);

--- a/OpenTESArena/src/Interface/Panel.h
+++ b/OpenTESArena/src/Interface/Panel.h
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "../Input/InputManager.h"
@@ -47,6 +48,12 @@ protected:
 
 	// Default cursor used by most panels.
 	CursorData getDefaultCursor() const;
+
+	void addInputActionListener(const std::string_view &actionName, const InputActionCallback &callback);
+	void addMouseButtonChangedListener(const MouseButtonChangedCallback &callback);
+	void addMouseButtonHeldListener(const MouseButtonHeldCallback &callback);
+	void addMouseScrollChangedListener(const MouseScrollChangedCallback &callback);
+	void addMouseMotionListener(const MouseMotionCallback &callback);
 public:
 	Panel(Game &game);
 	virtual ~Panel();

--- a/OpenTESArena/src/Interface/PauseMenuPanel.cpp
+++ b/OpenTESArena/src/Interface/PauseMenuPanel.cpp
@@ -8,6 +8,7 @@
 #include "PauseMenuUiModel.h"
 #include "PauseMenuUiView.h"
 #include "../Game/Game.h"
+#include "../Input/InputActionName.h"
 #include "../Media/PortraitFile.h"
 #include "../UI/CursorData.h"
 #include "../UI/TextRenderUtils.h"
@@ -115,6 +116,36 @@ bool PauseMenuPanel::init()
 		PauseMenuUiView::MusicDownButtonHeight,
 		PauseMenuUiController::onMusicDownButtonSelected);
 
+	this->addButtonProxy(MouseButtonType::Left, this->newButton.getRect(),
+		[this, &game]() { this->newButton.click(game); });
+	this->addButtonProxy(MouseButtonType::Left, this->loadButton.getRect(),
+		[this, &game]() { this->loadButton.click(game); });
+	this->addButtonProxy(MouseButtonType::Left, this->saveButton.getRect(),
+		[this, &game]() { this->saveButton.click(game); });
+	this->addButtonProxy(MouseButtonType::Left, this->exitButton.getRect(),
+		[this, &game]() { this->exitButton.click(game); });
+	this->addButtonProxy(MouseButtonType::Left, this->resumeButton.getRect(),
+		[this, &game]() { this->resumeButton.click(game); });
+	this->addButtonProxy(MouseButtonType::Left, this->optionsButton.getRect(),
+		[this, &game]() { this->optionsButton.click(game); });
+	this->addButtonProxy(MouseButtonType::Left, this->soundUpButton.getRect(),
+		[this, &game]() { this->soundUpButton.click(game, *this); });
+	this->addButtonProxy(MouseButtonType::Left, this->soundDownButton.getRect(),
+		[this, &game]() { this->soundDownButton.click(game, *this); });
+	this->addButtonProxy(MouseButtonType::Left, this->musicUpButton.getRect(),
+		[this, &game]() { this->musicUpButton.click(game, *this); });
+	this->addButtonProxy(MouseButtonType::Left, this->musicDownButton.getRect(),
+		[this, &game]() { this->musicDownButton.click(game, *this); });
+
+	this->addInputActionListener(InputActionName::Back,
+		[this, &game](const InputActionCallbackValues &values)
+	{
+		if (values.performed)
+		{
+			this->resumeButton.click(game);
+		}
+	});
+
 	// Cover up the detail slider with a new options background.
 	this->optionsButtonTexture = TextureUtils::generate(
 		PauseMenuUiView::OptionsButtonPatternType,
@@ -141,72 +172,6 @@ void PauseMenuPanel::updateSoundText(double volume)
 std::optional<CursorData> PauseMenuPanel::getCurrentCursor() const
 {
 	return this->getDefaultCursor();
-}
-
-void PauseMenuPanel::handleEvent(const SDL_Event &e)
-{
-	const auto &inputManager = this->getGame().getInputManager();
-	bool escapePressed = inputManager.keyPressed(e, SDLK_ESCAPE);
-
-	if (escapePressed)
-	{
-		this->resumeButton.click(this->getGame());
-	}
-
-	bool leftClick = inputManager.mouseButtonPressed(e, SDL_BUTTON_LEFT);
-
-	if (leftClick)
-	{
-		auto &game = this->getGame();
-		const Int2 mousePosition = inputManager.getMousePosition();
-		const Int2 mouseOriginalPoint = game.getRenderer().nativeToOriginal(mousePosition);
-
-		auto &options = game.getOptions();
-		auto &audioManager = game.getAudioManager();
-
-		// See if any of the buttons are clicked.
-		// (This code is getting kind of bad now. Maybe use a vector?)
-		if (this->loadButton.contains(mouseOriginalPoint))
-		{
-			this->loadButton.click(game);
-		}
-		else if (this->exitButton.contains(mouseOriginalPoint))
-		{
-			this->exitButton.click(game);
-		}
-		else if (this->newButton.contains(mouseOriginalPoint))
-		{
-			this->newButton.click(game);
-		}
-		else if (this->saveButton.contains(mouseOriginalPoint))
-		{
-			this->saveButton.click(game);
-		}
-		else if (this->resumeButton.contains(mouseOriginalPoint))
-		{
-			this->resumeButton.click(game);
-		}
-		else if (this->optionsButton.contains(mouseOriginalPoint))
-		{
-			this->optionsButton.click(game);
-		}
-		else if (this->musicUpButton.contains(mouseOriginalPoint))
-		{
-			this->musicUpButton.click(game, *this);
-		}
-		else if (this->musicDownButton.contains(mouseOriginalPoint))
-		{
-			this->musicDownButton.click(game, *this);
-		}
-		else if (this->soundUpButton.contains(mouseOriginalPoint))
-		{
-			this->soundUpButton.click(game, *this);
-		}
-		else if (this->soundDownButton.contains(mouseOriginalPoint))
-		{
-			this->soundDownButton.click(game, *this);
-		}
-	}
 }
 
 void PauseMenuPanel::render(Renderer &renderer)

--- a/OpenTESArena/src/Interface/PauseMenuPanel.h
+++ b/OpenTESArena/src/Interface/PauseMenuPanel.h
@@ -28,7 +28,6 @@ public:
 	void updateSoundText(double volume);
 
 	virtual std::optional<CursorData> getCurrentCursor() const override;
-	virtual void handleEvent(const SDL_Event &e) override;
 	virtual void render(Renderer &renderer) override;
 };
 

--- a/OpenTESArena/src/Interface/ProvinceMapPanel.h
+++ b/OpenTESArena/src/Interface/ProvinceMapPanel.h
@@ -72,7 +72,6 @@ public:
 	void handleFastTravel();
 
 	virtual std::optional<CursorData> getCurrentCursor() const override;
-	virtual void handleEvent(const SDL_Event &e) override;
 	virtual void tick(double dt) override;
 	virtual void render(Renderer &renderer) override;
 	virtual void renderSecondary(Renderer &renderer) override;

--- a/OpenTESArena/src/Interface/ProvinceMapUiController.cpp
+++ b/OpenTESArena/src/Interface/ProvinceMapUiController.cpp
@@ -55,7 +55,7 @@ void ProvinceMapUiController::onTextPopUpSelected(Game &game)
 	game.popSubPanel();
 }
 
-void ProvinceMapUiController::onSearchTextAccepted(Game &game, ProvinceSearchSubPanel &panel)
+void ProvinceSearchUiController::onTextAccepted(Game &game, ProvinceSearchSubPanel &panel)
 {
 	SDL_StopTextInput();
 
@@ -63,7 +63,7 @@ void ProvinceMapUiController::onSearchTextAccepted(Game &game, ProvinceSearchSub
 	// with one of the visible locations in the province, then select that location.
 	// Otherwise, display the list box of locations sorted by their location index.
 	const int *exactLocationIndex = nullptr;
-	panel.locationsListIndices = ProvinceMapUiModel::getMatchingLocations(game,
+	panel.locationsListIndices = ProvinceSearchUiModel::getMatchingLocations(game,
 		panel.locationName, panel.provinceID, &exactLocationIndex);
 
 	if (exactLocationIndex != nullptr)
@@ -79,11 +79,11 @@ void ProvinceMapUiController::onSearchTextAccepted(Game &game, ProvinceSearchSub
 	{
 		// No exact match. Change to list mode.
 		panel.initLocationsList();
-		panel.mode = ProvinceMapUiModel::SearchMode::List;
+		panel.mode = ProvinceSearchUiModel::Mode::List;
 	}
 }
 
-void ProvinceMapUiController::onSearchListLocationSelected(Game &game, ProvinceSearchSubPanel &panel, int locationID)
+void ProvinceSearchUiController::onListLocationSelected(Game &game, ProvinceSearchSubPanel &panel, int locationID)
 {
 	// Try to select the location in the province map panel based on whether the
 	// player is already there.
@@ -93,12 +93,12 @@ void ProvinceMapUiController::onSearchListLocationSelected(Game &game, ProvinceS
 	game.popSubPanel();
 }
 
-void ProvinceMapUiController::onSearchListUpButtonSelected(ListBox &listBox)
+void ProvinceSearchUiController::onListUpButtonSelected(ListBox &listBox)
 {
 	listBox.scrollUp();
 }
 
-void ProvinceMapUiController::onSearchListDownButtonSelected(ListBox &listBox)
+void ProvinceSearchUiController::onListDownButtonSelected(ListBox &listBox)
 {
 	listBox.scrollDown();
 }

--- a/OpenTESArena/src/Interface/ProvinceMapUiController.cpp
+++ b/OpenTESArena/src/Interface/ProvinceMapUiController.cpp
@@ -57,7 +57,8 @@ void ProvinceMapUiController::onTextPopUpSelected(Game &game)
 
 void ProvinceSearchUiController::onTextAccepted(Game &game, ProvinceSearchSubPanel &panel)
 {
-	SDL_StopTextInput();
+	auto &inputManager = game.getInputManager();
+	inputManager.setTextInputMode(false);
 
 	// Determine what to do with the current location name. If it is a valid match
 	// with one of the visible locations in the province, then select that location.

--- a/OpenTESArena/src/Interface/ProvinceMapUiController.cpp
+++ b/OpenTESArena/src/Interface/ProvinceMapUiController.cpp
@@ -78,7 +78,7 @@ void ProvinceMapUiController::onSearchTextAccepted(Game &game, ProvinceSearchSub
 	else
 	{
 		// No exact match. Change to list mode.
-		panel.initLocationsListBox();
+		panel.initLocationsList();
 		panel.mode = ProvinceMapUiModel::SearchMode::List;
 	}
 }

--- a/OpenTESArena/src/Interface/ProvinceMapUiController.h
+++ b/OpenTESArena/src/Interface/ProvinceMapUiController.h
@@ -10,20 +10,19 @@ class ProvinceSearchSubPanel;
 
 namespace ProvinceMapUiController
 {
-	// -- Province panel --
-
 	void onSearchButtonSelected(Game &game, ProvinceMapPanel &panel, int provinceID);
 	void onTravelButtonSelected(Game &game, ProvinceMapPanel &panel);
 	void onBackToWorldMapButtonSelected(Game &game);
 
-	void onTextPopUpSelected(Game &game);
+	void onTextPopUpSelected(Game &game);	
+}
 
-	// -- Search sub-panel --
-
-	void onSearchTextAccepted(Game &game, ProvinceSearchSubPanel &panel);
-	void onSearchListLocationSelected(Game &game, ProvinceSearchSubPanel &panel, int locationID);
-	void onSearchListUpButtonSelected(ListBox &listBox);
-	void onSearchListDownButtonSelected(ListBox &listBox);
+namespace ProvinceSearchUiController
+{
+	void onTextAccepted(Game &game, ProvinceSearchSubPanel &panel);
+	void onListLocationSelected(Game &game, ProvinceSearchSubPanel &panel, int locationID);
+	void onListUpButtonSelected(ListBox &listBox);
+	void onListDownButtonSelected(ListBox &listBox);
 }
 
 #endif

--- a/OpenTESArena/src/Interface/ProvinceMapUiModel.cpp
+++ b/OpenTESArena/src/Interface/ProvinceMapUiModel.cpp
@@ -307,19 +307,19 @@ std::string ProvinceMapUiModel::makeTravelText(Game &game, int srcProvinceIndex,
 	return locationFormatText + startDateString + "\n\n" + dayString + distanceString + arrivalDateString;
 }
 
-bool ProvinceMapUiModel::isCharAllowedInSearchText(char c)
+bool ProvinceSearchUiModel::isCharAllowed(char c)
 {
 	// Letters, numbers, spaces, and symbols are allowed.
 	return (c >= ' ') && (c < 127);
 }
 
-std::string ProvinceMapUiModel::getSearchSubPanelTitleText(Game &game)
+std::string ProvinceSearchUiModel::getTitleText(Game &game)
 {
 	const auto &exeData = game.getBinaryAssetLibrary().getExeData();
 	return exeData.travel.searchTitleText;
 }
 
-std::vector<int> ProvinceMapUiModel::getMatchingLocations(Game &game, const std::string &locationName,
+std::vector<int> ProvinceSearchUiModel::getMatchingLocations(Game &game, const std::string &locationName,
 	int provinceIndex, const int **exactLocationIndex)
 {
 	auto &gameState = game.getGameState();

--- a/OpenTESArena/src/Interface/ProvinceMapUiModel.h
+++ b/OpenTESArena/src/Interface/ProvinceMapUiModel.h
@@ -21,8 +21,6 @@ namespace ProvinceMapUiModel
 		TravelData(int locationID, int provinceID, int travelDays);
 	};
 
-	// -- Province panel --
-
 	const std::string SearchButtonTooltip = "Search";
 	const std::string TravelButtonTooltip = "Travel";
 	const std::string BackToWorldMapButtonTooltip = "Back to World Map";
@@ -35,16 +33,17 @@ namespace ProvinceMapUiModel
 
 	// Generates a text sub-panel with a parchment message.
 	std::unique_ptr<Panel> makeTextPopUp(Game &game, const std::string &text);
+}
 
-	// -- Search sub-panel --
+namespace ProvinceSearchUiModel
+{
+	enum class Mode { TextEntry, List };
 
-	enum class SearchMode { TextEntry, List };
+	constexpr int MaxNameLength = 20;
 
-	constexpr int SearchSubPanelMaxNameLength = 20;
+	bool isCharAllowed(char c);
 
-	bool isCharAllowedInSearchText(char c);
-
-	std::string getSearchSubPanelTitleText(Game &game);
+	std::string getTitleText(Game &game);
 
 	// Returns a list of all visible location indices in the given province that have a match with
 	// the given location name. Technically, this should only return up to one index, but returning

--- a/OpenTESArena/src/Interface/ProvinceMapUiView.cpp
+++ b/OpenTESArena/src/Interface/ProvinceMapUiView.cpp
@@ -90,44 +90,44 @@ std::string ProvinceMapUiView::getMapIconBlinkingOutlinesFilename()
 	return ArenaTextureName::MapIconOutlinesBlinking;
 }
 
-TextBox::InitInfo ProvinceMapUiView::getSearchSubPanelTitleTextBoxInitInfo(const std::string_view &text,
+TextBox::InitInfo ProvinceSearchUiView::getTitleTextBoxInitInfo(const std::string_view &text,
 	const FontLibrary &fontLibrary)
 {
 	return TextBox::InitInfo::makeWithXY(
 		text,
-		ProvinceMapUiView::SearchSubPanelTitleTextBoxX,
-		ProvinceMapUiView::SearchSubPanelTitleTextBoxY,
-		ProvinceMapUiView::SearchSubPanelTitleFontName,
-		ProvinceMapUiView::SearchSubPanelTitleColor,
-		ProvinceMapUiView::SearchSubPanelTitleTextAlignment,
+		ProvinceSearchUiView::TitleTextBoxX,
+		ProvinceSearchUiView::TitleTextBoxY,
+		ProvinceSearchUiView::TitleFontName,
+		ProvinceSearchUiView::TitleColor,
+		ProvinceSearchUiView::TitleTextAlignment,
 		fontLibrary);
 }
 
-TextBox::InitInfo ProvinceMapUiView::getSearchSubPanelTextEntryTextBoxInitInfo(const FontLibrary &fontLibrary)
+TextBox::InitInfo ProvinceSearchUiView::getTextEntryTextBoxInitInfo(const FontLibrary &fontLibrary)
 {
-	const std::string dummyText(ProvinceMapUiModel::SearchSubPanelMaxNameLength, TextRenderUtils::LARGEST_CHAR);
-	const Int2 &origin = ProvinceMapUiView::SearchSubPanelDefaultTextCursorPosition;
+	const std::string dummyText(ProvinceSearchUiModel::MaxNameLength, TextRenderUtils::LARGEST_CHAR);
+	const Int2 &origin = ProvinceSearchUiView::DefaultTextCursorPosition;
 	return TextBox::InitInfo::makeWithXY(
 		dummyText,
 		origin.x,
 		origin.y,
-		ProvinceMapUiView::SearchSubPanelTextEntryFontName,
-		ProvinceMapUiView::SearchSubPanelTextEntryColor,
-		ProvinceMapUiView::SearchSubPanelTextEntryTextAlignment,
+		ProvinceSearchUiView::TextEntryFontName,
+		ProvinceSearchUiView::TextEntryColor,
+		ProvinceSearchUiView::TextEntryTextAlignment,
 		fontLibrary);
 }
 
-int ProvinceMapUiView::getSearchSubPanelTextEntryTextureX(int textureWidth)
+int ProvinceSearchUiView::getTextEntryTextureX(int textureWidth)
 {
 	return (ArenaRenderUtils::SCREEN_WIDTH / 2) - (textureWidth / 2) - 1;
 }
 
-int ProvinceMapUiView::getSearchSubPanelTextEntryTextureY(int textureHeight)
+int ProvinceSearchUiView::getTextEntryTextureY(int textureHeight)
 {
 	return (ArenaRenderUtils::SCREEN_HEIGHT / 2) - (textureHeight / 2) - 1;
 }
 
-ListBox::Properties ProvinceMapUiView::makeSearchSubPanelListBoxProperties(const FontLibrary &fontLibrary)
+ListBox::Properties ProvinceSearchUiView::makeListBoxProperties(const FontLibrary &fontLibrary)
 {
 	const char *fontName = ArenaFontName::Arena;
 	int fontDefIndex;
@@ -158,12 +158,12 @@ ListBox::Properties ProvinceMapUiView::makeSearchSubPanelListBoxProperties(const
 		itemColor, scrollScale);
 }
 
-TextureAssetReference ProvinceMapUiView::getSearchSubPanelListTextureAssetRef()
+TextureAssetReference ProvinceSearchUiView::getListTextureAssetRef()
 {
 	return TextureAssetReference(std::string(ArenaTextureName::PopUp8));
 }
 
-TextureAssetReference ProvinceMapUiView::getSearchSubPanelListPaletteTextureAssetRef(Game &game, int provinceID)
+TextureAssetReference ProvinceSearchUiView::getListPaletteTextureAssetRef(Game &game, int provinceID)
 {
 	const auto &exeData = game.getBinaryAssetLibrary().getExeData();
 	const auto &provinceImgFilenames = exeData.locations.provinceImgFilenames;

--- a/OpenTESArena/src/Interface/ProvinceMapUiView.h
+++ b/OpenTESArena/src/Interface/ProvinceMapUiView.h
@@ -19,8 +19,6 @@ struct TextureAssetReference;
 
 namespace ProvinceMapUiView
 {
-	// -- Province panel --
-
 	const Rect SearchButtonRect(34, ArenaRenderUtils::SCREEN_HEIGHT - 32, 18, 27);
 	const Rect TravelButtonRect(53, ArenaRenderUtils::SCREEN_HEIGHT - 32, 18, 27);
 	const Rect BackToWorldMapRect(72, ArenaRenderUtils::SCREEN_HEIGHT - 32, 18, 27);
@@ -73,47 +71,48 @@ namespace ProvinceMapUiView
 
 	std::string getMapIconOutlinesFilename();
 	std::string getMapIconBlinkingOutlinesFilename();
+}
 
-	// -- Search sub-panel --
+namespace ProvinceSearchUiView
+{
+	const Int2 DefaultTextCursorPosition(85, 100);
 
-	const Int2 SearchSubPanelDefaultTextCursorPosition(85, 100);
+	const int TitleTextBoxX = 30;
+	const int TitleTextBoxY = 89;
+	const std::string TitleFontName = ArenaFontName::Arena;
+	const Color TitleColor(52, 24, 8);
+	constexpr TextAlignment TitleTextAlignment = TextAlignment::TopLeft;
 
-	const int SearchSubPanelTitleTextBoxX = 30;
-	const int SearchSubPanelTitleTextBoxY = 89;
-	const std::string SearchSubPanelTitleFontName = ArenaFontName::Arena;
-	const Color SearchSubPanelTitleColor(52, 24, 8);
-	constexpr TextAlignment SearchSubPanelTitleTextAlignment = TextAlignment::TopLeft;
+	TextBox::InitInfo getTitleTextBoxInitInfo(const std::string_view &text, const FontLibrary &fontLibrary);
 
-	TextBox::InitInfo getSearchSubPanelTitleTextBoxInitInfo(const std::string_view &text, const FontLibrary &fontLibrary);
+	const std::string TextEntryFontName = ArenaFontName::Arena;
+	const Color TextEntryColor(52, 24, 8);
+	constexpr TextAlignment TextEntryTextAlignment = TextAlignment::TopLeft;
 
-	const std::string SearchSubPanelTextEntryFontName = ArenaFontName::Arena;
-	const Color SearchSubPanelTextEntryColor(52, 24, 8);
-	constexpr TextAlignment SearchSubPanelTextEntryTextAlignment = TextAlignment::TopLeft;
+	TextBox::InitInfo getTextEntryTextBoxInitInfo(const FontLibrary &fontLibrary);
 
-	TextBox::InitInfo getSearchSubPanelTextEntryTextBoxInitInfo(const FontLibrary &fontLibrary);
+	int getTextEntryTextureX(int textureWidth);
+	int getTextEntryTextureY(int textureHeight);
+	constexpr int TextureWidth = 280;
+	constexpr int TextureHeight = 40;
+	constexpr TextureUtils::PatternType TexturePattern = TextureUtils::PatternType::Parchment;
 
-	int getSearchSubPanelTextEntryTextureX(int textureWidth);
-	int getSearchSubPanelTextEntryTextureY(int textureHeight);
-	constexpr int SearchSubPanelTextureWidth = 280;
-	constexpr int SearchSubPanelTextureHeight = 40;
-	constexpr TextureUtils::PatternType SearchSubPanelTexturePattern = TextureUtils::PatternType::Parchment;
+	const Int2 ListUpButtonCenterPoint(70, 24);
+	constexpr int ListUpButtonWidth = 8;
+	constexpr int ListUpButtonHeight = 8;
 
-	const Int2 SearchSubPanelListUpButtonCenterPoint(70, 24);
-	constexpr int SearchSubPanelListUpButtonWidth = 8;
-	constexpr int SearchSubPanelListUpButtonHeight = 8;
+	const Int2 ListDownButtonCenterPoint(70, 97);
+	constexpr int ListDownButtonWidth = 8;
+	constexpr int ListDownButtonHeight = 8;
 
-	const Int2 SearchSubPanelListDownButtonCenterPoint(70, 97);
-	constexpr int SearchSubPanelListDownButtonWidth = 8;
-	constexpr int SearchSubPanelListDownButtonHeight = 8;
+	constexpr int ListTextureX = 57;
+	constexpr int ListTextureY = 11;
 
-	constexpr int SearchSubPanelListTextureX = 57;
-	constexpr int SearchSubPanelListTextureY = 11;
+	const Rect ListBoxRect(85, 34, 147, 54);
+	ListBox::Properties makeListBoxProperties(const FontLibrary &fontLibrary);
 
-	const Rect SearchSubPanelListBoxRect(85, 34, 147, 54);
-	ListBox::Properties makeSearchSubPanelListBoxProperties(const FontLibrary &fontLibrary);
-
-	TextureAssetReference getSearchSubPanelListTextureAssetRef();
-	TextureAssetReference getSearchSubPanelListPaletteTextureAssetRef(Game &game, int provinceID);
+	TextureAssetReference getListTextureAssetRef();
+	TextureAssetReference getListPaletteTextureAssetRef(Game &game, int provinceID);
 }
 
 #endif

--- a/OpenTESArena/src/Interface/ProvinceSearchSubPanel.cpp
+++ b/OpenTESArena/src/Interface/ProvinceSearchSubPanel.cpp
@@ -148,7 +148,8 @@ bool ProvinceSearchSubPanel::init(ProvinceMapPanel &provinceMapPanel, int provin
 	this->provinceID = provinceID;
 
 	// Start with text input enabled.
-	SDL_StartTextInput();
+	auto &inputManager = game.getInputManager();
+	inputManager.setTextInputMode(true);
 
 	return true;
 }

--- a/OpenTESArena/src/Interface/ProvinceSearchSubPanel.cpp
+++ b/OpenTESArena/src/Interface/ProvinceSearchSubPanel.cpp
@@ -10,6 +10,8 @@
 #include "../Assets/ArenaTextureName.h"
 #include "../Assets/CityDataFile.h"
 #include "../Game/Game.h"
+#include "../Input/InputActionName.h"
+#include "../Input/TextEvents.h"
 #include "../Media/Color.h"
 #include "../Media/TextureManager.h"
 #include "../Rendering/ArenaRenderUtils.h"
@@ -56,7 +58,7 @@ bool ProvinceSearchSubPanel::init(ProvinceMapPanel &provinceMapPanel, int provin
 		return false;
 	}
 
-	this->textAcceptButton = Button<Game&, ProvinceSearchSubPanel&>(ProvinceMapUiController::onSearchTextAccepted);
+	// Button proxies for these are added when the locations list is initialized.
 	this->listUpButton = Button<ListBox&>(
 		ProvinceMapUiView::SearchSubPanelListUpButtonCenterPoint,
 		ProvinceMapUiView::SearchSubPanelListUpButtonWidth,
@@ -68,11 +70,85 @@ bool ProvinceSearchSubPanel::init(ProvinceMapPanel &provinceMapPanel, int provin
 		ProvinceMapUiView::SearchSubPanelListDownButtonHeight,
 		ProvinceMapUiController::onSearchListDownButtonSelected);
 
+	this->addInputActionListener(InputActionName::Accept,
+		[this, &game](const InputActionCallbackValues &values)
+	{
+		if (values.performed)
+		{
+			if (this->mode == ProvinceMapUiModel::SearchMode::TextEntry)
+			{
+				// Begin the next step in the location search. Run the entered text through some
+				// checks to see if it matches any location names.
+				ProvinceMapUiController::onSearchTextAccepted(this->getGame(), *this);
+			}
+		}
+	});
+
+	this->addInputActionListener(InputActionName::Back,
+		[this, &game](const InputActionCallbackValues &values)
+	{
+		if (values.performed)
+		{
+			// Return to the province map panel.
+			game.popSubPanel();
+		}
+	});
+
+	this->addInputActionListener(InputActionName::Backspace,
+		[this](const InputActionCallbackValues &values)
+	{
+		if (values.performed)
+		{
+			if (this->mode == ProvinceMapUiModel::SearchMode::TextEntry)
+			{
+				const bool textChanged = TextEntry::backspace(this->locationName);
+				if (textChanged)
+				{
+					this->textEntryTextBox.setText(this->locationName);
+				}
+			}
+		}
+	});
+
+	this->addMouseScrollChangedListener([this](Game &game, MouseWheelScrollType type, const Int2 &position)
+	{
+		if (this->mode == ProvinceMapUiModel::SearchMode::List)
+		{
+			const Rect &listBoxRect = this->locationsListBox.getRect();
+			const Int2 classicPosition = game.getRenderer().nativeToOriginal(position);
+			if (listBoxRect.contains(classicPosition))
+			{
+				if (type == MouseWheelScrollType::Up)
+				{
+					this->listUpButton.click(this->locationsListBox);
+				}
+				else if (type == MouseWheelScrollType::Down)
+				{
+					this->listDownButton.click(this->locationsListBox);
+				}
+			}
+		}
+	});
+
+	this->addTextInputListener([this](const std::string_view &text)
+	{
+		if (this->mode == ProvinceMapUiModel::SearchMode::TextEntry)
+		{
+			const bool textChanged = TextEntry::append(this->locationName, text,
+				ProvinceMapUiModel::isCharAllowedInSearchText, ProvinceMapUiModel::SearchSubPanelMaxNameLength);
+
+			if (textChanged)
+			{
+				this->textEntryTextBox.setText(this->locationName);
+			}
+		}
+	});
+
 	this->provinceMapPanel = &provinceMapPanel;
 	this->mode = ProvinceMapUiModel::SearchMode::TextEntry;
 	this->provinceID = provinceID;
 
-	// Start with text input enabled (see handleTextEntryEvent()).
+	// Start with text input enabled.
 	SDL_StartTextInput();
 
 	return true;
@@ -91,7 +167,7 @@ std::optional<CursorData> ProvinceSearchSubPanel::getCurrentCursor() const
 	}
 }
 
-void ProvinceSearchSubPanel::initLocationsListBox()
+void ProvinceSearchSubPanel::initLocationsList()
 {
 	// @todo: move the locationNames into UiModel
 	auto &game = this->getGame();
@@ -105,6 +181,22 @@ void ProvinceSearchSubPanel::initLocationsListBox()
 	this->locationsListBox.init(ProvinceMapUiView::SearchSubPanelListBoxRect,
 		ProvinceMapUiView::makeSearchSubPanelListBoxProperties(game.getFontLibrary()), game.getRenderer());
 
+	this->clearButtonProxies();
+
+	// Add list box scroll button proxies.
+	this->addButtonProxy(MouseButtonType::Left, this->listUpButton.getRect(),
+		[this]()
+	{
+		this->listUpButton.click(this->locationsListBox);
+	});
+
+	this->addButtonProxy(MouseButtonType::Left, this->listDownButton.getRect(),
+		[this]()
+	{
+		this->listDownButton.click(this->locationsListBox);
+	});
+
+	// Add list box items and button proxies.
 	for (int i = 0; i < static_cast<int>(this->locationsListIndices.size()); i++)
 	{
 		const int locationIndex = this->locationsListIndices[i];
@@ -120,126 +212,25 @@ void ProvinceSearchSubPanel::initLocationsListBox()
 			const int locationsListIndex = this->locationsListIndices[i];
 			ProvinceMapUiController::onSearchListLocationSelected(game, *this, locationsListIndex);
 		});
-	}
-}
 
-void ProvinceSearchSubPanel::handleTextEntryEvent(const SDL_Event &e)
-{
-	auto &game = this->getGame();
-	const auto &inputManager = game.getInputManager();
-	const bool escapePressed = inputManager.keyPressed(e, SDLK_ESCAPE);
-	const bool enterPressed = inputManager.keyPressed(e, SDLK_RETURN) ||
-		inputManager.keyPressed(e, SDLK_KP_ENTER);
-	const bool backspacePressed = inputManager.keyPressed(e, SDLK_BACKSPACE) ||
-		inputManager.keyPressed(e, SDLK_KP_BACKSPACE);
-	const bool rightClick = inputManager.mouseButtonPressed(e, SDL_BUTTON_RIGHT);
-
-	// In the original game, right clicking here is registered as enter, but that seems
-	// inconsistent/unintuitive, so I'm making it register as escape instead.
-	if (escapePressed || rightClick)
-	{
-		// Return to the province map panel.
-		game.popSubPanel();
-	}
-	else if (enterPressed)
-	{
-		// Begin the next step in the location search. Run the entered text through some
-		// checks to see if it matches any location names.
-		this->textAcceptButton.click(this->getGame(), *this);
-	}
-	else
-	{
-		// Listen for SDL text input and changes in text.
-		const bool textChanged = TextEntry::updateText(this->locationName, e, backspacePressed,
-			ProvinceMapUiModel::isCharAllowedInSearchText, ProvinceMapUiModel::SearchSubPanelMaxNameLength);
-
-		if (textChanged)
+		auto rectFunc = [this, i]()
 		{
-			this->textEntryTextBox.setText(this->locationName);
-		}
-	}
-}
+			return this->locationsListBox.getItemGlobalRect(i);
+		};
 
-void ProvinceSearchSubPanel::handleListEvent(const SDL_Event &e)
-{
-	auto &game = this->getGame();
-	const auto &inputManager = game.getInputManager();
-	const bool escapePressed = inputManager.keyPressed(e, SDLK_ESCAPE);
-	const bool rightClick = inputManager.mouseButtonPressed(e, SDL_BUTTON_RIGHT);
-
-	if (escapePressed || rightClick)
-	{
-		// Return to the province map panel.
-		game.popSubPanel();
-	}
-	else
-	{
-		const bool leftClick = inputManager.mouseButtonPressed(e, SDL_BUTTON_LEFT);
-		const bool mouseWheelUp = inputManager.mouseWheeledUp(e);
-		const bool mouseWheelDown = inputManager.mouseWheeledDown(e);
-
-		// If over one of the text elements, select it and perform the travel
-		// behavior depending on whether the player is already there.
-		const Int2 mousePosition = inputManager.getMousePosition();
-		const Int2 originalPoint = this->getGame().getRenderer().nativeToOriginal(mousePosition);
-
-		// Custom width to better fill the screen-space.
-		const Rect &listBoxRect = this->locationsListBox.getRect();
-		if (listBoxRect.contains(originalPoint))
+		auto callback = [this, i]()
 		{
-			if (leftClick)
-			{
-				for (int i = 0; i < this->locationsListBox.getCount(); i++)
-				{
-					const Rect &itemGlobalRect = this->locationsListBox.getItemGlobalRect(i);
-					if (itemGlobalRect.contains(originalPoint))
-					{
-						const ListBox::ItemCallback &itemCallback = this->locationsListBox.getCallback(i);
-						itemCallback();
-						break;
-					}
-				}
-			}
-			else if (mouseWheelUp)
-			{
-				this->listUpButton.click(this->locationsListBox);
-			}
-			else if (mouseWheelDown)
-			{
-				this->listDownButton.click(this->locationsListBox);
-			}
-		}
-		else if (leftClick)
-		{
-			// Check scroll buttons (they are outside the list box to the left).
-			if (this->listUpButton.contains(originalPoint))
-			{
-				this->listUpButton.click(this->locationsListBox);
-			}
-			else if (this->listDownButton.contains(originalPoint))
-			{
-				this->listDownButton.click(this->locationsListBox);
-			}
-		}
-	}
-}
+			const ListBox::ItemCallback &itemCallback = this->locationsListBox.getCallback(i);
+			itemCallback();
+		};
 
-void ProvinceSearchSubPanel::handleEvent(const SDL_Event &e)
-{
-	if (this->mode == ProvinceMapUiModel::SearchMode::TextEntry)
-	{
-		this->handleTextEntryEvent(e);
-	}
-	else
-	{
-		this->handleListEvent(e);
+		this->addButtonProxy(MouseButtonType::Left, rectFunc, callback);
 	}
 }
 
 void ProvinceSearchSubPanel::tick(double dt)
 {
-	// @todo: eventually blink text input cursor in text entry, and listen for
-	// scrolling in list.
+	// @todo: eventually blink text input cursor in text entry, and listen for scrolling in list box.
 	static_cast<void>(dt);
 }
 

--- a/OpenTESArena/src/Interface/ProvinceSearchSubPanel.h
+++ b/OpenTESArena/src/Interface/ProvinceSearchSubPanel.h
@@ -22,11 +22,8 @@ private:
 	Texture parchment;
 	TextBox textTitleTextBox, textEntryTextBox;
 	ListBox locationsListBox;
-	Button<Game&, ProvinceSearchSubPanel&> textAcceptButton;
 	Button<ListBox&> listUpButton, listDownButton;
 
-	void handleTextEntryEvent(const SDL_Event &e);
-	void handleListEvent(const SDL_Event &e);
 	void renderTextEntry(Renderer &renderer);
 	void renderList(Renderer &renderer);
 public:
@@ -43,12 +40,11 @@ public:
 
 	bool init(ProvinceMapPanel &provinceMapPanel, int provinceID);
 
-	// Initializes the locations list box based on the locations list IDs.
+	// Initializes the locations list screen based on the locations list IDs.
 	// - Public for UI controller
-	void initLocationsListBox();
+	void initLocationsList();
 
 	virtual std::optional<CursorData> getCurrentCursor() const override;
-	virtual void handleEvent(const SDL_Event &e) override;
 	virtual void tick(double dt) override;
 	virtual void render(Renderer &renderer) override;
 };

--- a/OpenTESArena/src/Interface/ProvinceSearchSubPanel.h
+++ b/OpenTESArena/src/Interface/ProvinceSearchSubPanel.h
@@ -32,7 +32,7 @@ public:
 	ProvinceMapPanel *provinceMapPanel;
 	std::vector<int> locationsListIndices;
 	std::string locationName;
-	ProvinceMapUiModel::SearchMode mode;
+	ProvinceSearchUiModel::Mode mode;
 	int provinceID;
 
 	ProvinceSearchSubPanel(Game &game);

--- a/OpenTESArena/src/Interface/TextCinematicPanel.cpp
+++ b/OpenTESArena/src/Interface/TextCinematicPanel.cpp
@@ -28,11 +28,8 @@ TextCinematicPanel::TextCinematicPanel(Game &game)
 
 TextCinematicPanel::~TextCinematicPanel()
 {
-	auto &game = this->getGame();
-	auto &inputManager = game.getInputManager();
-	inputManager.setInputActionMapActive(InputActionMapName::Cinematic, false);
-
 	// Stop voice if it is still playing.
+	auto &game = this->getGame();
 	auto &audioManager = game.getAudioManager();
 	audioManager.stopSound();
 }
@@ -95,9 +92,6 @@ bool TextCinematicPanel::init(int textCinematicDefIndex, double secondsPerImage,
 		return textBoxes;
 	}();
 
-	auto &inputManager = game.getInputManager();
-	inputManager.setInputActionMapActive(InputActionMapName::Cinematic, true);
-
 	auto skipPageFunc = [this, onFinished](Game &game)
 	{
 		// Only allow page skipping if there is no speech.
@@ -125,7 +119,7 @@ bool TextCinematicPanel::init(int textCinematicDefIndex, double secondsPerImage,
 	this->addButtonProxy(MouseButtonType::Left, this->skipButton.getRect(),
 		[this, &game]() { this->skipButton.click(game); });
 
-	this->addInputActionListener(InputActionName::Back,
+	this->addInputActionListener(InputActionName::Skip,
 		[onFinished, &game](const InputActionCallbackValues &values)
 	{
 		if (values.performed)

--- a/OpenTESArena/src/Interface/TextCinematicPanel.h
+++ b/OpenTESArena/src/Interface/TextCinematicPanel.h
@@ -29,6 +29,8 @@ class Renderer;
 
 class TextCinematicPanel : public Panel
 {
+public:
+	using OnFinishedFunction = std::function<void(Game&)>;
 private:
 	std::vector<TextBox> textBoxes; // One for every three new lines.
 	Button<Game&> skipButton;
@@ -38,11 +40,10 @@ private:
 	int animImageIndex, textIndex, textCinematicDefIndex;
 public:
 	TextCinematicPanel(Game &game);
-	~TextCinematicPanel() override = default;
+	~TextCinematicPanel() override;
 
-	bool init(int textCinematicDefIndex, double secondsPerImage, const std::function<void(Game&)> &onFinished);
+	bool init(int textCinematicDefIndex, double secondsPerImage, const OnFinishedFunction &onFinished);
 
-	virtual void handleEvent(const SDL_Event &e) override;
 	virtual void tick(double dt) override;
 	virtual void render(Renderer &renderer) override;
 };

--- a/OpenTESArena/src/Interface/TextSubPanel.h
+++ b/OpenTESArena/src/Interface/TextSubPanel.h
@@ -13,9 +13,11 @@
 
 class TextSubPanel : public Panel
 {
+public:
+	using OnClosedFunction = std::function<void(Game&)>;
 private:
+	Button<Game&> closeButton;
 	TextBox textBox;
-	std::function<void(Game&)> onClosed;
 	Texture texture;
 	Int2 textureCenter;
 public:
@@ -23,12 +25,11 @@ public:
 	~TextSubPanel() override = default;
 
 	bool init(const TextBox::InitInfo &textBoxInitInfo, const std::string_view &text,
-		const std::function<void(Game&)> &onClosed, Texture &&texture, const Int2 &textureCenter);
+		const OnClosedFunction &onClosed, Texture &&texture, const Int2 &textureCenter);
 	bool init(const TextBox::InitInfo &textBoxInitInfo, const std::string_view &text,
-		const std::function<void(Game&)> &onClosed);
+		const OnClosedFunction &onClosed);
 
 	virtual std::optional<CursorData> getCurrentCursor() const override;
-	virtual void handleEvent(const SDL_Event &e) override;
 	virtual void render(Renderer &renderer) override;
 };
 

--- a/OpenTESArena/src/Interface/WorldMapPanel.h
+++ b/OpenTESArena/src/Interface/WorldMapPanel.h
@@ -11,7 +11,6 @@ class Renderer;
 class WorldMapPanel : public Panel
 {
 private:
-	Button<Game&> backToGameButton;
 	Buffer<Int2> provinceNameOffsets; // Yellow province name positions.
 public:
 	WorldMapPanel(Game &game);

--- a/OpenTESArena/src/Interface/WorldMapPanel.h
+++ b/OpenTESArena/src/Interface/WorldMapPanel.h
@@ -12,16 +12,14 @@ class WorldMapPanel : public Panel
 {
 private:
 	Button<Game&> backToGameButton;
-	Button<Game&, int> provinceButton;
 	Buffer<Int2> provinceNameOffsets; // Yellow province name positions.
 public:
 	WorldMapPanel(Game &game);
-	~WorldMapPanel() override = default;
+	~WorldMapPanel() override;
 
 	bool init();
 
 	virtual std::optional<CursorData> getCurrentCursor() const override;
-	virtual void handleEvent(const SDL_Event &e) override;
 	virtual void render(Renderer &renderer) override;
 };
 

--- a/OpenTESArena/src/Interface/WorldMapUiModel.h
+++ b/OpenTESArena/src/Interface/WorldMapUiModel.h
@@ -3,18 +3,30 @@
 
 #include <array>
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "../Math/Vector2.h"
 
 class Game;
 class Panel;
+class WorldMapMask;
 
 namespace WorldMapUiModel
 {
 	// -- World map --
 
+	static constexpr int EXIT_BUTTON_MASK_ID = 9;
+	static constexpr int MASK_COUNT = EXIT_BUTTON_MASK_ID + 1;
+
 	std::string getProvinceNameOffsetFilename();
+
+	// Gets the mask click area for a province or the exit button.
+	const WorldMapMask &getMask(const Game &game, int maskID);
+
+	// Gets the province ID or exit button ID of the hovered pixel on the world map.
+	std::optional<int> getMaskID(Game &game, const Int2 &mousePosition, bool ignoreCenterProvince,
+		bool ignoreExitButton);
 
 	// -- Fast travel --
 

--- a/OpenTESArena/src/UI/Button.cpp
+++ b/OpenTESArena/src/UI/Button.cpp
@@ -1,8 +1,8 @@
 #include "Button.h"
 
-ButtonProxy::ButtonProxy(MouseButtonType buttonType, const Rect &rect, const std::function<void()> &callback,
-	const std::function<bool()> &isActiveFunc)
-	: rect(rect), callback(callback), isActiveFunc(isActiveFunc)
+ButtonProxy::ButtonProxy(MouseButtonType buttonType, const RectFunction &rectFunc,
+	const Callback &callback, const ActiveFunction &isActiveFunc)
+	: rectFunc(rectFunc), callback(callback), isActiveFunc(isActiveFunc)
 {
 	this->buttonType = buttonType;
 }

--- a/OpenTESArena/src/UI/Button.cpp
+++ b/OpenTESArena/src/UI/Button.cpp
@@ -1,0 +1,13 @@
+#include "Button.h"
+
+ButtonProxy::ButtonProxy(MouseButtonType buttonType, const Rect &rect, const std::function<void()> &callback,
+	const std::function<bool()> &isActiveFunc)
+	: rect(rect), callback(callback), isActiveFunc(isActiveFunc)
+{
+	this->buttonType = buttonType;
+}
+
+ButtonProxy::ButtonProxy()
+{
+	this->buttonType = static_cast<MouseButtonType>(-1);
+}

--- a/OpenTESArena/src/UI/Button.h
+++ b/OpenTESArena/src/UI/Button.h
@@ -103,13 +103,17 @@ public:
 // worrying about buttons' variadic templates.
 struct ButtonProxy
 {
-	MouseButtonType buttonType; // Which mouse button triggers a click.
-	Rect rect; // Position + size in classic UI space.
-	std::function<void()> callback; // Called if the button is clicked.
-	std::function<bool()> isActiveFunc; // Contains a callable function if it can be inactive.
+	using RectFunction = std::function<Rect()>;
+	using Callback = std::function<void()>;
+	using ActiveFunction = std::function<bool()>;
 
-	ButtonProxy(MouseButtonType buttonType, const Rect &rect, const std::function<void()> &callback,
-		const std::function<bool()> &isActiveFunc = std::function<bool()>());
+	MouseButtonType buttonType; // Which mouse button triggers a click.
+	RectFunction rectFunc; // Position + size in classic UI space. Uses a function for dynamic buttons (ListBox, etc.).
+	Callback callback; // Called if the button is clicked.
+	ActiveFunction isActiveFunc; // Contains a callable function if it can be inactive.
+
+	ButtonProxy(MouseButtonType buttonType, const RectFunction &rectFunc,
+		const Callback &callback, const ActiveFunction &isActiveFunc = ActiveFunction());
 	ButtonProxy();
 };
 

--- a/OpenTESArena/src/UI/Button.h
+++ b/OpenTESArena/src/UI/Button.h
@@ -3,6 +3,7 @@
 
 #include <functional>
 
+#include "../Input/PointerTypes.h"
 #include "../Math/Rect.h"
 #include "../Math/Vector2.h"
 
@@ -16,14 +17,11 @@ private:
 	std::function<void(Args...)> callback;
 	Rect rect;
 public:
-	Button(int x, int y, int width, int height,
-		const std::function<void(Args...)> &callback)
+	Button(int x, int y, int width, int height, const std::function<void(Args...)> &callback)
 		: callback(callback), rect(x, y, width, height) { }
 
-	Button(const Int2 &center, int width, int height,
-		const std::function<void(Args...)> &callback)
-		: Button(center.x - (width / 2), center.y - (height / 2),
-			width, height, callback) { }
+	Button(const Int2 &center, int width, int height, const std::function<void(Args...)> &callback)
+		: Button(center.x - (width / 2), center.y - (height / 2), width, height, callback) { }
 
 	// "Hidden" button, intended only as a hotkey.
 	Button(const std::function<void(Args...)> &callback)
@@ -36,6 +34,11 @@ public:
 	Button(Button&&) = default;
 
 	Button &operator=(Button&&) = default;
+
+	const Rect &getRect() const
+	{
+		return this->rect;
+	}
 
 	int getX() const
 	{
@@ -94,6 +97,20 @@ public:
 	{
 		this->callback(std::forward<Args>(args)...);
 	}
+};
+
+// Allows the input manager to iterate over UI buttons and determine which one is clicked without
+// worrying about buttons' variadic templates.
+struct ButtonProxy
+{
+	MouseButtonType buttonType; // Which mouse button triggers a click.
+	Rect rect; // Position + size in classic UI space.
+	std::function<void()> callback; // Called if the button is clicked.
+	std::function<bool()> isActiveFunc; // Contains a callable function if it can be inactive.
+
+	ButtonProxy(MouseButtonType buttonType, const Rect &rect, const std::function<void()> &callback,
+		const std::function<bool()> &isActiveFunc = std::function<bool()>());
+	ButtonProxy();
 };
 
 #endif

--- a/OpenTESArena/src/UI/TextEntry.cpp
+++ b/OpenTESArena/src/UI/TextEntry.cpp
@@ -1,6 +1,8 @@
-#include "SDL.h"
+#include "SDL_events.h"
 
 #include "TextEntry.h"
+
+#include "components/debug/Debug.h"
 
 bool TextEntry::updateText(std::string &text, const SDL_Event &e, bool backspace,
 	bool(*charIsAllowed)(char), size_t maxLength)
@@ -33,5 +35,36 @@ bool TextEntry::updateText(std::string &text, const SDL_Event &e, bool backspace
 	}
 
 	// No change in the displayed text.
+	return false;
+}
+
+bool TextEntry::append(std::string &text, const std::string_view &inputText, bool(*isCharAllowed)(char), size_t maxLength)
+{
+	bool dirty = false;
+	for (const char c : inputText)
+	{
+		if (text.size() >= maxLength)
+		{
+			break;
+		}
+
+		if (isCharAllowed(c))
+		{
+			text += c;
+			dirty = true;
+		}
+	}
+
+	return dirty;
+}
+
+bool TextEntry::backspace(std::string &text)
+{
+	if (text.size() > 0)
+	{
+		text.pop_back();
+		return true;
+	}
+
 	return false;
 }

--- a/OpenTESArena/src/UI/TextEntry.h
+++ b/OpenTESArena/src/UI/TextEntry.h
@@ -3,6 +3,7 @@
 
 #include <cstddef>
 #include <string>
+#include <string_view>
 
 union SDL_Event;
 
@@ -11,8 +12,16 @@ namespace TextEntry
 	// Modifies the text parameter based on the given SDL input event and backspace boolean,
 	// and returns whether the text was changed. The "charIsAllowed" function decides
 	// which characters from the SDL input event can be appended to the string.
+	// @todo: deprecated
 	bool updateText(std::string &text, const SDL_Event &e, bool backspace,
 		bool(*charIsAllowed)(char), size_t maxLength);
+
+	// Attempts to append the given input text. Returns whether the text changed.
+	bool append(std::string &text, const std::string_view &inputText, bool(*isCharAllowed)(char),
+		size_t maxLength = std::string::npos);
+
+	// Attempts to delete the backmost character. Returns whether the text changed.
+	bool backspace(std::string &text);
 }
 
 #endif

--- a/components/utilities/StringView.cpp
+++ b/components/utilities/StringView.cpp
@@ -2,6 +2,11 @@
 
 #include "StringView.h"
 
+bool StringView::equals(const std::string_view &a, const std::string_view &b)
+{
+	return a == b;
+}
+
 bool StringView::caseInsensitiveEquals(const std::string_view &a, const std::string_view &b)
 {
 	if (a.size() != b.size())

--- a/components/utilities/StringView.h
+++ b/components/utilities/StringView.h
@@ -10,6 +10,9 @@
 
 namespace StringView
 {
+	// Performs a typical ASCII string comparison (mostly intended for const char* convenience).
+	bool equals(const std::string_view &a, const std::string_view &b);
+
 	// Performs a case-insensitive ASCII string comparison.
 	bool caseInsensitiveEquals(const std::string_view &a, const std::string_view &b);
 


### PR DESCRIPTION
Previously, all UI panels listened to hardcoded SDL keycodes and mouse button presses, and each panel manually implemented the means of clicking a button.

Now, panels register various types of input listeners and all SDL events are handled by the InputManager. Some of the input listeners are for input actions (inspired by Unity's input actions) which allow panels to register a callback with a string that points to an input action definition for a physical input event (key down, key up, mouse button down, etc.). This should make key rebinding much easier to implement, although that has not been started yet.

There are a couple weird places where a fullscreen button is used to implement a panel's interactivity. Not sure if that needs to change, but it's just a little weird.

Not completely set on the idea of held keys and mouse buttons being broadcast as events; might make them public getters on the input manager in the future instead.