### PR TITLE
Add exclusive fullscreen support

### DIFF
--- a/OpenTESArena/src/Game/Game.cpp
+++ b/OpenTESArena/src/Game/Game.cpp
@@ -74,11 +74,17 @@ Game::Game()
 	}
 
 	// Initialize the renderer and window with the given settings.
+	auto resolutionScaleFunc = [this]()
+	{
+		const auto &options = this->getOptions();
+		return options.getGraphics_ResolutionScale();
+	};
+
 	constexpr RendererSystemType2D rendererSystemType2D = RendererSystemType2D::SDL2;
 	constexpr RendererSystemType3D rendererSystemType3D = RendererSystemType3D::SoftwareClassic;
 	if (!this->renderer.init(this->options.getGraphics_ScreenWidth(), this->options.getGraphics_ScreenHeight(),
 		static_cast<Renderer::WindowMode>(this->options.getGraphics_WindowMode()),
-		this->options.getGraphics_LetterboxMode(), rendererSystemType2D, rendererSystemType3D))
+		this->options.getGraphics_LetterboxMode(), resolutionScaleFunc, rendererSystemType2D, rendererSystemType3D))
 	{
 		throw DebugException("Couldn't init renderer.");
 	}

--- a/OpenTESArena/src/Game/Options.h
+++ b/OpenTESArena/src/Game/Options.h
@@ -59,7 +59,7 @@ public:
 	// Min/max/allowed values for the application.
 	static constexpr int MIN_FPS = 15;
 	static constexpr int MIN_WINDOW_MODE = 0;
-	static constexpr int MAX_WINDOW_MODE = 1;
+	static constexpr int MAX_WINDOW_MODE = 2;
 	static constexpr double MIN_RESOLUTION_SCALE = 0.10;
 	static constexpr double MAX_RESOLUTION_SCALE = 1.0;
 	static constexpr double MIN_VERTICAL_FOV = 40.0;

--- a/OpenTESArena/src/Interface/GameWorldUiModel.cpp
+++ b/OpenTESArena/src/Interface/GameWorldUiModel.cpp
@@ -252,10 +252,8 @@ VoxelDouble3 GameWorldUiModel::screenToWorldRayDirection(Game &game, const Int2 
 {
 	const auto &options = game.getOptions();
 	const auto &renderer = game.getRenderer();
-	const Int2 windowDims = renderer.getWindowDimensions();
-	const int viewWidth = windowDims.x;
-	const int viewHeight = renderer.getViewHeight();
-	const double viewAspectRatio = static_cast<double>(viewWidth) / static_cast<double>(viewHeight);
+	const Int2 viewDims = renderer.getViewDimensions();
+	const double viewAspectRatio = static_cast<double>(viewDims.x) / static_cast<double>(viewDims.y);
 
 	auto &gameState = game.getGameState();
 	const auto &player = gameState.getPlayer();
@@ -263,8 +261,8 @@ VoxelDouble3 GameWorldUiModel::screenToWorldRayDirection(Game &game, const Int2 
 
 	// Mouse position percents across the screen. Add 0.50 to sample at the center
 	// of the pixel.
-	const double mouseXPercent = (static_cast<double>(windowPoint.x) + 0.50) / static_cast<double>(viewWidth);
-	const double mouseYPercent = (static_cast<double>(windowPoint.y) + 0.50) / static_cast<double>(viewHeight);
+	const double mouseXPercent = (static_cast<double>(windowPoint.x) + 0.50) / static_cast<double>(viewDims.x);
+	const double mouseYPercent = (static_cast<double>(windowPoint.y) + 0.50) / static_cast<double>(viewDims.y);
 
 	return renderer.screenPointToRay(mouseXPercent, mouseYPercent, cameraDirection,
 		options.getGraphics_VerticalFOV(), viewAspectRatio);

--- a/OpenTESArena/src/Interface/GameWorldUiView.cpp
+++ b/OpenTESArena/src/Interface/GameWorldUiView.cpp
@@ -519,9 +519,8 @@ void GameWorldUiView::DEBUG_ColorRaycastPixel(Game &game)
 	const auto &player = gameState.getPlayer();
 	const CoordDouble3 &rayStart = player.getPosition();
 	const VoxelDouble3 &cameraDirection = player.getDirection();
-	const int viewWidth = windowDims.x;
-	const int viewHeight = renderer.getViewHeight();
-	const double viewAspectRatio = static_cast<double>(viewWidth) / static_cast<double>(viewHeight);
+	const Int2 viewDims = renderer.getViewDimensions();
+	const double viewAspectRatio = static_cast<double>(viewDims.x) / static_cast<double>(viewDims.y);
 
 	const MapInstance &mapInst = gameState.getActiveMapInst();
 	const LevelInstance &levelInst = mapInst.getActiveLevel();
@@ -596,10 +595,8 @@ void GameWorldUiView::DEBUG_PhysicsRaycast(Game &game)
 	const Double3 &cameraDirection = player.getDirection();
 
 	auto &renderer = game.getRenderer();
-	const Int2 windowDims = renderer.getWindowDimensions();
-	const int viewWidth = windowDims.x;
-	const int viewHeight = renderer.getViewHeight();
-	const Int2 viewCenterPoint(viewWidth / 2, viewHeight / 2);
+	const Int2 viewDims = renderer.getViewDimensions();
+	const Int2 viewCenterPoint(viewDims.x / 2, viewDims.y / 2);
 
 	const CoordDouble3 rayStart = player.getPosition();
 	const VoxelDouble3 rayDirection = GameWorldUiModel::screenToWorldRayDirection(game, viewCenterPoint);

--- a/OpenTESArena/src/Interface/OptionsUiModel.cpp
+++ b/OpenTESArena/src/Interface/OptionsUiModel.cpp
@@ -194,11 +194,12 @@ std::unique_ptr<OptionsUiModel::IntOption> OptionsUiModel::makeWindowModeOption(
 	const auto &options = game.getOptions();
 	return std::make_unique<OptionsUiModel::IntOption>(
 		OptionsUiModel::WINDOW_MODE_NAME,
+		"Determines the game window mode for the display device.\n\nWindow\nBorderless Fullscreen\nExclusive Fullscreen",
 		options.getGraphics_WindowMode(),
 		1,
 		Options::MIN_WINDOW_MODE,
 		Options::MAX_WINDOW_MODE,
-		std::vector<std::string> { "Window", "Borderless Full" },
+		std::vector<std::string> { "Window", "Borderless Fullscreen", "Exclusive Fullscreen" },
 		[&game](int value)
 	{
 		auto &options = game.getOptions();
@@ -212,7 +213,9 @@ std::unique_ptr<OptionsUiModel::IntOption> OptionsUiModel::makeWindowModeOption(
 			case 0:
 				return Renderer::WindowMode::Window;
 			case 1:
-				return Renderer::WindowMode::BorderlessFull;
+				return Renderer::WindowMode::BorderlessFullscreen;
+			case 2:
+				return Renderer::WindowMode::ExclusiveFullscreen;
 			default:
 				DebugUnhandledReturnMsg(Renderer::WindowMode, std::to_string(value));
 			}

--- a/OpenTESArena/src/Rendering/Renderer.h
+++ b/OpenTESArena/src/Rendering/Renderer.h
@@ -2,6 +2,7 @@
 #define RENDERER_H
 
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <vector>
@@ -49,7 +50,8 @@ public:
 	enum class WindowMode
 	{
 		Window,
-		BorderlessFull
+		BorderlessFullscreen,
+		ExclusiveFullscreen
 	};
 
 	// Profiler information from the most recently rendered frame.
@@ -70,6 +72,8 @@ public:
 		void init(int width, int height, int threadCount, int potentiallyVisFlatCount,
 			int visFlatCount, int visLightCount, double frameTime);
 	};
+
+	using ResolutionScaleFunc = std::function<double()>;
 private:
 	static const char *DEFAULT_RENDER_SCALE_QUALITY;
 	static const char *DEFAULT_TITLE;
@@ -81,6 +85,7 @@ private:
 	SDL_Renderer *renderer;
 	Texture nativeTexture, gameWorldTexture; // Frame buffers.
 	ProfilerData profilerData;
+	ResolutionScaleFunc resolutionScaleFunc; // Gets an up-to-date resolution scale value from the game options.
 	int letterboxMode; // Determines aspect ratio of the original UI (16:10, 4:3, etc.).
 	bool fullGameWindow; // Determines height of 3D frame buffer.
 
@@ -118,7 +123,7 @@ public:
 	// The "view height" is the height in pixels for the visible game world. This 
 	// depends on whether the whole screen is rendered or just the portion above 
 	// the interface. The game interface is 53 pixels tall in 320x200.
-	int getViewHeight() const;
+	Int2 getViewDimensions() const;
 
 	// This is for the "letterbox" part of the screen, scaled to fit the window 
 	// using the given letterbox aspect.
@@ -161,7 +166,7 @@ public:
 	Texture createTexture(uint32_t format, int access, int w, int h);
 	Texture createTextureFromSurface(const Surface &surface);
 
-	bool init(int width, int height, WindowMode windowMode, int letterboxMode,
+	bool init(int width, int height, WindowMode windowMode, int letterboxMode, const ResolutionScaleFunc &resolutionScaleFunc,
 		RendererSystemType2D systemType2D, RendererSystemType3D systemType3D);
 
 	// Resizes the renderer dimensions.

--- a/options/options-default.txt
+++ b/options/options-default.txt
@@ -12,7 +12,7 @@ ScreenWidth=1280
 ScreenHeight=720
 
 # Determines how the game window is displayed.
-# 0: window, 1: borderless fullscreen
+# 0: window, 1: borderless fullscreen, 2: exclusive fullscreen
 WindowMode=0
 
 TargetFPS=60


### PR DESCRIPTION
Replaces my first attempt PR #158 from 2019.

It seems to work in general on Windows 10. Will test on Raspberry Pi 4.

Two bugs found so far that I'm okay with merging because they are minor:
1) If an SDL_Texture (specifically the debug profiler text) tries to update when exclusive fullscreen is on but the game is not focused, the lock texture call fails and an assertion is hit in `TextBox::getTextureID()`. This happens when alt-tabbing.
2) Starting the game in exclusive fullscreen and then switching to windowed will make the window appear like borderless fullscreen because the renderer wasn't initialized with the dimensions from the options