### PR TITLE
Fixed ‘uint64_t’ does not name a type error preventing building on linux

### DIFF
--- a/components/utilities/VirtualHeap.h
+++ b/components/utilities/VirtualHeap.h
@@ -1,6 +1,7 @@
 #ifndef VIRTUAL_HEAP_H
 #define VIRTUAL_HEAP_H
 
+#include <cstdint>
 #include <deque>
 #include <type_traits>
 #include <unordered_map>


### PR DESCRIPTION
Hello! I was attempting to build this project from scratch in order to make a contribution and I ran across this error while running `make`. Just made this simple, one-line fix for it and I was able to build the project without any issues.