### PR TITLE
Assign attribute points in character creation #271

### DIFF
--- a/OpenTESArena/src/Interface/CharacterCreationUiController.cpp
+++ b/OpenTESArena/src/Interface/CharacterCreationUiController.cpp
@@ -672,6 +672,7 @@ void ChooseAttributesUiController::onRerollButtonSelected(Game &game)
 	charCreationState.rollAttributes(game.random);
 	
 	game.popSubPanel();
+	game.setPanel<ChooseAttributesPanel>();
 }
 
 void ChooseAttributesUiController::onAppearanceTextBoxSelected(Game &game)

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
@@ -294,7 +294,7 @@ bool ChooseAttributesPanel::init()
 			static_cast<int>(upDownTextureDims.x * scaleFactor),
 			static_cast<int>(upDownTextureDims.y * scaleFactor));
 		
-		// Botón flecha arriba
+		// Up arrow
 		const int upButtonIndex = attributeIndex * 2;
 		this->upDownButtons[upButtonIndex] = Button<>();
 		this->upDownButtons[upButtonIndex].setX(buttonCenter.x - (scaledDims.x / 2));
@@ -302,7 +302,7 @@ bool ChooseAttributesPanel::init()
 		this->upDownButtons[upButtonIndex].setWidth(scaledDims.x);
 		this->upDownButtons[upButtonIndex].setHeight(scaledDims.y / 2);
 		
-		// Botón flecha abajo
+		// Down arrow
 		const int downButtonIndex = (attributeIndex * 2) + 1;
 		this->upDownButtons[downButtonIndex] = Button<>();
 		this->upDownButtons[downButtonIndex].setX(buttonCenter.x - (scaledDims.x / 2));
@@ -310,7 +310,7 @@ bool ChooseAttributesPanel::init()
 		this->upDownButtons[downButtonIndex].setWidth(scaledDims.x);
 		this->upDownButtons[downButtonIndex].setHeight(scaledDims.y / 2);
 		
-		// Click handler para flecha arriba
+		// Click handler for up arrow
 		this->addButtonProxy(MouseButtonType::Left, this->upDownButtons[upButtonIndex].getRect(),
 			[this, attributeIndex]() {
 				if (attributeIndex == this->selectedAttribute && this->bonusPoints > 0) {
@@ -344,13 +344,13 @@ bool ChooseAttributesPanel::init()
 						Int2(bonusTextBoxRect.getWidth(), bonusTextBoxRect.getHeight()),
 						PivotType::TopLeft);
 
-					DebugLog(std::string(attribute.name) + " incrementado por " + 
+					DebugLog(std::string(attribute.name) + " increased by " + 
 						std::to_string(modifiableAttribute.maxValue) + 
-						", puntos bonus restantes: " + std::to_string(this->bonusPoints));
+						", bonus points remaining: " + std::to_string(this->bonusPoints));
 				}
 			});
 
-		// Click handler para flecha abajo
+		// Click handler for down arrow
 		this->addButtonProxy(MouseButtonType::Left, this->upDownButtons[downButtonIndex].getRect(),
 			[this, attributeIndex]() {
 				Game& game = this->getGame();
@@ -385,9 +385,9 @@ bool ChooseAttributesPanel::init()
 						Int2(bonusTextBoxRect.getWidth(), bonusTextBoxRect.getHeight()),
 						PivotType::TopLeft);
 
-					DebugLog(std::string(attribute.name) + " decrementado a " + 
+					DebugLog(std::string(attribute.name) + " decremented to " + 
 						std::to_string(modifiableAttribute.maxValue) + 
-						", puntos bonus restantes: " + std::to_string(this->bonusPoints));
+						", remaining bonus points: " + std::to_string(this->bonusPoints));
 				}
 			});
 	}
@@ -395,21 +395,18 @@ bool ChooseAttributesPanel::init()
 	// posicion charisma atributo
 	const Rect &lastAttributeTextBoxRect = this->attributeTextBoxes[PrimaryAttributes::COUNT - 1].getRect();
 
-	// code for botton points
 	const Int2 bonusPointsTextureDims = *renderer.tryGetUiTextureDims(bonusPointsTextureID);
 	const Int2 bonusPointsPosition(
 		lastAttributeTextBoxRect.getLeft() + 25,
 		lastAttributeTextBoxRect.getTop()
 	);
 
-	// fondo bonus PTS
 	this->addDrawCall(
 		bonusPointsTextureID,
 		bonusPointsPosition,
 		bonusPointsTextureDims,
 		PivotType::TopLeft);
 
-	// Iniciar TextBox de puntos bonus
 	const TextBox::InitInfo bonusPointsTextBoxInitInfo = TextBox::InitInfo::makeWithCenter(
 		std::to_string(bonusPoints),
 		Int2(bonusPointsPosition.x + bonusPointsTextureDims.x - 28,

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <array>
 #include <map>
+#include <random>
 
 #include "CharacterCreationUiController.h"
 #include "CharacterCreationUiModel.h"
@@ -25,6 +26,19 @@
 ChooseAttributesPanel::ChooseAttributesPanel(Game &game)
 	: Panel(game) { }
 
+int ChooseAttributesPanel::calculateInitialBonusPoints() const
+{
+	std::random_device rd;
+	std::mt19937 gen(rd());
+	std::uniform_int_distribution<> d6(1, 6);
+	
+	int totalPoints = 0;
+	for (int i = 0; i < 4; i++) {
+		totalPoints += d6(gen);
+	}
+	return totalPoints;
+}
+
 bool ChooseAttributesPanel::init()
 {
 	auto &game = this->getGame();
@@ -35,7 +49,7 @@ bool ChooseAttributesPanel::init()
 	charCreationState.setPortraitIndex(0);
 	charCreationState.clearChangedPoints();
 
-	this->bonusPoints = 10;
+	this->bonusPoints = calculateInitialBonusPoints();
 
 	this->attributesAreSaved = false;
 
@@ -334,8 +348,8 @@ bool ChooseAttributesPanel::init()
 	// Iniciar TextBox de puntos bonus
 	const TextBox::InitInfo bonusPointsTextBoxInitInfo = TextBox::InitInfo::makeWithCenter(
 		std::to_string(bonusPoints),
-		Int2(bonusPointsPosition.x + bonusPointsTextureDims.x - 30,  // 30 pixels desde el borde derecho
-			bonusPointsPosition.y + (bonusPointsTextureDims.y / 2)),  // Centrado verticalmente
+		Int2(bonusPointsPosition.x + bonusPointsTextureDims.x - 28,
+			bonusPointsPosition.y + (bonusPointsTextureDims.y / 2)),
 		ArenaFontName::Arena,
 		Color::Yellow,
 		TextAlignment::MiddleCenter,

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
@@ -265,13 +265,15 @@ bool ChooseAttributesPanel::init()
 		Int2(classTextBoxRect.getWidth(), classTextBoxRect.getHeight()),
 		PivotType::TopLeft);
 
-	// code arrow
+	const Rect &firstAttributeTextBox = this->attributeTextBoxes[0].getRect();
+	int fixedArrowX = firstAttributeTextBox.getRight() + 3;
+	
 	for (int attributeIndex = 0; attributeIndex < PrimaryAttributes::COUNT; attributeIndex++)
 	{
 		const Rect &attributeTextBoxRect = this->attributeTextBoxes[attributeIndex].getRect();
 		
 		const Int2 buttonCenter(
-			attributeTextBoxRect.getRight() + 5,
+			fixedArrowX,
 			attributeTextBoxRect.getCenter().y);
 		
 		const float scaleFactor = 0.5f;

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
@@ -135,7 +135,7 @@ bool ChooseAttributesPanel::init()
 	this->shirtTextureRef.init(shirtTextureID, renderer);
 	this->statsBgTextureRef.init(statsBgTextureID, renderer);
 
-	// text for Arrows 
+	// texture for Arrows 
 	const TextureAsset upDownTextureAsset = TextureAsset(std::string(ArenaTextureName::UpDown));
 	UiTextureID upDownTextureID;
 	const TextureAsset paletteTextureAsset = TextureAsset(std::string(ArenaPaletteName::CharSheet));
@@ -145,6 +145,16 @@ bool ChooseAttributesPanel::init()
 		return false;
 	}
 	this->upDownTextureRef.init(upDownTextureID, renderer);
+
+	// texture bonus points
+	const TextureAsset bonusPointsTextureAsset = TextureAsset(std::string(ArenaTextureName::BonusPointsText));
+	UiTextureID bonusPointsTextureID;
+	if (!TextureUtils::tryAllocUiTexture(bonusPointsTextureAsset, paletteTextureAsset, textureManager, renderer, &bonusPointsTextureID))
+	{
+		DebugLogError("Couldn't get texture ID for bonus points.");
+		return false;
+	}
+	this->bonusPointsTextureRef.init(bonusPointsTextureID, renderer);
 
 	const Buffer<TextureAsset> headTextureAssets = ChooseAttributesUiView::getHeadTextureAssets(game);
 	this->headTextureRefs.init(headTextureAssets.getCount());
@@ -284,6 +294,19 @@ bool ChooseAttributesPanel::init()
 						);
 			});
 	}
+
+	// code for botton points
+	const Int2 bonusPointsTextureDims = *renderer.tryGetUiTextureDims(bonusPointsTextureID);
+	const Rect& lastAttributeTextBoxRect = this->attributeTextBoxes[PrimaryAttributes::COUNT - 1].getRect();
+	const Int2 bonusPointsPosition(
+		lastAttributeTextBoxRect.getLeft() + 25,
+		lastAttributeTextBoxRect.getTop()
+	);
+	this->addDrawCall(
+		bonusPointsTextureID,
+		bonusPointsPosition,
+		bonusPointsTextureDims,
+		PivotType::TopLeft);
 
 	for (int attributeIndex = 0; attributeIndex < PrimaryAttributes::COUNT; attributeIndex++)
 	{

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
@@ -258,11 +258,23 @@ bool ChooseAttributesPanel::init()
 		this->addButtonProxy(MouseButtonType::Left, this->upDownButtons[attributeIndex].getRect(),
 			[this, attributeIndex, &game]()
 			{
-				const CharacterCreationState &charCreationState = game.getCharacterCreationState();
-				const PrimaryAttributes &attributes = charCreationState.getAttributes();
-				const BufferView<const PrimaryAttribute> attributesView = attributes.getAttributes();
-				const PrimaryAttribute &attribute = attributesView.get(attributeIndex);
-				DebugLog("Selected attribute: " + std::string(attribute.name));
+
+				const CharacterCreationState& charCreationState = game.getCharacterCreationState();
+				BufferView<PrimaryAttribute> attributesView = const_cast<PrimaryAttributes&>(charCreationState.getAttributes()).getAttributes();
+				PrimaryAttribute& modifiableAttribute = attributesView.get(attributeIndex);
+				modifiableAttribute.maxValue += 1;
+				DebugLog("Selected attribute: " + std::string(modifiableAttribute.name));
+
+				// update the  TextBox for atribute
+				std::string updatedValueText = std::to_string(modifiableAttribute.maxValue);
+				this->attributeTextBoxes[attributeIndex].setText(updatedValueText);
+				const Rect& attributeTextBoxRect = this->attributeTextBoxes[attributeIndex].getRect();
+				this->addDrawCall(
+					[this, attributeIndex]() { return this->attributeTextBoxes[attributeIndex].getTextureID(); },
+					[attributeTextBoxRect]() { return attributeTextBoxRect.getTopLeft(); },
+					[attributeTextBoxRect]() { return Int2(attributeTextBoxRect.getWidth(), attributeTextBoxRect.getHeight()); },
+					[]() { return PivotType::TopLeft; },
+					UiDrawCall::defaultActiveFunc);			
 			});
 	}
 

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
@@ -138,7 +138,7 @@ bool ChooseAttributesPanel::init()
 	// text for Arrows 
 	const TextureAsset upDownTextureAsset = TextureAsset(std::string(ArenaTextureName::UpDown));
 	UiTextureID upDownTextureID;
-	const TextureAsset paletteTextureAsset = TextureAsset(std::string(ArenaPaletteName::Default));
+	const TextureAsset paletteTextureAsset = TextureAsset(std::string(ArenaPaletteName::CharSheet));
 	if (!TextureUtils::tryAllocUiTexture(upDownTextureAsset, paletteTextureAsset, textureManager, renderer, &upDownTextureID))
 	{
 		DebugLogError("Couldn't get texture ID for up/down arrows.");

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
@@ -256,25 +256,32 @@ bool ChooseAttributesPanel::init()
 			PivotType::Middle);
 			
 		this->addButtonProxy(MouseButtonType::Left, this->upDownButtons[attributeIndex].getRect(),
-			[this, attributeIndex, &game]()
-			{
+			[this, attributeIndex, &game]() {
 
-				const CharacterCreationState& charCreationState = game.getCharacterCreationState();
-				BufferView<PrimaryAttribute> attributesView = const_cast<PrimaryAttributes&>(charCreationState.getAttributes()).getAttributes();
-				PrimaryAttribute& modifiableAttribute = attributesView.get(attributeIndex);
-				modifiableAttribute.maxValue += 1;
-				DebugLog("Selected attribute: " + std::string(modifiableAttribute.name));
+				auto& charCreationState = game.getCharacterCreationState();
+				auto& attributes = const_cast<PrimaryAttributes&>(charCreationState.getAttributes());
+				auto& modifiableAttribute = attributes.getAttributes()[attributeIndex];
+				++modifiableAttribute.maxValue;
+				DebugLog("Atributo seleccionado: " + std::string(modifiableAttribute.name) + ", nuevo valor: " + std::to_string(modifiableAttribute.maxValue));
 
-				// update the  TextBox for atribute
-				std::string updatedValueText = std::to_string(modifiableAttribute.maxValue);
-				this->attributeTextBoxes[attributeIndex].setText(updatedValueText);
-				const Rect& attributeTextBoxRect = this->attributeTextBoxes[attributeIndex].getRect();
+				// Update the TextBox
+				auto& attributeTextBox = this->attributeTextBoxes[attributeIndex];
+				attributeTextBox.setText(std::to_string(modifiableAttribute.maxValue));
+				auto attributeTextBoxRect = attributeTextBox.getRect();
+
 				this->addDrawCall(
-					[this, attributeIndex]() { return this->attributeTextBoxes[attributeIndex].getTextureID(); },
-					[attributeTextBoxRect]() { return attributeTextBoxRect.getTopLeft(); },
-					[attributeTextBoxRect]() { return Int2(attributeTextBoxRect.getWidth(), attributeTextBoxRect.getHeight()); },
-					[]() { return PivotType::TopLeft; },
-					UiDrawCall::defaultActiveFunc);			
+					[this, attributeIndex]() {
+						return this->attributeTextBoxes[attributeIndex].getTextureID();
+					},
+					[attributeTextBoxRect]() {
+						return attributeTextBoxRect.getTopLeft();
+					},
+						[attributeTextBoxRect]() {
+						return Int2(attributeTextBoxRect.getWidth(), attributeTextBoxRect.getHeight());
+					},
+						[]() { return PivotType::TopLeft; },
+						UiDrawCall::defaultActiveFunc
+						);
 			});
 	}
 

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.h
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.h
@@ -27,6 +27,7 @@ private:
 	Button<> upDownButtons[PrimaryAttributes::COUNT * 2];
 	bool attributesAreSaved; // Whether attributes have been saved and the player portrait can now be changed.
 	int bonusPoints;
+	int calculateInitialBonusPoints() const;
 public:
 	ChooseAttributesPanel(Game &game);
 	~ChooseAttributesPanel() override = default;

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.h
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.h
@@ -2,9 +2,12 @@
 #define CHOOSE_ATTRIBUTES_PANEL_H
 
 #include "Panel.h"
+#include "../Game/Game.h"
 #include "../Stats/PrimaryAttribute.h"
 #include "../UI/Button.h"
 #include "../UI/TextBox.h"
+#include "../UI/TextAlignment.h"
+#include "../UI/TextRenderUtils.h"
 
 // For choosing character creation attributes and the portrait. I think it should be used for level-up
 // purposes, since distributing points is basically identical to setting your character's original attributes.
@@ -21,8 +24,9 @@ private:
 	Buffer<ScopedUiTextureRef> headTextureRefs;
 	ScopedUiTextureRef bodyTextureRef, shirtTextureRef, pantsTextureRef, statsBgTextureRef, cursorTextureRef;
 	ScopedUiTextureRef upDownTextureRef, bonusPointsTextureRef;
-	Button<> upDownButtons[PrimaryAttributes::COUNT];
+	Button<> upDownButtons[PrimaryAttributes::COUNT * 2];
 	bool attributesAreSaved; // Whether attributes have been saved and the player portrait can now be changed.
+	int bonusPoints;
 public:
 	ChooseAttributesPanel(Game &game);
 	~ChooseAttributesPanel() override = default;

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.h
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.h
@@ -27,12 +27,20 @@ private:
 	Button<> upDownButtons[PrimaryAttributes::COUNT * 2];
 	bool attributesAreSaved; // Whether attributes have been saved and the player portrait can now be changed.
 	int bonusPoints;
+	int selectedAttribute;
+	int lastSelectedAttribute;
+	int fixedArrowX;
+	int arrowDrawCallIndex;
 	int calculateInitialBonusPoints() const;
+	
+	void redrawAttributeArrows();
 public:
 	ChooseAttributesPanel(Game &game);
 	~ChooseAttributesPanel() override = default;
 
 	bool init();
+	
+	void tick(double dt) override;
 };
 
 #endif

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.h
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.h
@@ -19,6 +19,8 @@ private:
 	Button<Game&, bool> portraitButton;
 	Buffer<ScopedUiTextureRef> headTextureRefs;
 	ScopedUiTextureRef bodyTextureRef, shirtTextureRef, pantsTextureRef, statsBgTextureRef, cursorTextureRef;
+	ScopedUiTextureRef upDownTextureRef;
+	Button<> upDownButtons[PrimaryAttributes::COUNT];
 	bool attributesAreSaved; // Whether attributes have been saved and the player portrait can now be changed.
 public:
 	ChooseAttributesPanel(Game &game);

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.h
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.h
@@ -15,11 +15,12 @@ private:
 	TextBox nameTextBox, raceTextBox, classTextBox;
 	TextBox attributeTextBoxes[PrimaryAttributes::COUNT];
 	TextBox experienceTextBox, levelTextBox;
+	TextBox bonusPointsTextBox;
 	Button<Game&, bool*> doneButton;
 	Button<Game&, bool> portraitButton;
 	Buffer<ScopedUiTextureRef> headTextureRefs;
 	ScopedUiTextureRef bodyTextureRef, shirtTextureRef, pantsTextureRef, statsBgTextureRef, cursorTextureRef;
-	ScopedUiTextureRef upDownTextureRef;
+	ScopedUiTextureRef upDownTextureRef, bonusPointsTextureRef;
 	Button<> upDownButtons[PrimaryAttributes::COUNT];
 	bool attributesAreSaved; // Whether attributes have been saved and the player portrait can now be changed.
 public:

--- a/OpenTESArena/src/Player/CharacterCreationState.cpp
+++ b/OpenTESArena/src/Player/CharacterCreationState.cpp
@@ -80,4 +80,5 @@ void CharacterCreationState::clear()
 	this->portraitIndex = CharacterCreationState::NO_INDEX;
 	this->male = false;
 	this->attributes.clear();
+	this->changedPoints.fill(0);
 }

--- a/OpenTESArena/src/Player/CharacterCreationState.h
+++ b/OpenTESArena/src/Player/CharacterCreationState.h
@@ -21,6 +21,8 @@ private:
 	int portraitIndex;
 	bool male;
 	PrimaryAttributes attributes;
+	std::array<int, 8> changedPoints;
+
 public:
 	CharacterCreationState();
 
@@ -30,6 +32,8 @@ public:
 	const PrimaryAttributes &getAttributes() const;
 	int getPortraitIndex() const;
 	bool isMale() const;
+	const int* getChangedPoints() const { return changedPoints.data(); }
+	int* getChangedPoints() { return changedPoints.data(); }
 
 	void setName(const char *name);
 	void setClassDefID(int id);
@@ -37,6 +41,7 @@ public:
 	void setPortraitIndex(int index);
 	void setGender(bool male);
 	void rollAttributes(Random &random);
+	void clearChangedPoints() { changedPoints.fill(0); }
 
 	void clear();
 };


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/6b198c61-a3fe-43e6-a366-5e4a4a78b388)

Added the UI of the up/down arrows to the character creation panel. Click on an attribute to select it and display the arrows.

Added the UI of the bonus points button.

Up arrow increases attribute value by spending bonus points, Down arrow decreases attribute value and recovers spent bonus points.

The reroll stat button generates again bonus points in a random way.

Range of possible starting bonus points is 4-24
