### PR TITLE
Bonus by attributes in choseeAttributePanel 

### DIFF
--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
@@ -339,7 +339,7 @@ bool ChooseAttributesPanel::init()
 			attribute.maxValue += 1;
 			
 			auto newBonusValues = ArenaPlayerUtils::calculateAttributeBonus(attribute.name, attribute.maxValue);
-			this->updateBonusAttributeValues(newBonusValues);
+			this->updateBonusAttributeValues();
 
 			TextBox &attributeTextBox = this->attributeTextBoxes[attributeIndex];
 			attributeTextBox.setText(std::to_string(attribute.maxValue));
@@ -364,7 +364,7 @@ bool ChooseAttributesPanel::init()
 			attribute.maxValue -= 1;
 
 			auto newBonusValues = ArenaPlayerUtils::calculateAttributeBonus(attribute.name, attribute.maxValue);
-			this->updateBonusAttributeValues(newBonusValues);
+			this->updateBonusAttributeValues();
 
 			TextBox &attributeTextBox = this->attributeTextBoxes[attributeIndex];
 			attributeTextBox.setText(std::to_string(attribute.maxValue));
@@ -708,7 +708,7 @@ bool ChooseAttributesPanel::init()
 	return true;
 }
 
-void ChooseAttributesPanel::updateBonusAttributeValues(const ArenaPlayerUtils::AttributeBonusValues& bonusValues)
+void ChooseAttributesPanel::updateBonusAttributeValues()
 {
 	Game& game = this->getGame();
 	CharacterCreationState& charCreationState = game.getCharacterCreationState();

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
@@ -340,6 +340,12 @@ bool ChooseAttributesPanel::init()
 				this->bonusToHealthTextBox.setText(std::to_string(this->bonusToHealthValue));
 				this->healModTextBox.setText(std::to_string(this->bonusToHealthValue));
 			}
+			if (strcmp(attribute.name, "Strength") == 0) {
+				this->bonusDamageValue = ArenaPlayerUtils::calculateDamageBonus(attribute.maxValue);
+				this->bonusDamageTextBox.setText(std::to_string(this->bonusDamageValue));
+				this->maxKilosValue = attribute.maxValue * 2;
+				this->maxKilosTextBox.setText(std::to_string(this->maxKilosValue));
+			}
 			TextBox &attributeTextBox = this->attributeTextBoxes[attributeIndex];
 			attributeTextBox.setText(std::to_string(attribute.maxValue));
 			this->bonusPointsTextBox.setText(std::to_string(this->bonusPoints));
@@ -375,6 +381,12 @@ bool ChooseAttributesPanel::init()
 				this->bonusToHealthValue = ArenaPlayerUtils::calculateBonusToHealth(attribute.maxValue);
 				this->bonusToHealthTextBox.setText(std::to_string(this->bonusToHealthValue));
 				this->healModTextBox.setText(std::to_string(this->bonusToHealthValue));
+			}
+			if (strcmp(attribute.name, "Strength") == 0) {
+				this->bonusDamageValue = ArenaPlayerUtils::calculateDamageBonus(attribute.maxValue);
+				this->bonusDamageTextBox.setText(std::to_string(this->bonusDamageValue));
+				this->maxKilosValue = attribute.maxValue * 2;
+				this->maxKilosTextBox.setText(std::to_string(this->maxKilosValue));
 			}
 			TextBox &attributeTextBox = this->attributeTextBoxes[attributeIndex];
 			attributeTextBox.setText(std::to_string(attribute.maxValue));
@@ -560,6 +572,65 @@ bool ChooseAttributesPanel::init()
 		[this]() { return this->healModTextBox.getTextureID(); },
 		UiDrawCall::makePositionFunc(healModTextBoxRect.getTopLeft()),
 		UiDrawCall::makeSizeFunc(healModTextBoxRect.getSize()),
+		UiDrawCall::makePivotFunc(PivotType::TopLeft),
+		UiDrawCall::defaultActiveFunc);
+
+	// TextBox de Bonus Damage
+	const Rect& positionAttributeStrengthTextBoxRect = this->attributeTextBoxes[PrimaryAttributes::COUNT - 8].getRect();
+	const Int2 bonusDamageTextBoxTopLeftPosition(
+		positionAttributeStrengthTextBoxRect.getLeft() + 60,
+		positionAttributeStrengthTextBoxRect.getTop());
+	const TextBox::InitInfo bonusDamageTextBoxInitInfo = TextBox::InitInfo::makeWithXY(
+		std::string(3, TextRenderUtils::LARGEST_CHAR),
+		bonusDamageTextBoxTopLeftPosition.x,
+		bonusDamageTextBoxTopLeftPosition.y,
+		ChooseAttributesUiView::BonusPointsFontName,
+		ChooseAttributesUiView::BonusPointsTextColor,
+		TextAlignment::TopLeft,
+		std::nullopt,
+		1,
+		fontLibrary);
+
+	if (!this->bonusDamageTextBox.init(bonusDamageTextBoxInitInfo, "fuerza", renderer))
+	{
+		DebugLogError("Couldn't init bonus damage text box.");
+		return false;
+	}
+
+	const Rect &bonusDamageTextBoxRect = this->bonusDamageTextBox.getRect();
+	this->addDrawCall(
+		[this]() { return this->bonusDamageTextBox.getTextureID(); },
+		UiDrawCall::makePositionFunc(bonusDamageTextBoxRect.getTopLeft()),
+		UiDrawCall::makeSizeFunc(bonusDamageTextBoxRect.getSize()),
+		UiDrawCall::makePivotFunc(PivotType::TopLeft),
+		UiDrawCall::defaultActiveFunc);
+
+	// TextBox de Max Kilos
+	const Int2 maxKilosTextBoxTopLeftPosition(
+		positionAttributeStrengthTextBoxRect.getLeft() + 120,
+		positionAttributeStrengthTextBoxRect.getTop());
+	const TextBox::InitInfo maxKilosTextBoxInitInfo = TextBox::InitInfo::makeWithXY(
+		std::string(3, TextRenderUtils::LARGEST_CHAR),
+		maxKilosTextBoxTopLeftPosition.x,
+		maxKilosTextBoxTopLeftPosition.y,
+		ChooseAttributesUiView::BonusPointsFontName,
+		ChooseAttributesUiView::BonusPointsTextColor,
+		TextAlignment::TopLeft,
+		std::nullopt,
+		1,
+		fontLibrary);
+
+	if (!this->maxKilosTextBox.init(maxKilosTextBoxInitInfo, "kilo", renderer))
+	{
+		DebugLogError("Couldn't init max kilos text box.");
+		return false;
+	}
+
+	const Rect &maxKilosTextBoxRect = this->maxKilosTextBox.getRect();
+	this->addDrawCall(
+		[this]() { return this->maxKilosTextBox.getTextureID(); },
+		UiDrawCall::makePositionFunc(maxKilosTextBoxRect.getTopLeft()),
+		UiDrawCall::makeSizeFunc(maxKilosTextBoxRect.getSize()),
 		UiDrawCall::makePivotFunc(PivotType::TopLeft),
 		UiDrawCall::defaultActiveFunc);
 

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
@@ -335,6 +335,10 @@ bool ChooseAttributesPanel::init()
 				this->bonusToCharismaValue = ArenaPlayerUtils::calculateBonusToCharisma(attribute.maxValue);
 				this->bonusToCharismaTextBox.setText(std::to_string(this->bonusToCharismaValue));
 			}
+			if (strcmp(attribute.name, "Endurance") == 0) {
+				this->bonusToHealthValue = ArenaPlayerUtils::calculateBonusToHealth(attribute.maxValue);
+				this->bonusToHealthTextBox.setText(std::to_string(this->bonusToHealthValue));
+			}
 			TextBox &attributeTextBox = this->attributeTextBoxes[attributeIndex];
 			attributeTextBox.setText(std::to_string(attribute.maxValue));
 			this->bonusPointsTextBox.setText(std::to_string(this->bonusPoints));
@@ -365,6 +369,10 @@ bool ChooseAttributesPanel::init()
 			if (strcmp(attribute.name, "Personality") == 0) {
 				this->bonusToCharismaValue = ArenaPlayerUtils::calculateBonusToCharisma(attribute.maxValue);
 				this->bonusToCharismaTextBox.setText(std::to_string(this->bonusToCharismaValue));
+			}
+			if (strcmp(attribute.name, "Endurance") == 0) {
+				this->bonusToHealthValue = ArenaPlayerUtils::calculateBonusToHealth(attribute.maxValue);
+				this->bonusToHealthTextBox.setText(std::to_string(this->bonusToHealthValue));
 			}
 			TextBox &attributeTextBox = this->attributeTextBoxes[attributeIndex];
 			attributeTextBox.setText(std::to_string(attribute.maxValue));
@@ -493,6 +501,37 @@ bool ChooseAttributesPanel::init()
 		UiDrawCall::makeSizeFunc(bonusToCharismaTextBoxRect.getSize()),
 		UiDrawCall::makePivotFunc(PivotType::TopLeft),
 		UiDrawCall::defaultActiveFunc);
+
+	// TextBox de Health
+	const Rect& positionAttributeEndureceTextBoxRect = this->attributeTextBoxes[PrimaryAttributes::COUNT - 3].getRect();
+	const Int2 bonusToHealthTextBoxTopLeftPosition(
+		positionAttributeEndureceTextBoxRect.getLeft() + 60,
+		positionAttributeEndureceTextBoxRect.getTop());
+	const TextBox::InitInfo bonusToHealthTextBoxInitInfo = TextBox::InitInfo::makeWithXY(
+		std::string(3, TextRenderUtils::LARGEST_CHAR),
+		bonusToHealthTextBoxTopLeftPosition.x,
+		bonusToHealthTextBoxTopLeftPosition.y,
+		ChooseAttributesUiView::BonusPointsFontName,
+		ChooseAttributesUiView::BonusPointsTextColor,
+		TextAlignment::TopLeft,
+		std::nullopt,
+		1,
+		fontLibrary);
+
+	if (!this->bonusToHealthTextBox.init(bonusToHealthTextBoxInitInfo, "5", renderer))
+	{
+		DebugLogError("Couldn't init bonus to health text box.");
+		return false;
+	}
+
+	const Rect &bonusToHealthTextBoxRect = this->bonusToHealthTextBox.getRect();
+	this->addDrawCall(
+		[this]() { return this->bonusToHealthTextBox.getTextureID(); },
+		UiDrawCall::makePositionFunc(bonusToHealthTextBoxRect.getTopLeft()),
+		UiDrawCall::makeSizeFunc(bonusToHealthTextBoxRect.getSize()),
+		UiDrawCall::makePivotFunc(PivotType::TopLeft),
+		UiDrawCall::defaultActiveFunc);
+
 	//............................................................................................................................................
 	//My code
 	for (int attributeIndex = 0; attributeIndex < PrimaryAttributes::COUNT; attributeIndex++)

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
@@ -380,9 +380,10 @@ bool ChooseAttributesPanel::init()
 	// my code
 	this->bonusToHitTextBox.setText("prueba");
 
+	const Rect& lastAttributeTextBoxRect = this->attributeTextBoxes[PrimaryAttributes::COUNT - 6].getRect();
 	const Int2 bonusToHitTextBoxTopLeftPosition(
-		bonusPointsTextBoxTopLeftPosition.x,
-		bonusPointsTextBoxTopLeftPosition.y + 20);
+		lastAttributeTextBoxRect.getLeft() + 60,
+		lastAttributeTextBoxRect.getTop() - 10);
 	const TextBox::InitInfo bonusToHitTextBoxInitInfo = TextBox::InitInfo::makeWithXY(
 		std::string(3, TextRenderUtils::LARGEST_CHAR),
 		bonusToHitTextBoxTopLeftPosition.x,

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
@@ -346,6 +346,10 @@ bool ChooseAttributesPanel::init()
 				this->maxKilosValue = attribute.maxValue * 2;
 				this->maxKilosTextBox.setText(std::to_string(this->maxKilosValue));
 			}
+			if (strcmp(attribute.name, "Willpower") == 0) {
+				this->magicDefValue = ArenaPlayerUtils::calculateMagicDefenseBonus(attribute.maxValue);
+				this->magicDefTextBox.setText(std::to_string(this->magicDefValue));
+			}
 			TextBox &attributeTextBox = this->attributeTextBoxes[attributeIndex];
 			attributeTextBox.setText(std::to_string(attribute.maxValue));
 			this->bonusPointsTextBox.setText(std::to_string(this->bonusPoints));
@@ -388,6 +392,10 @@ bool ChooseAttributesPanel::init()
 				this->maxKilosValue = attribute.maxValue * 2;
 				this->maxKilosTextBox.setText(std::to_string(this->maxKilosValue));
 			}
+			if (strcmp(attribute.name, "Willpower") == 0) {
+				this->magicDefValue = ArenaPlayerUtils::calculateMagicDefenseBonus(attribute.maxValue);
+				this->magicDefTextBox.setText(std::to_string(this->magicDefValue));
+			}
 			TextBox &attributeTextBox = this->attributeTextBoxes[attributeIndex];
 			attributeTextBox.setText(std::to_string(attribute.maxValue));
 			this->bonusPointsTextBox.setText(std::to_string(this->bonusPoints));
@@ -429,7 +437,7 @@ bool ChooseAttributesPanel::init()
 
 	// my code bonus atribute stat.............................................................................
 	
-
+	//bonus to hit
 	const Rect& lastAttributeTextBoxRect = this->attributeTextBoxes[PrimaryAttributes::COUNT - 6].getRect();
 	const Int2 bonusToHitTextBoxTopLeftPosition(
 		lastAttributeTextBoxRect.getLeft() + 60,
@@ -459,7 +467,7 @@ bool ChooseAttributesPanel::init()
 		UiDrawCall::makePivotFunc(PivotType::TopLeft),
 		UiDrawCall::defaultActiveFunc);
 
-	// codigo de inicializacion de bonusToDefendTextBox
+	// textBox bonusToDefend
 	const Int2 bonusToDefendTextBoxTopLeftPosition(
 		lastAttributeTextBoxRect.getLeft() + 120,
 		lastAttributeTextBoxRect.getTop() + 8);
@@ -487,7 +495,7 @@ bool ChooseAttributesPanel::init()
 		UiDrawCall::makePivotFunc(PivotType::TopLeft),
 		UiDrawCall::defaultActiveFunc);
 
-	//  TextBox de Carisma
+	//  TextBox charisma
 	const Int2 bonusToCharismaTextBoxTopLeftPosition(
 		lastAttributeTextBoxRect.getLeft() + 60,
 		lastAttributeTextBoxRect.getTop() + 32);
@@ -516,7 +524,7 @@ bool ChooseAttributesPanel::init()
 		UiDrawCall::makePivotFunc(PivotType::TopLeft),
 		UiDrawCall::defaultActiveFunc);
 
-	// TextBox de Health
+	// TextBox Health
 	const Rect& positionAttributeEndureceTextBoxRect = this->attributeTextBoxes[PrimaryAttributes::COUNT - 3].getRect();
 	const Int2 bonusToHealthTextBoxTopLeftPosition(
 		positionAttributeEndureceTextBoxRect.getLeft() + 60,
@@ -546,7 +554,7 @@ bool ChooseAttributesPanel::init()
 		UiDrawCall::makePivotFunc(PivotType::TopLeft),
 		UiDrawCall::defaultActiveFunc);
 
-	// TextBox de Heal Mod
+	// TextBox Heal Mod
 	const Int2 healModTextBoxTopLeftPosition(
 		positionAttributeEndureceTextBoxRect.getLeft() + 120,
 		positionAttributeEndureceTextBoxRect.getTop());
@@ -575,7 +583,7 @@ bool ChooseAttributesPanel::init()
 		UiDrawCall::makePivotFunc(PivotType::TopLeft),
 		UiDrawCall::defaultActiveFunc);
 
-	// TextBox de Bonus Damage
+	// TextBox Bonus Damage
 	const Rect& positionAttributeStrengthTextBoxRect = this->attributeTextBoxes[PrimaryAttributes::COUNT - 8].getRect();
 	const Int2 bonusDamageTextBoxTopLeftPosition(
 		positionAttributeStrengthTextBoxRect.getLeft() + 60,
@@ -605,7 +613,7 @@ bool ChooseAttributesPanel::init()
 		UiDrawCall::makePivotFunc(PivotType::TopLeft),
 		UiDrawCall::defaultActiveFunc);
 
-	// TextBox de Max Kilos
+	// TextBox Max Kilos
 	const Int2 maxKilosTextBoxTopLeftPosition(
 		positionAttributeStrengthTextBoxRect.getLeft() + 120,
 		positionAttributeStrengthTextBoxRect.getTop());
@@ -631,6 +639,36 @@ bool ChooseAttributesPanel::init()
 		[this]() { return this->maxKilosTextBox.getTextureID(); },
 		UiDrawCall::makePositionFunc(maxKilosTextBoxRect.getTopLeft()),
 		UiDrawCall::makeSizeFunc(maxKilosTextBoxRect.getSize()),
+		UiDrawCall::makePivotFunc(PivotType::TopLeft),
+		UiDrawCall::defaultActiveFunc);
+
+	// TextBox Magic Defense
+	const Rect& positionAttributeWillpowerTextBoxRect = this->attributeTextBoxes[PrimaryAttributes::COUNT - 6].getRect();
+	const Int2 magicDefTextBoxTopLeftPosition(
+		positionAttributeWillpowerTextBoxRect.getLeft() + 60,
+		positionAttributeWillpowerTextBoxRect.getTop());
+	const TextBox::InitInfo magicDefTextBoxInitInfo = TextBox::InitInfo::makeWithXY(
+		std::string(3, TextRenderUtils::LARGEST_CHAR),
+		magicDefTextBoxTopLeftPosition.x,
+		magicDefTextBoxTopLeftPosition.y,
+		ChooseAttributesUiView::BonusPointsFontName,
+		ChooseAttributesUiView::BonusPointsTextColor,
+		TextAlignment::TopLeft,
+		std::nullopt,
+		1,
+		fontLibrary);
+
+	if (!this->magicDefTextBox.init(magicDefTextBoxInitInfo, "magic", renderer))
+	{
+		DebugLogError("Couldn't init magic defense text box.");
+		return false;
+	}
+
+	const Rect &magicDefTextBoxRect = this->magicDefTextBox.getRect();
+	this->addDrawCall(
+		[this]() { return this->magicDefTextBox.getTextureID(); },
+		UiDrawCall::makePositionFunc(magicDefTextBoxRect.getTopLeft()),
+		UiDrawCall::makeSizeFunc(magicDefTextBoxRect.getSize()),
 		UiDrawCall::makePivotFunc(PivotType::TopLeft),
 		UiDrawCall::defaultActiveFunc);
 

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
@@ -35,7 +35,7 @@ void ChooseAttributesPanel::populateBaseAttributesRandomly(CharacterCreationStat
 	{
 		PrimaryAttribute &attribute = attributes[i];
 		const int addedValue = ChooseAttributesUiModel::rollClassic(ChooseAttributesUiModel::PrimaryAttributeRandomMax, random);
-		attribute.maxValue += addedValue;
+		attribute.maxValue += addedValue;	
 	}
 }
 
@@ -52,6 +52,16 @@ bool ChooseAttributesPanel::init()
 	ArenaRandom &arenaRandom = game.arenaRandom;
 	this->populateBaseAttributesRandomly(charCreationState, arenaRandom);
 	this->bonusPoints = ChooseAttributesUiModel::rollClassic(ChooseAttributesUiModel::BonusPointsRandomMax, arenaRandom);
+
+	BufferView<PrimaryAttribute> attributes = charCreationState.attributes.getAttributes();
+	for (int i = 0; i < PrimaryAttributes::COUNT; i++)
+	{
+		const PrimaryAttribute &attribute = attributes[i];
+		if (strcmp(attribute.name, "Agility") == 0) {
+			this->bonusToHitValue = ArenaPlayerUtils::calculateBonusToHit(attribute.maxValue);
+			break;
+		}
+	}
 
 	this->selectedAttributeIndex = 0;
 	this->attributesAreSaved = false;
@@ -406,7 +416,7 @@ bool ChooseAttributesPanel::init()
 		1,
 		fontLibrary);
 
-	if (!this->bonusToHitTextBox.init(bonusToHitTextBoxInitInfo, "0", renderer))
+	if (!this->bonusToHitTextBox.init(bonusToHitTextBoxInitInfo,std::to_string(this->bonusToHitValue), renderer))
 	{
 		DebugLogError("Couldn't init bonus to hit text box.");
 		return false;
@@ -434,7 +444,7 @@ bool ChooseAttributesPanel::init()
 		std::nullopt,
 		1,
 		fontLibrary);
-	if (!this->bonusToDefendTextBox.init(bonusToDefendTextBoxInitInfo, "0", renderer))
+	if (!this->bonusToDefendTextBox.init(bonusToDefendTextBoxInitInfo, std::to_string(this->bonusToHitValue), renderer))
 	{
 		DebugLogError("Couldn't init bonus to defend text box.");
 		return false;

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
@@ -331,6 +331,10 @@ bool ChooseAttributesPanel::init()
 				this->bonusToHitTextBox.setText(std::to_string(this->bonusToHitValue));
 				this->bonusToDefendTextBox.setText(std::to_string(this->bonusToHitValue));
 			}
+			if (strcmp(attribute.name, "Personality") == 0) {
+				this->bonusToCharismaValue = ArenaPlayerUtils::calculateBonusToCharisma(attribute.maxValue);
+				this->bonusToCharismaTextBox.setText(std::to_string(this->bonusToCharismaValue));
+			}
 			TextBox &attributeTextBox = this->attributeTextBoxes[attributeIndex];
 			attributeTextBox.setText(std::to_string(attribute.maxValue));
 			this->bonusPointsTextBox.setText(std::to_string(this->bonusPoints));
@@ -358,7 +362,10 @@ bool ChooseAttributesPanel::init()
 				this->bonusToHitTextBox.setText(std::to_string(this->bonusToHitValue));
 				this->bonusToDefendTextBox.setText(std::to_string(this->bonusToHitValue));
 			}
-
+			if (strcmp(attribute.name, "Personality") == 0) {
+				this->bonusToCharismaValue = ArenaPlayerUtils::calculateBonusToCharisma(attribute.maxValue);
+				this->bonusToCharismaTextBox.setText(std::to_string(this->bonusToCharismaValue));
+			}
 			TextBox &attributeTextBox = this->attributeTextBoxes[attributeIndex];
 			attributeTextBox.setText(std::to_string(attribute.maxValue));
 			this->bonusPointsTextBox.setText(std::to_string(this->bonusPoints));
@@ -486,7 +493,7 @@ bool ChooseAttributesPanel::init()
 		UiDrawCall::makeSizeFunc(bonusToCharismaTextBoxRect.getSize()),
 		UiDrawCall::makePivotFunc(PivotType::TopLeft),
 		UiDrawCall::defaultActiveFunc);
-	/............................................................................................................................................
+	//............................................................................................................................................
 	//My code
 	for (int attributeIndex = 0; attributeIndex < PrimaryAttributes::COUNT; attributeIndex++)
 	{

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
@@ -17,6 +17,7 @@
 #include "../UI/TextAlignment.h"
 #include "../UI/TextRenderUtils.h"
 #include "../UI/ArenaFontName.h"
+#include <OpenTESArena/src/Player/ArenaPlayerUtils.h>
 
 ChooseAttributesPanel::ChooseAttributesPanel(Game &game)
 	: Panel(game)
@@ -315,7 +316,10 @@ bool ChooseAttributesPanel::init()
 			BufferView<PrimaryAttribute> attributesView = attributes.getAttributes();
 			PrimaryAttribute &attribute = attributesView.get(attributeIndex);
 			attribute.maxValue += 1;
-
+			if (attribute.name == "Agility") {
+				const int bonusToHit = ArenaPlayerUtils::calculateBonusToHit(attribute.maxValue);
+				this->bonusToHitTextBox.setText(std::to_string(bonusToHit));
+			 }
 			TextBox &attributeTextBox = this->attributeTextBoxes[attributeIndex];
 			attributeTextBox.setText(std::to_string(attribute.maxValue));
 			this->bonusPointsTextBox.setText(std::to_string(this->bonusPoints));

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
@@ -383,7 +383,7 @@ bool ChooseAttributesPanel::init()
 	const Rect& lastAttributeTextBoxRect = this->attributeTextBoxes[PrimaryAttributes::COUNT - 6].getRect();
 	const Int2 bonusToHitTextBoxTopLeftPosition(
 		lastAttributeTextBoxRect.getLeft() + 60,
-		lastAttributeTextBoxRect.getTop() - 10);
+		lastAttributeTextBoxRect.getTop() + 8);
 	const TextBox::InitInfo bonusToHitTextBoxInitInfo = TextBox::InitInfo::makeWithXY(
 		std::string(3, TextRenderUtils::LARGEST_CHAR),
 		bonusToHitTextBoxTopLeftPosition.x,

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
@@ -457,7 +457,36 @@ bool ChooseAttributesPanel::init()
 		UiDrawCall::makeSizeFunc(bonusToDefendTextBoxRect.getSize()),
 		UiDrawCall::makePivotFunc(PivotType::TopLeft),
 		UiDrawCall::defaultActiveFunc);
-	//.........................................................................................................
+
+	//  TextBox de Carisma
+	const Int2 bonusToCharismaTextBoxTopLeftPosition(
+		lastAttributeTextBoxRect.getLeft() + 60,
+		lastAttributeTextBoxRect.getTop() + 32);
+	const TextBox::InitInfo bonusToCharismaTextBoxInitInfo = TextBox::InitInfo::makeWithXY(
+		std::string(3, TextRenderUtils::LARGEST_CHAR),
+		bonusToCharismaTextBoxTopLeftPosition.x,
+		bonusToCharismaTextBoxTopLeftPosition.y,
+		ChooseAttributesUiView::BonusPointsFontName,
+		ChooseAttributesUiView::BonusPointsTextColor,
+		TextAlignment::TopLeft,
+		std::nullopt,
+		1,
+		fontLibrary);
+
+	if (!this->bonusToCharismaTextBox.init(bonusToCharismaTextBoxInitInfo, "400", renderer))
+	{
+		DebugLogError("Couldn't init bonus to charisma text box.");
+		return false;
+	}
+
+	const Rect &bonusToCharismaTextBoxRect = this->bonusToCharismaTextBox.getRect();
+	this->addDrawCall(
+		[this]() { return this->bonusToCharismaTextBox.getTextureID(); },
+		UiDrawCall::makePositionFunc(bonusToCharismaTextBoxRect.getTopLeft()),
+		UiDrawCall::makeSizeFunc(bonusToCharismaTextBoxRect.getSize()),
+		UiDrawCall::makePivotFunc(PivotType::TopLeft),
+		UiDrawCall::defaultActiveFunc);
+	/............................................................................................................................................
 	//My code
 	for (int attributeIndex = 0; attributeIndex < PrimaryAttributes::COUNT; attributeIndex++)
 	{

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
@@ -339,22 +339,7 @@ bool ChooseAttributesPanel::init()
 			attribute.maxValue += 1;
 			
 			auto newBonusValues = ArenaPlayerUtils::calculateAttributeBonus(attribute.name, attribute.maxValue);
-			
-			this->bonusToHitValue = newBonusValues.bonusToHit;
-			this->bonusToCharismaValue = newBonusValues.bonusToCharisma;
-			this->bonusToHealthValue =  newBonusValues.bonusToHealth;
-			this->bonusDamageValue =  newBonusValues.bonusDamage;
-			this->maxKilosValue =  newBonusValues.maxKilos;
-			this->magicDefValue =  newBonusValues.magicDef;
-
-			this->bonusToHitTextBox.setText(std::to_string(this->bonusToHitValue));
-			this->bonusToDefendTextBox.setText(std::to_string(this->bonusToHitValue));
-			this->bonusToCharismaTextBox.setText(std::to_string(this->bonusToCharismaValue));
-			this->bonusToHealthTextBox.setText(std::to_string(this->bonusToHealthValue));
-			this->healModTextBox.setText(std::to_string(this->bonusToHealthValue));
-			this->bonusDamageTextBox.setText(std::to_string(this->bonusDamageValue));
-			this->maxKilosTextBox.setText(std::to_string(this->maxKilosValue));
-			this->magicDefTextBox.setText(std::to_string(this->magicDefValue));
+			this->updateBonusAttributeValues(newBonusValues);
 
 			TextBox &attributeTextBox = this->attributeTextBoxes[attributeIndex];
 			attributeTextBox.setText(std::to_string(attribute.maxValue));
@@ -377,24 +362,9 @@ bool ChooseAttributesPanel::init()
 			BufferView<PrimaryAttribute> attributesView = attributes.getAttributes();
 			PrimaryAttribute &attribute = attributesView.get(attributeIndex);
 			attribute.maxValue -= 1;
-			
-			auto newBonusValues = ArenaPlayerUtils::calculateAttributeBonus(attribute.name, attribute.maxValue);
-			
-			this->bonusToHitValue = newBonusValues.bonusToHit;
-			this->bonusToCharismaValue = newBonusValues.bonusToCharisma;
-			this->bonusToHealthValue = newBonusValues.bonusToHealth;
-			this->bonusDamageValue = newBonusValues.bonusDamage;
-			this->maxKilosValue = newBonusValues.maxKilos;
-			this->magicDefValue = newBonusValues.magicDef;
 
-			this->bonusToHitTextBox.setText(std::to_string(this->bonusToHitValue));
-			this->bonusToDefendTextBox.setText(std::to_string(this->bonusToHitValue));
-			this->bonusToCharismaTextBox.setText(std::to_string(this->bonusToCharismaValue));
-			this->bonusToHealthTextBox.setText(std::to_string(this->bonusToHealthValue));
-			this->healModTextBox.setText(std::to_string(this->bonusToHealthValue));
-			this->bonusDamageTextBox.setText(std::to_string(this->bonusDamageValue));
-			this->maxKilosTextBox.setText(std::to_string(this->maxKilosValue));
-			this->magicDefTextBox.setText(std::to_string(this->magicDefValue));
+			auto newBonusValues = ArenaPlayerUtils::calculateAttributeBonus(attribute.name, attribute.maxValue);
+			this->updateBonusAttributeValues(newBonusValues);
 
 			TextBox &attributeTextBox = this->attributeTextBoxes[attributeIndex];
 			attributeTextBox.setText(std::to_string(attribute.maxValue));
@@ -736,4 +706,23 @@ bool ChooseAttributesPanel::init()
 		ChooseAttributesUiView::InitialTextureCenterPoint);
 
 	return true;
+}
+
+void ChooseAttributesPanel::updateBonusAttributeValues(const ArenaPlayerUtils::AttributeBonusValues& bonusValues)
+{
+	this->bonusToHitValue = bonusValues.bonusToHit;
+	this->bonusToCharismaValue = bonusValues.bonusToCharisma;
+	this->bonusToHealthValue = bonusValues.bonusToHealth;
+	this->bonusDamageValue = bonusValues.bonusDamage;
+	this->maxKilosValue = bonusValues.maxKilos;
+	this->magicDefValue = bonusValues.magicDef;
+
+	this->bonusToHitTextBox.setText(std::to_string(this->bonusToHitValue));
+	this->bonusToDefendTextBox.setText(std::to_string(this->bonusToHitValue));
+	this->bonusToCharismaTextBox.setText(std::to_string(this->bonusToCharismaValue));
+	this->bonusToHealthTextBox.setText(std::to_string(this->bonusToHealthValue));
+	this->healModTextBox.setText(std::to_string(this->bonusToHealthValue));
+	this->bonusDamageTextBox.setText(std::to_string(this->bonusDamageValue));
+	this->maxKilosTextBox.setText(std::to_string(this->maxKilosValue));
+	this->magicDefTextBox.setText(std::to_string(this->magicDefValue));
 }

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
@@ -317,9 +317,9 @@ bool ChooseAttributesPanel::init()
 			PrimaryAttribute &attribute = attributesView.get(attributeIndex);
 			attribute.maxValue += 1;
 			if (strcmp(attribute.name, "Agility") == 0) {
-				const int bonusToHit = ArenaPlayerUtils::calculateBonusToHit(attribute.maxValue);
-				this->bonusToHitTextBox.setText(std::to_string(bonusToHit));
-			}			
+				this->bonusToHitValue = ArenaPlayerUtils::calculateBonusToHit(attribute.maxValue);
+				this->bonusToHitTextBox.setText(std::to_string(this->bonusToHitValue));
+			}
 			TextBox &attributeTextBox = this->attributeTextBoxes[attributeIndex];
 			attributeTextBox.setText(std::to_string(attribute.maxValue));
 			this->bonusPointsTextBox.setText(std::to_string(this->bonusPoints));
@@ -382,7 +382,7 @@ bool ChooseAttributesPanel::init()
 		UiDrawCall::defaultActiveFunc);
 
 	// my code
-	this->bonusToHitTextBox.setText("prueba");
+	
 
 	const Rect& lastAttributeTextBoxRect = this->attributeTextBoxes[PrimaryAttributes::COUNT - 6].getRect();
 	const Int2 bonusToHitTextBoxTopLeftPosition(

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
@@ -377,6 +377,37 @@ bool ChooseAttributesPanel::init()
 		UiDrawCall::makePivotFunc(PivotType::TopLeft),
 		UiDrawCall::defaultActiveFunc);
 
+	// my code
+	this->bonusToHitTextBox.setText("prueba");
+
+	const Int2 bonusToHitTextBoxTopLeftPosition(
+		bonusPointsTextBoxTopLeftPosition.x,
+		bonusPointsTextBoxTopLeftPosition.y + 20);
+	const TextBox::InitInfo bonusToHitTextBoxInitInfo = TextBox::InitInfo::makeWithXY(
+		std::string(3, TextRenderUtils::LARGEST_CHAR),
+		bonusToHitTextBoxTopLeftPosition.x,
+		bonusToHitTextBoxTopLeftPosition.y,
+		ChooseAttributesUiView::BonusPointsFontName,
+		ChooseAttributesUiView::BonusPointsTextColor,
+		TextAlignment::TopLeft,
+		std::nullopt,
+		1,
+		fontLibrary);
+
+	if (!this->bonusToHitTextBox.init(bonusToHitTextBoxInitInfo, "5", renderer))
+	{
+		DebugLogError("Couldn't init bonus to hit text box.");
+		return false;
+	}
+
+	const Rect &bonusToHitTextBoxRect = this->bonusToHitTextBox.getRect();
+	this->addDrawCall(
+		[this]() { return this->bonusToHitTextBox.getTextureID(); },
+		UiDrawCall::makePositionFunc(bonusToHitTextBoxRect.getTopLeft()),
+		UiDrawCall::makeSizeFunc(bonusToHitTextBoxRect.getSize()),
+		UiDrawCall::makePivotFunc(PivotType::TopLeft),
+		UiDrawCall::defaultActiveFunc);
+	//My code
 	for (int attributeIndex = 0; attributeIndex < PrimaryAttributes::COUNT; attributeIndex++)
 	{
 		UiDrawCall::TextureFunc attributeTextBoxTextureFunc = [this, attributeIndex]()

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
@@ -54,13 +54,24 @@ bool ChooseAttributesPanel::init()
 	this->bonusPoints = ChooseAttributesUiModel::rollClassic(ChooseAttributesUiModel::BonusPointsRandomMax, arenaRandom);
 
 	BufferView<PrimaryAttribute> attributes = charCreationState.attributes.getAttributes();
+	
+	this->bonusToHitValue = 0;
+	this->bonusToCharismaValue = 0;
+	this->bonusToHealthValue = 0;
+	this->bonusDamageValue = 0;
+	this->maxKilosValue = 0;
+	this->magicDefValue = 0;
+
 	for (int i = 0; i < PrimaryAttributes::COUNT; i++)
 	{
 		const PrimaryAttribute &attribute = attributes[i];
-		if (strcmp(attribute.name, "Agility") == 0) {
-			this->bonusToHitValue = ArenaPlayerUtils::calculateBonusToHit(attribute.maxValue);
-			break;
-		}
+		auto bonusValues = ArenaPlayerUtils::calculateAttributeBonus(attribute.name, attribute.maxValue);
+		this->bonusToHitValue += bonusValues.bonusToHit;
+		this->bonusToCharismaValue += bonusValues.bonusToCharisma;
+		this->bonusToHealthValue += bonusValues.bonusToHealth;
+		this->bonusDamageValue += bonusValues.bonusDamage;
+		this->maxKilosValue += bonusValues.maxKilos;
+		this->magicDefValue += bonusValues.magicDef;
 	}
 
 	this->selectedAttributeIndex = 0;
@@ -326,15 +337,15 @@ bool ChooseAttributesPanel::init()
 			BufferView<PrimaryAttribute> attributesView = attributes.getAttributes();
 			PrimaryAttribute &attribute = attributesView.get(attributeIndex);
 			attribute.maxValue += 1;
-
-			auto bonusValues = ArenaPlayerUtils::calculateAttributeBonus(attribute.name, attribute.maxValue);
 			
-			this->bonusToHitValue = bonusValues.bonusToHit;
-			this->bonusToCharismaValue = bonusValues.bonusToCharisma;
-			this->bonusToHealthValue = bonusValues.bonusToHealth;
-			this->bonusDamageValue = bonusValues.bonusDamage;
-			this->maxKilosValue = bonusValues.maxKilos;
-			this->magicDefValue = bonusValues.magicDef;
+			auto newBonusValues = ArenaPlayerUtils::calculateAttributeBonus(attribute.name, attribute.maxValue);
+			
+			this->bonusToHitValue = newBonusValues.bonusToHit;
+			this->bonusToCharismaValue = newBonusValues.bonusToCharisma;
+			this->bonusToHealthValue =  newBonusValues.bonusToHealth;
+			this->bonusDamageValue =  newBonusValues.bonusDamage;
+			this->maxKilosValue =  newBonusValues.maxKilos;
+			this->magicDefValue =  newBonusValues.magicDef;
 
 			this->bonusToHitTextBox.setText(std::to_string(this->bonusToHitValue));
 			this->bonusToDefendTextBox.setText(std::to_string(this->bonusToHitValue));
@@ -366,15 +377,15 @@ bool ChooseAttributesPanel::init()
 			BufferView<PrimaryAttribute> attributesView = attributes.getAttributes();
 			PrimaryAttribute &attribute = attributesView.get(attributeIndex);
 			attribute.maxValue -= 1;
-
-			auto bonusValues = ArenaPlayerUtils::calculateAttributeBonus(attribute.name, attribute.maxValue);
 			
-			this->bonusToHitValue = bonusValues.bonusToHit;
-			this->bonusToCharismaValue = bonusValues.bonusToCharisma;
-			this->bonusToHealthValue = bonusValues.bonusToHealth;
-			this->bonusDamageValue = bonusValues.bonusDamage;
-			this->maxKilosValue = bonusValues.maxKilos;
-			this->magicDefValue = bonusValues.magicDef;
+			auto newBonusValues = ArenaPlayerUtils::calculateAttributeBonus(attribute.name, attribute.maxValue);
+			
+			this->bonusToHitValue = newBonusValues.bonusToHit;
+			this->bonusToCharismaValue = newBonusValues.bonusToCharisma;
+			this->bonusToHealthValue = newBonusValues.bonusToHealth;
+			this->bonusDamageValue = newBonusValues.bonusDamage;
+			this->maxKilosValue = newBonusValues.maxKilos;
+			this->magicDefValue = newBonusValues.magicDef;
 
 			this->bonusToHitTextBox.setText(std::to_string(this->bonusToHitValue));
 			this->bonusToDefendTextBox.setText(std::to_string(this->bonusToHitValue));
@@ -499,7 +510,7 @@ bool ChooseAttributesPanel::init()
 		1,
 		fontLibrary);
 
-	if (!this->bonusToCharismaTextBox.init(bonusToCharismaTextBoxInitInfo, "400", renderer))
+	if (!this->bonusToCharismaTextBox.init(bonusToCharismaTextBoxInitInfo, std::to_string(this->bonusToCharismaValue), renderer))
 	{
 		DebugLogError("Couldn't init bonus to charisma text box.");
 		return false;
@@ -529,7 +540,7 @@ bool ChooseAttributesPanel::init()
 		1,
 		fontLibrary);
 
-	if (!this->bonusToHealthTextBox.init(bonusToHealthTextBoxInitInfo, "5", renderer))
+	if (!this->bonusToHealthTextBox.init(bonusToHealthTextBoxInitInfo, std::to_string(this->bonusToHealthValue), renderer))
 	{
 		DebugLogError("Couldn't init bonus to health text box.");
 		return false;
@@ -558,7 +569,7 @@ bool ChooseAttributesPanel::init()
 		1,
 		fontLibrary);
 
-	if (!this->healModTextBox.init(healModTextBoxInitInfo, "0", renderer))
+	if (!this->healModTextBox.init(healModTextBoxInitInfo, std::to_string(this->bonusToHealthValue), renderer))
 	{
 		DebugLogError("Couldn't init heal mod text box.");
 		return false;
@@ -588,7 +599,7 @@ bool ChooseAttributesPanel::init()
 		1,
 		fontLibrary);
 
-	if (!this->bonusDamageTextBox.init(bonusDamageTextBoxInitInfo, "fuerza", renderer))
+	if (!this->bonusDamageTextBox.init(bonusDamageTextBoxInitInfo, std::to_string(this->bonusDamageValue), renderer))
 	{
 		DebugLogError("Couldn't init bonus damage text box.");
 		return false;
@@ -617,7 +628,7 @@ bool ChooseAttributesPanel::init()
 		1,
 		fontLibrary);
 
-	if (!this->maxKilosTextBox.init(maxKilosTextBoxInitInfo, "kilo", renderer))
+	if (!this->maxKilosTextBox.init(maxKilosTextBoxInitInfo, std::to_string(this->maxKilosValue), renderer))
 	{
 		DebugLogError("Couldn't init max kilos text box.");
 		return false;
@@ -647,7 +658,7 @@ bool ChooseAttributesPanel::init()
 		1,
 		fontLibrary);
 
-	if (!this->magicDefTextBox.init(magicDefTextBoxInitInfo, "magic", renderer))
+	if (!this->magicDefTextBox.init(magicDefTextBoxInitInfo, std::to_string(this->magicDefValue), renderer))
 	{
 		DebugLogError("Couldn't init magic defense text box.");
 		return false;

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
@@ -342,6 +342,11 @@ bool ChooseAttributesPanel::init()
 			PrimaryAttribute &attribute = attributesView.get(attributeIndex);
 			attribute.maxValue -= 1;
 
+			if (strcmp(attribute.name, "Agility") == 0) {
+				this->bonusToHitValue = ArenaPlayerUtils::calculateBonusToHit(attribute.maxValue);
+				this->bonusToHitTextBox.setText(std::to_string(this->bonusToHitValue));
+			}
+
 			TextBox &attributeTextBox = this->attributeTextBoxes[attributeIndex];
 			attributeTextBox.setText(std::to_string(attribute.maxValue));
 			this->bonusPointsTextBox.setText(std::to_string(this->bonusPoints));
@@ -399,7 +404,7 @@ bool ChooseAttributesPanel::init()
 		1,
 		fontLibrary);
 
-	if (!this->bonusToHitTextBox.init(bonusToHitTextBoxInitInfo, "5", renderer))
+	if (!this->bonusToHitTextBox.init(bonusToHitTextBoxInitInfo, "0", renderer))
 	{
 		DebugLogError("Couldn't init bonus to hit text box.");
 		return false;

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
@@ -316,10 +316,10 @@ bool ChooseAttributesPanel::init()
 			BufferView<PrimaryAttribute> attributesView = attributes.getAttributes();
 			PrimaryAttribute &attribute = attributesView.get(attributeIndex);
 			attribute.maxValue += 1;
-			if (attribute.name == "Agility") {
+			if (strcmp(attribute.name, "Agility") == 0) {
 				const int bonusToHit = ArenaPlayerUtils::calculateBonusToHit(attribute.maxValue);
 				this->bonusToHitTextBox.setText(std::to_string(bonusToHit));
-			 }
+			}			
 			TextBox &attributeTextBox = this->attributeTextBoxes[attributeIndex];
 			attributeTextBox.setText(std::to_string(attribute.maxValue));
 			this->bonusPointsTextBox.setText(std::to_string(this->bonusPoints));

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
@@ -710,12 +710,28 @@ bool ChooseAttributesPanel::init()
 
 void ChooseAttributesPanel::updateBonusAttributeValues(const ArenaPlayerUtils::AttributeBonusValues& bonusValues)
 {
-	this->bonusToHitValue = bonusValues.bonusToHit;
-	this->bonusToCharismaValue = bonusValues.bonusToCharisma;
-	this->bonusToHealthValue = bonusValues.bonusToHealth;
-	this->bonusDamageValue = bonusValues.bonusDamage;
-	this->maxKilosValue = bonusValues.maxKilos;
-	this->magicDefValue = bonusValues.magicDef;
+	Game& game = this->getGame();
+	CharacterCreationState& charCreationState = game.getCharacterCreationState();
+	BufferView<PrimaryAttribute> attributes = charCreationState.attributes.getAttributes();
+
+	this->bonusToHitValue = 0;
+	this->bonusToCharismaValue = 0;
+	this->bonusToHealthValue = 0;
+	this->bonusDamageValue = 0;
+	this->maxKilosValue = 0;
+	this->magicDefValue = 0;
+
+	for (int i = 0; i < PrimaryAttributes::COUNT; i++)
+	{
+		const PrimaryAttribute& attribute = attributes[i];
+		auto bonusValues = ArenaPlayerUtils::calculateAttributeBonus(attribute.name, attribute.maxValue);
+		this->bonusToHitValue += bonusValues.bonusToHit;
+		this->bonusToCharismaValue += bonusValues.bonusToCharisma;
+		this->bonusToHealthValue += bonusValues.bonusToHealth;
+		this->bonusDamageValue += bonusValues.bonusDamage;
+		this->maxKilosValue += bonusValues.maxKilos;
+		this->magicDefValue += bonusValues.magicDef;
+	}
 
 	this->bonusToHitTextBox.setText(std::to_string(this->bonusToHitValue));
 	this->bonusToDefendTextBox.setText(std::to_string(this->bonusToHitValue));

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
@@ -338,6 +338,7 @@ bool ChooseAttributesPanel::init()
 			if (strcmp(attribute.name, "Endurance") == 0) {
 				this->bonusToHealthValue = ArenaPlayerUtils::calculateBonusToHealth(attribute.maxValue);
 				this->bonusToHealthTextBox.setText(std::to_string(this->bonusToHealthValue));
+				this->healModTextBox.setText(std::to_string(this->bonusToHealthValue));
 			}
 			TextBox &attributeTextBox = this->attributeTextBoxes[attributeIndex];
 			attributeTextBox.setText(std::to_string(attribute.maxValue));
@@ -373,6 +374,7 @@ bool ChooseAttributesPanel::init()
 			if (strcmp(attribute.name, "Endurance") == 0) {
 				this->bonusToHealthValue = ArenaPlayerUtils::calculateBonusToHealth(attribute.maxValue);
 				this->bonusToHealthTextBox.setText(std::to_string(this->bonusToHealthValue));
+				this->healModTextBox.setText(std::to_string(this->bonusToHealthValue));
 			}
 			TextBox &attributeTextBox = this->attributeTextBoxes[attributeIndex];
 			attributeTextBox.setText(std::to_string(attribute.maxValue));
@@ -529,6 +531,35 @@ bool ChooseAttributesPanel::init()
 		[this]() { return this->bonusToHealthTextBox.getTextureID(); },
 		UiDrawCall::makePositionFunc(bonusToHealthTextBoxRect.getTopLeft()),
 		UiDrawCall::makeSizeFunc(bonusToHealthTextBoxRect.getSize()),
+		UiDrawCall::makePivotFunc(PivotType::TopLeft),
+		UiDrawCall::defaultActiveFunc);
+
+	// TextBox de Heal Mod
+	const Int2 healModTextBoxTopLeftPosition(
+		positionAttributeEndureceTextBoxRect.getLeft() + 120,
+		positionAttributeEndureceTextBoxRect.getTop());
+	const TextBox::InitInfo healModTextBoxInitInfo = TextBox::InitInfo::makeWithXY(
+		std::string(3, TextRenderUtils::LARGEST_CHAR),
+		healModTextBoxTopLeftPosition.x,
+		healModTextBoxTopLeftPosition.y,
+		ChooseAttributesUiView::BonusPointsFontName,
+		ChooseAttributesUiView::BonusPointsTextColor,
+		TextAlignment::TopLeft,
+		std::nullopt,
+		1,
+		fontLibrary);
+
+	if (!this->healModTextBox.init(healModTextBoxInitInfo, "0", renderer))
+	{
+		DebugLogError("Couldn't init heal mod text box.");
+		return false;
+	}
+
+	const Rect &healModTextBoxRect = this->healModTextBox.getRect();
+	this->addDrawCall(
+		[this]() { return this->healModTextBox.getTextureID(); },
+		UiDrawCall::makePositionFunc(healModTextBoxRect.getTopLeft()),
+		UiDrawCall::makeSizeFunc(healModTextBoxRect.getSize()),
 		UiDrawCall::makePivotFunc(PivotType::TopLeft),
 		UiDrawCall::defaultActiveFunc);
 

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
@@ -435,9 +435,7 @@ bool ChooseAttributesPanel::init()
 		UiDrawCall::makePivotFunc(PivotType::TopLeft),
 		UiDrawCall::defaultActiveFunc);
 
-	// my code bonus atribute stat.............................................................................
-	
-	//bonus to hit
+	//textBox bonus to hit
 	const Rect& lastAttributeTextBoxRect = this->attributeTextBoxes[PrimaryAttributes::COUNT - 6].getRect();
 	const Int2 bonusToHitTextBoxTopLeftPosition(
 		lastAttributeTextBoxRect.getLeft() + 60,
@@ -467,7 +465,7 @@ bool ChooseAttributesPanel::init()
 		UiDrawCall::makePivotFunc(PivotType::TopLeft),
 		UiDrawCall::defaultActiveFunc);
 
-	// textBox bonusToDefend
+	// textBox bonus ToDefend
 	const Int2 bonusToDefendTextBoxTopLeftPosition(
 		lastAttributeTextBoxRect.getLeft() + 120,
 		lastAttributeTextBoxRect.getTop() + 8);
@@ -495,7 +493,7 @@ bool ChooseAttributesPanel::init()
 		UiDrawCall::makePivotFunc(PivotType::TopLeft),
 		UiDrawCall::defaultActiveFunc);
 
-	//  TextBox charisma
+	//	TextBox bonus charisma
 	const Int2 bonusToCharismaTextBoxTopLeftPosition(
 		lastAttributeTextBoxRect.getLeft() + 60,
 		lastAttributeTextBoxRect.getTop() + 32);
@@ -524,7 +522,7 @@ bool ChooseAttributesPanel::init()
 		UiDrawCall::makePivotFunc(PivotType::TopLeft),
 		UiDrawCall::defaultActiveFunc);
 
-	// TextBox Health
+	// TextBox bonus Health
 	const Rect& positionAttributeEndureceTextBoxRect = this->attributeTextBoxes[PrimaryAttributes::COUNT - 3].getRect();
 	const Int2 bonusToHealthTextBoxTopLeftPosition(
 		positionAttributeEndureceTextBoxRect.getLeft() + 60,
@@ -554,7 +552,7 @@ bool ChooseAttributesPanel::init()
 		UiDrawCall::makePivotFunc(PivotType::TopLeft),
 		UiDrawCall::defaultActiveFunc);
 
-	// TextBox Heal Mod
+	// TextBox bonus Heal Mod
 	const Int2 healModTextBoxTopLeftPosition(
 		positionAttributeEndureceTextBoxRect.getLeft() + 120,
 		positionAttributeEndureceTextBoxRect.getTop());
@@ -642,7 +640,7 @@ bool ChooseAttributesPanel::init()
 		UiDrawCall::makePivotFunc(PivotType::TopLeft),
 		UiDrawCall::defaultActiveFunc);
 
-	// TextBox Magic Defense
+	// TextBox bonus Magic Defense
 	const Rect& positionAttributeWillpowerTextBoxRect = this->attributeTextBoxes[PrimaryAttributes::COUNT - 6].getRect();
 	const Int2 magicDefTextBoxTopLeftPosition(
 		positionAttributeWillpowerTextBoxRect.getLeft() + 60,
@@ -672,8 +670,6 @@ bool ChooseAttributesPanel::init()
 		UiDrawCall::makePivotFunc(PivotType::TopLeft),
 		UiDrawCall::defaultActiveFunc);
 
-	//............................................................................................................................................
-	//My code
 	for (int attributeIndex = 0; attributeIndex < PrimaryAttributes::COUNT; attributeIndex++)
 	{
 		UiDrawCall::TextureFunc attributeTextBoxTextureFunc = [this, attributeIndex]()

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
@@ -35,7 +35,7 @@ void ChooseAttributesPanel::populateBaseAttributesRandomly(CharacterCreationStat
 	{
 		PrimaryAttribute &attribute = attributes[i];
 		const int addedValue = ChooseAttributesUiModel::rollClassic(ChooseAttributesUiModel::PrimaryAttributeRandomMax, random);
-		attribute.maxValue += addedValue;	
+		attribute.maxValue += addedValue;
 	}
 }
 
@@ -326,30 +326,25 @@ bool ChooseAttributesPanel::init()
 			BufferView<PrimaryAttribute> attributesView = attributes.getAttributes();
 			PrimaryAttribute &attribute = attributesView.get(attributeIndex);
 			attribute.maxValue += 1;
-			if (strcmp(attribute.name, "Agility") == 0) {
-				this->bonusToHitValue = ArenaPlayerUtils::calculateBonusToHit(attribute.maxValue);
-				this->bonusToHitTextBox.setText(std::to_string(this->bonusToHitValue));
-				this->bonusToDefendTextBox.setText(std::to_string(this->bonusToHitValue));
-			}
-			if (strcmp(attribute.name, "Personality") == 0) {
-				this->bonusToCharismaValue = ArenaPlayerUtils::calculateBonusToCharisma(attribute.maxValue);
-				this->bonusToCharismaTextBox.setText(std::to_string(this->bonusToCharismaValue));
-			}
-			if (strcmp(attribute.name, "Endurance") == 0) {
-				this->bonusToHealthValue = ArenaPlayerUtils::calculateBonusToHealth(attribute.maxValue);
-				this->bonusToHealthTextBox.setText(std::to_string(this->bonusToHealthValue));
-				this->healModTextBox.setText(std::to_string(this->bonusToHealthValue));
-			}
-			if (strcmp(attribute.name, "Strength") == 0) {
-				this->bonusDamageValue = ArenaPlayerUtils::calculateDamageBonus(attribute.maxValue);
-				this->bonusDamageTextBox.setText(std::to_string(this->bonusDamageValue));
-				this->maxKilosValue = attribute.maxValue * 2;
-				this->maxKilosTextBox.setText(std::to_string(this->maxKilosValue));
-			}
-			if (strcmp(attribute.name, "Willpower") == 0) {
-				this->magicDefValue = ArenaPlayerUtils::calculateMagicDefenseBonus(attribute.maxValue);
-				this->magicDefTextBox.setText(std::to_string(this->magicDefValue));
-			}
+
+			auto bonusValues = ArenaPlayerUtils::calculateAttributeBonus(attribute.name, attribute.maxValue);
+			
+			this->bonusToHitValue = bonusValues.bonusToHit;
+			this->bonusToCharismaValue = bonusValues.bonusToCharisma;
+			this->bonusToHealthValue = bonusValues.bonusToHealth;
+			this->bonusDamageValue = bonusValues.bonusDamage;
+			this->maxKilosValue = bonusValues.maxKilos;
+			this->magicDefValue = bonusValues.magicDef;
+
+			this->bonusToHitTextBox.setText(std::to_string(this->bonusToHitValue));
+			this->bonusToDefendTextBox.setText(std::to_string(this->bonusToHitValue));
+			this->bonusToCharismaTextBox.setText(std::to_string(this->bonusToCharismaValue));
+			this->bonusToHealthTextBox.setText(std::to_string(this->bonusToHealthValue));
+			this->healModTextBox.setText(std::to_string(this->bonusToHealthValue));
+			this->bonusDamageTextBox.setText(std::to_string(this->bonusDamageValue));
+			this->maxKilosTextBox.setText(std::to_string(this->maxKilosValue));
+			this->magicDefTextBox.setText(std::to_string(this->magicDefValue));
+
 			TextBox &attributeTextBox = this->attributeTextBoxes[attributeIndex];
 			attributeTextBox.setText(std::to_string(attribute.maxValue));
 			this->bonusPointsTextBox.setText(std::to_string(this->bonusPoints));
@@ -372,30 +367,24 @@ bool ChooseAttributesPanel::init()
 			PrimaryAttribute &attribute = attributesView.get(attributeIndex);
 			attribute.maxValue -= 1;
 
-			if (strcmp(attribute.name, "Agility") == 0) {
-				this->bonusToHitValue = ArenaPlayerUtils::calculateBonusToHit(attribute.maxValue);
-				this->bonusToHitTextBox.setText(std::to_string(this->bonusToHitValue));
-				this->bonusToDefendTextBox.setText(std::to_string(this->bonusToHitValue));
-			}
-			if (strcmp(attribute.name, "Personality") == 0) {
-				this->bonusToCharismaValue = ArenaPlayerUtils::calculateBonusToCharisma(attribute.maxValue);
-				this->bonusToCharismaTextBox.setText(std::to_string(this->bonusToCharismaValue));
-			}
-			if (strcmp(attribute.name, "Endurance") == 0) {
-				this->bonusToHealthValue = ArenaPlayerUtils::calculateBonusToHealth(attribute.maxValue);
-				this->bonusToHealthTextBox.setText(std::to_string(this->bonusToHealthValue));
-				this->healModTextBox.setText(std::to_string(this->bonusToHealthValue));
-			}
-			if (strcmp(attribute.name, "Strength") == 0) {
-				this->bonusDamageValue = ArenaPlayerUtils::calculateDamageBonus(attribute.maxValue);
-				this->bonusDamageTextBox.setText(std::to_string(this->bonusDamageValue));
-				this->maxKilosValue = attribute.maxValue * 2;
-				this->maxKilosTextBox.setText(std::to_string(this->maxKilosValue));
-			}
-			if (strcmp(attribute.name, "Willpower") == 0) {
-				this->magicDefValue = ArenaPlayerUtils::calculateMagicDefenseBonus(attribute.maxValue);
-				this->magicDefTextBox.setText(std::to_string(this->magicDefValue));
-			}
+			auto bonusValues = ArenaPlayerUtils::calculateAttributeBonus(attribute.name, attribute.maxValue);
+			
+			this->bonusToHitValue = bonusValues.bonusToHit;
+			this->bonusToCharismaValue = bonusValues.bonusToCharisma;
+			this->bonusToHealthValue = bonusValues.bonusToHealth;
+			this->bonusDamageValue = bonusValues.bonusDamage;
+			this->maxKilosValue = bonusValues.maxKilos;
+			this->magicDefValue = bonusValues.magicDef;
+
+			this->bonusToHitTextBox.setText(std::to_string(this->bonusToHitValue));
+			this->bonusToDefendTextBox.setText(std::to_string(this->bonusToHitValue));
+			this->bonusToCharismaTextBox.setText(std::to_string(this->bonusToCharismaValue));
+			this->bonusToHealthTextBox.setText(std::to_string(this->bonusToHealthValue));
+			this->healModTextBox.setText(std::to_string(this->bonusToHealthValue));
+			this->bonusDamageTextBox.setText(std::to_string(this->bonusDamageValue));
+			this->maxKilosTextBox.setText(std::to_string(this->maxKilosValue));
+			this->magicDefTextBox.setText(std::to_string(this->magicDefValue));
+
 			TextBox &attributeTextBox = this->attributeTextBoxes[attributeIndex];
 			attributeTextBox.setText(std::to_string(attribute.maxValue));
 			this->bonusPointsTextBox.setText(std::to_string(this->bonusPoints));

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.cpp
@@ -319,6 +319,7 @@ bool ChooseAttributesPanel::init()
 			if (strcmp(attribute.name, "Agility") == 0) {
 				this->bonusToHitValue = ArenaPlayerUtils::calculateBonusToHit(attribute.maxValue);
 				this->bonusToHitTextBox.setText(std::to_string(this->bonusToHitValue));
+				this->bonusToDefendTextBox.setText(std::to_string(this->bonusToHitValue));
 			}
 			TextBox &attributeTextBox = this->attributeTextBoxes[attributeIndex];
 			attributeTextBox.setText(std::to_string(attribute.maxValue));
@@ -345,6 +346,7 @@ bool ChooseAttributesPanel::init()
 			if (strcmp(attribute.name, "Agility") == 0) {
 				this->bonusToHitValue = ArenaPlayerUtils::calculateBonusToHit(attribute.maxValue);
 				this->bonusToHitTextBox.setText(std::to_string(this->bonusToHitValue));
+				this->bonusToDefendTextBox.setText(std::to_string(this->bonusToHitValue));
 			}
 
 			TextBox &attributeTextBox = this->attributeTextBoxes[attributeIndex];
@@ -386,7 +388,7 @@ bool ChooseAttributesPanel::init()
 		UiDrawCall::makePivotFunc(PivotType::TopLeft),
 		UiDrawCall::defaultActiveFunc);
 
-	// my code
+	// my code bonus atribute stat.............................................................................
 	
 
 	const Rect& lastAttributeTextBoxRect = this->attributeTextBoxes[PrimaryAttributes::COUNT - 6].getRect();
@@ -417,6 +419,35 @@ bool ChooseAttributesPanel::init()
 		UiDrawCall::makeSizeFunc(bonusToHitTextBoxRect.getSize()),
 		UiDrawCall::makePivotFunc(PivotType::TopLeft),
 		UiDrawCall::defaultActiveFunc);
+
+	// codigo de inicializacion de bonusToDefendTextBox
+	const Int2 bonusToDefendTextBoxTopLeftPosition(
+		lastAttributeTextBoxRect.getLeft() + 120,
+		lastAttributeTextBoxRect.getTop() + 8);
+	const TextBox::InitInfo bonusToDefendTextBoxInitInfo = TextBox::InitInfo::makeWithXY(
+		std::string(3, TextRenderUtils::LARGEST_CHAR),
+		bonusToDefendTextBoxTopLeftPosition.x,
+		bonusToDefendTextBoxTopLeftPosition.y,
+		ChooseAttributesUiView::BonusPointsFontName,
+		ChooseAttributesUiView::BonusPointsTextColor,
+		TextAlignment::TopLeft,
+		std::nullopt,
+		1,
+		fontLibrary);
+	if (!this->bonusToDefendTextBox.init(bonusToDefendTextBoxInitInfo, "0", renderer))
+	{
+		DebugLogError("Couldn't init bonus to defend text box.");
+		return false;
+	}
+
+	const Rect &bonusToDefendTextBoxRect = this->bonusToDefendTextBox.getRect();
+	this->addDrawCall(
+		[this]() { return this->bonusToDefendTextBox.getTextureID(); },
+		UiDrawCall::makePositionFunc(bonusToDefendTextBoxRect.getTopLeft()),
+		UiDrawCall::makeSizeFunc(bonusToDefendTextBoxRect.getSize()),
+		UiDrawCall::makePivotFunc(PivotType::TopLeft),
+		UiDrawCall::defaultActiveFunc);
+	//.........................................................................................................
 	//My code
 	for (int attributeIndex = 0; attributeIndex < PrimaryAttributes::COUNT; attributeIndex++)
 	{

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.h
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.h
@@ -8,6 +8,7 @@
 #include "../UI/TextAlignment.h"
 #include "../UI/TextBox.h"
 #include "../UI/TextRenderUtils.h"
+#include "../Player/ArenaPlayerUtils.h"
 
 class ArenaRandom;
 
@@ -33,6 +34,8 @@ private:
 	int bonusPoints;
 	int selectedAttributeIndex;
 	int bonusToHitValue, bonusToCharismaValue, bonusToHealthValue, bonusDamageValue, maxKilosValue, magicDefValue;
+
+	void updateBonusAttributeValues(const ArenaPlayerUtils::AttributeBonusValues& bonusValues);
 public:
 	ChooseAttributesPanel(Game &game);
 	~ChooseAttributesPanel() override = default;

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.h
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.h
@@ -25,6 +25,7 @@ private:
 	TextBox bonusPointsTextBox;
 	//Todo
 	TextBox bonusToHitTextBox;
+	int bonusToHitValue;
 	//bonusToDamage,magicDefense,bonusHealth,charisma,healModificator,bonusToDefend,maxkilos;
 	//
 	Button<Game&, int, bool*> doneButton;

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.h
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.h
@@ -30,12 +30,14 @@ private:
 	TextBox healModTextBox;
 	TextBox bonusDamageTextBox;
 	TextBox maxKilosTextBox;
+	TextBox magicDefTextBox;
 
 	int bonusToHitValue;
 	int bonusToCharismaValue;
 	int bonusToHealthValue;
 	int bonusDamageValue;
 	int maxKilosValue;
+	int magicDefValue;
 	//bonusToDamage,magicDefense,bonusHealth,charisma,healModificator,bonusToDefend,maxkilos;
 	//
 	Button<Game&, int, bool*> doneButton;

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.h
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.h
@@ -28,10 +28,14 @@ private:
 	TextBox bonusToCharismaTextBox;
 	TextBox bonusToHealthTextBox;
 	TextBox healModTextBox;
+	TextBox bonusDamageTextBox;
+	TextBox maxKilosTextBox;
 
 	int bonusToHitValue;
 	int bonusToCharismaValue;
 	int bonusToHealthValue;
+	int bonusDamageValue;
+	int maxKilosValue;
 	//bonusToDamage,magicDefense,bonusHealth,charisma,healModificator,bonusToDefend,maxkilos;
 	//
 	Button<Game&, int, bool*> doneButton;

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.h
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.h
@@ -23,8 +23,8 @@ private:
 	TextBox attributeTextBoxes[PrimaryAttributes::COUNT];
 	TextBox experienceTextBox, levelTextBox;
 	TextBox bonusPointsTextBox;
-	//Todo
 	TextBox bonusToHitTextBox;
+	TextBox bonusToDefendTextBox;
 	int bonusToHitValue;
 	//bonusToDamage,magicDefense,bonusHealth,charisma,healModificator,bonusToDefend,maxkilos;
 	//

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.h
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.h
@@ -8,7 +8,6 @@
 #include "../UI/TextAlignment.h"
 #include "../UI/TextBox.h"
 #include "../UI/TextRenderUtils.h"
-#include "../Player/ArenaPlayerUtils.h"
 
 class ArenaRandom;
 
@@ -35,7 +34,7 @@ private:
 	int selectedAttributeIndex;
 	int bonusToHitValue, bonusToCharismaValue, bonusToHealthValue, bonusDamageValue, maxKilosValue, magicDefValue;
 
-	void updateBonusAttributeValues(const ArenaPlayerUtils::AttributeBonusValues& bonusValues);
+	void updateBonusAttributeValues();
 public:
 	ChooseAttributesPanel(Game &game);
 	~ChooseAttributesPanel() override = default;

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.h
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.h
@@ -22,24 +22,7 @@ private:
 	TextBox nameTextBox, raceTextBox, classTextBox;
 	TextBox attributeTextBoxes[PrimaryAttributes::COUNT];
 	TextBox experienceTextBox, levelTextBox;
-	TextBox bonusPointsTextBox;
-	TextBox bonusToHitTextBox;
-	TextBox bonusToDefendTextBox;
-	TextBox bonusToCharismaTextBox;
-	TextBox bonusToHealthTextBox;
-	TextBox healModTextBox;
-	TextBox bonusDamageTextBox;
-	TextBox maxKilosTextBox;
-	TextBox magicDefTextBox;
-
-	int bonusToHitValue;
-	int bonusToCharismaValue;
-	int bonusToHealthValue;
-	int bonusDamageValue;
-	int maxKilosValue;
-	int magicDefValue;
-	//bonusToDamage,magicDefense,bonusHealth,charisma,healModificator,bonusToDefend,maxkilos;
-	//
+	TextBox bonusPointsTextBox, bonusToHitTextBox, bonusToDefendTextBox, bonusToCharismaTextBox, bonusToHealthTextBox, healModTextBox, bonusDamageTextBox, maxKilosTextBox, magicDefTextBox;
 	Button<Game&, int, bool*> doneButton;
 	Button<Game&, bool> portraitButton;
 	Buffer<ScopedUiTextureRef> headTextureRefs;
@@ -49,6 +32,7 @@ private:
 	bool attributesAreSaved; // Whether attributes have been saved and the player portrait can now be changed.
 	int bonusPoints;
 	int selectedAttributeIndex;
+	int bonusToHitValue, bonusToCharismaValue, bonusToHealthValue, bonusDamageValue, maxKilosValue, magicDefValue;
 public:
 	ChooseAttributesPanel(Game &game);
 	~ChooseAttributesPanel() override = default;

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.h
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.h
@@ -25,7 +25,10 @@ private:
 	TextBox bonusPointsTextBox;
 	TextBox bonusToHitTextBox;
 	TextBox bonusToDefendTextBox;
+	TextBox bonusToCharismaTextBox;
+
 	int bonusToHitValue;
+	int bonusToCharismaValue;
 	//bonusToDamage,magicDefense,bonusHealth,charisma,healModificator,bonusToDefend,maxkilos;
 	//
 	Button<Game&, int, bool*> doneButton;

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.h
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.h
@@ -26,9 +26,11 @@ private:
 	TextBox bonusToHitTextBox;
 	TextBox bonusToDefendTextBox;
 	TextBox bonusToCharismaTextBox;
+	TextBox bonusToHealthTextBox;
 
 	int bonusToHitValue;
 	int bonusToCharismaValue;
+	int bonusToHealthValue;
 	//bonusToDamage,magicDefense,bonusHealth,charisma,healModificator,bonusToDefend,maxkilos;
 	//
 	Button<Game&, int, bool*> doneButton;

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.h
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.h
@@ -27,6 +27,7 @@ private:
 	TextBox bonusToDefendTextBox;
 	TextBox bonusToCharismaTextBox;
 	TextBox bonusToHealthTextBox;
+	TextBox healModTextBox;
 
 	int bonusToHitValue;
 	int bonusToCharismaValue;

--- a/OpenTESArena/src/Interface/ChooseAttributesPanel.h
+++ b/OpenTESArena/src/Interface/ChooseAttributesPanel.h
@@ -23,6 +23,10 @@ private:
 	TextBox attributeTextBoxes[PrimaryAttributes::COUNT];
 	TextBox experienceTextBox, levelTextBox;
 	TextBox bonusPointsTextBox;
+	//Todo
+	TextBox bonusToHitTextBox;
+	//bonusToDamage,magicDefense,bonusHealth,charisma,healModificator,bonusToDefend,maxkilos;
+	//
 	Button<Game&, int, bool*> doneButton;
 	Button<Game&, bool> portraitButton;
 	Buffer<ScopedUiTextureRef> headTextureRefs;

--- a/OpenTESArena/src/Player/ArenaPlayerUtils.cpp
+++ b/OpenTESArena/src/Player/ArenaPlayerUtils.cpp
@@ -70,6 +70,12 @@ int ArenaPlayerUtils::calculateBonusToHit(int Agility)
 		case 60: lastValidBonus = +2; break;
 		case 65: lastValidBonus = +3; break;
 		case 70: lastValidBonus = +4; break;
+		case 75: lastValidBonus = +5; break;
+		case 80: lastValidBonus = +6; break;
+		case 85: lastValidBonus = +7; break;
+		case 90: lastValidBonus = +8; break;
+		case 95: lastValidBonus = +9; break;
+		case 100: lastValidBonus = +10; break;
 	}
 	return lastValidBonus;
 }

--- a/OpenTESArena/src/Player/ArenaPlayerUtils.cpp
+++ b/OpenTESArena/src/Player/ArenaPlayerUtils.cpp
@@ -82,3 +82,10 @@ int ArenaPlayerUtils::calculateBonusToHealth(int endurance)
 	int bonus = (endurance - 55) / 10 + 1;
 	return std::min(bonus, 5);
 }
+
+int ArenaPlayerUtils::calculateDamageBonus(int strength)
+{
+	if (strength <= 43) return 0;
+	return (strength - 48) / 5;
+}
+

--- a/OpenTESArena/src/Player/ArenaPlayerUtils.cpp
+++ b/OpenTESArena/src/Player/ArenaPlayerUtils.cpp
@@ -1,4 +1,4 @@
-#include <algorithm>
+﻿#include <algorithm>
 #include <cmath>
 
 #include "ArenaPlayerUtils.h"
@@ -73,4 +73,12 @@ int ArenaPlayerUtils::calculateBonusToCharisma(int charisma)
 	if (charisma <= 45) return -1;
 	if (charisma <= 46) return 0;
 	return (charisma - 50) / 5;
+}
+
+int ArenaPlayerUtils::calculateBonusToHealth(int endurance)
+{
+	if (endurance <= 34) return -1;
+	if (endurance <= 54) return 0;
+	int bonus = (endurance - 55) / 10 + 1;
+	return std::min(bonus, 5);
 }

--- a/OpenTESArena/src/Player/ArenaPlayerUtils.cpp
+++ b/OpenTESArena/src/Player/ArenaPlayerUtils.cpp
@@ -60,7 +60,16 @@ int ArenaPlayerUtils::calculateMaxSpellPoints(int charClassDefID, int intelligen
 	return maxSpellPoints;
 }
 
-int ArenaPlayerUtils::calculateBonusToHit(int intelligence)
+int ArenaPlayerUtils::calculateBonusToHit(int Agility)
 {
-	return 555;
+	static int lastValidBonus = 0;
+	switch (Agility) {
+		case 45: lastValidBonus = -1; break;
+		case 46: lastValidBonus = 0; break;
+		case 55: lastValidBonus = +1; break;
+		case 60: lastValidBonus = +2; break;
+		case 65: lastValidBonus = +3; break;
+		case 70: lastValidBonus = +4; break;
+	}
+	return lastValidBonus;
 }

--- a/OpenTESArena/src/Player/ArenaPlayerUtils.cpp
+++ b/OpenTESArena/src/Player/ArenaPlayerUtils.cpp
@@ -66,3 +66,11 @@ int ArenaPlayerUtils::calculateBonusToHit(int Agility)
 	if (Agility <= 46) return 0;
 	return (Agility - 50) / 5;
 }
+
+
+int ArenaPlayerUtils::calculateBonusToCharisma(int charisma)
+{
+	if (charisma <= 45) return -1;
+	if (charisma <= 46) return 0;
+	return (charisma - 50) / 5;
+}

--- a/OpenTESArena/src/Player/ArenaPlayerUtils.cpp
+++ b/OpenTESArena/src/Player/ArenaPlayerUtils.cpp
@@ -88,4 +88,10 @@ int ArenaPlayerUtils::calculateDamageBonus(int strength)
 	if (strength <= 43) return 0;
 	return (strength - 48) / 5;
 }
+int ArenaPlayerUtils::calculateMagicDefenseBonus(int Will) {
+	if (Will <= 38) return -2;
+	if (Will <= 41) return -1;
+	if (Will <= 46) return 0;
+	return (Will - 46) / 9; 
+}
 

--- a/OpenTESArena/src/Player/ArenaPlayerUtils.cpp
+++ b/OpenTESArena/src/Player/ArenaPlayerUtils.cpp
@@ -59,3 +59,8 @@ int ArenaPlayerUtils::calculateMaxSpellPoints(int charClassDefID, int intelligen
 	const int maxSpellPoints = static_cast<int>(static_cast<double>(intelligence) * charClassDef.spellPointsMultiplier);
 	return maxSpellPoints;
 }
+
+int ArenaPlayerUtils::calculateBonusToHit(int intelligence)
+{
+	return 555;
+}

--- a/OpenTESArena/src/Player/ArenaPlayerUtils.cpp
+++ b/OpenTESArena/src/Player/ArenaPlayerUtils.cpp
@@ -103,7 +103,8 @@ ArenaPlayerUtils::AttributeBonusValues ArenaPlayerUtils::calculateAttributeBonus
 		values.bonusToDefend = values.bonusToHit;
 	}
 	else if (strcmp(attributeName, "Personality") == 0) {
-		values.bonusToCharisma = calculateBonusToCharisma(attributeValue);
+		//Personality and agility have the same bonus progression.
+		values.bonusToCharisma = calculateBonusToHit(attributeValue);
 	}
 	else if (strcmp(attributeName, "Endurance") == 0) {
 		values.bonusToHealth = calculateBonusToHealth(attributeValue);

--- a/OpenTESArena/src/Player/ArenaPlayerUtils.cpp
+++ b/OpenTESArena/src/Player/ArenaPlayerUtils.cpp
@@ -62,20 +62,7 @@ int ArenaPlayerUtils::calculateMaxSpellPoints(int charClassDefID, int intelligen
 
 int ArenaPlayerUtils::calculateBonusToHit(int Agility)
 {
-	static int lastValidBonus = 0;
-	switch (Agility) {
-		case 45: lastValidBonus = -1; break;
-		case 46: lastValidBonus = 0; break;
-		case 55: lastValidBonus = +1; break;
-		case 60: lastValidBonus = +2; break;
-		case 65: lastValidBonus = +3; break;
-		case 70: lastValidBonus = +4; break;
-		case 75: lastValidBonus = +5; break;
-		case 80: lastValidBonus = +6; break;
-		case 85: lastValidBonus = +7; break;
-		case 90: lastValidBonus = +8; break;
-		case 95: lastValidBonus = +9; break;
-		case 100: lastValidBonus = +10; break;
-	}
-	return lastValidBonus;
+	if (Agility <= 45) return -1;
+	if (Agility <= 46) return 0;
+	return (Agility - 50) / 5;
 }

--- a/OpenTESArena/src/Player/ArenaPlayerUtils.cpp
+++ b/OpenTESArena/src/Player/ArenaPlayerUtils.cpp
@@ -68,12 +68,6 @@ int ArenaPlayerUtils::calculateBonusToHit(int Agility)
 }
 
 
-int ArenaPlayerUtils::calculateBonusToCharisma(int charisma)
-{
-	if (charisma <= 45) return -1;
-	if (charisma <= 46) return 0;
-	return (charisma - 50) / 5;
-}
 
 int ArenaPlayerUtils::calculateBonusToHealth(int endurance)
 {

--- a/OpenTESArena/src/Player/ArenaPlayerUtils.cpp
+++ b/OpenTESArena/src/Player/ArenaPlayerUtils.cpp
@@ -95,3 +95,26 @@ int ArenaPlayerUtils::calculateMagicDefenseBonus(int Will) {
 	return (Will - 46) / 9; 
 }
 
+ArenaPlayerUtils::AttributeBonusValues ArenaPlayerUtils::calculateAttributeBonus(const char* attributeName, int attributeValue) {
+	AttributeBonusValues values = { 0, 0, 0, 0, 0, 0, 0, 0 };
+
+	if (strcmp(attributeName, "Agility") == 0) {
+		values.bonusToHit = calculateBonusToHit(attributeValue);
+		values.bonusToDefend = values.bonusToHit;
+	}
+	else if (strcmp(attributeName, "Personality") == 0) {
+		values.bonusToCharisma = calculateBonusToCharisma(attributeValue);
+	}
+	else if (strcmp(attributeName, "Endurance") == 0) {
+		values.bonusToHealth = calculateBonusToHealth(attributeValue);
+		values.healMod = values.bonusToHealth;
+	}
+	else if (strcmp(attributeName, "Strength") == 0) {
+		values.bonusDamage = calculateDamageBonus(attributeValue);
+		values.maxKilos = attributeValue * 2;
+	}
+	else if (strcmp(attributeName, "Willpower") == 0) {
+		values.magicDef = calculateMagicDefenseBonus(attributeValue);
+	}
+	return values;
+}

--- a/OpenTESArena/src/Player/ArenaPlayerUtils.h
+++ b/OpenTESArena/src/Player/ArenaPlayerUtils.h
@@ -38,6 +38,7 @@ namespace ArenaPlayerUtils
 	int calculateBonusToHit(int Agility);
 	int calculateBonusToCharisma(int charisma);
 	int calculateBonusToHealth(int endurance);
+	int calculateDamageBonus(int strength);
 }
 
 #endif

--- a/OpenTESArena/src/Player/ArenaPlayerUtils.h
+++ b/OpenTESArena/src/Player/ArenaPlayerUtils.h
@@ -40,6 +40,18 @@ namespace ArenaPlayerUtils
 	int calculateBonusToHealth(int endurance);
 	int calculateDamageBonus(int strength);
 	int calculateMagicDefenseBonus(int will);
+
+	struct AttributeBonusValues {
+		int bonusToHit;
+		int bonusToDefend;
+		int bonusToCharisma;
+		int bonusToHealth;
+		int healMod;
+		int bonusDamage;
+		int maxKilos;
+		int magicDef;
+	};
+	AttributeBonusValues calculateAttributeBonus(const char* attributeName, int attributeValue);
 }
 
 #endif

--- a/OpenTESArena/src/Player/ArenaPlayerUtils.h
+++ b/OpenTESArena/src/Player/ArenaPlayerUtils.h
@@ -36,6 +36,7 @@ namespace ArenaPlayerUtils
 	int calculateMaxStamina(int strength, int endurance);
 	int calculateMaxSpellPoints(int charClassDefID, int intelligence);
 	int calculateBonusToHit(int Agility);
+	int calculateBonusToCharisma(int charisma);
 }
 
 #endif

--- a/OpenTESArena/src/Player/ArenaPlayerUtils.h
+++ b/OpenTESArena/src/Player/ArenaPlayerUtils.h
@@ -39,6 +39,7 @@ namespace ArenaPlayerUtils
 	int calculateBonusToCharisma(int charisma);
 	int calculateBonusToHealth(int endurance);
 	int calculateDamageBonus(int strength);
+	int calculateMagicDefenseBonus(int will);
 }
 
 #endif

--- a/OpenTESArena/src/Player/ArenaPlayerUtils.h
+++ b/OpenTESArena/src/Player/ArenaPlayerUtils.h
@@ -37,6 +37,7 @@ namespace ArenaPlayerUtils
 	int calculateMaxSpellPoints(int charClassDefID, int intelligence);
 	int calculateBonusToHit(int Agility);
 	int calculateBonusToCharisma(int charisma);
+	int calculateBonusToHealth(int endurance);
 }
 
 #endif

--- a/OpenTESArena/src/Player/ArenaPlayerUtils.h
+++ b/OpenTESArena/src/Player/ArenaPlayerUtils.h
@@ -35,7 +35,7 @@ namespace ArenaPlayerUtils
 	int calculateMaxHealthPoints(int charClassDefID, Random &random);
 	int calculateMaxStamina(int strength, int endurance);
 	int calculateMaxSpellPoints(int charClassDefID, int intelligence);
-	int calculateBonusToHit(int intelligence);
+	int calculateBonusToHit(int Agility);
 }
 
 #endif

--- a/OpenTESArena/src/Player/ArenaPlayerUtils.h
+++ b/OpenTESArena/src/Player/ArenaPlayerUtils.h
@@ -36,7 +36,6 @@ namespace ArenaPlayerUtils
 	int calculateMaxStamina(int strength, int endurance);
 	int calculateMaxSpellPoints(int charClassDefID, int intelligence);
 	int calculateBonusToHit(int Agility);
-	int calculateBonusToCharisma(int charisma);
 	int calculateBonusToHealth(int endurance);
 	int calculateDamageBonus(int strength);
 	int calculateMagicDefenseBonus(int will);

--- a/OpenTESArena/src/Player/ArenaPlayerUtils.h
+++ b/OpenTESArena/src/Player/ArenaPlayerUtils.h
@@ -35,7 +35,7 @@ namespace ArenaPlayerUtils
 	int calculateMaxHealthPoints(int charClassDefID, Random &random);
 	int calculateMaxStamina(int strength, int endurance);
 	int calculateMaxSpellPoints(int charClassDefID, int intelligence);
-
+	int calculateBonusToHit(int intelligence);
 }
 
 #endif


### PR DESCRIPTION
In choseeAttributePanel now see the and it calculates the bonuses derived from the main attributes which are:  Damage, magic de, to hit, to defend, healh, heal mod, charisma 

![image](https://github.com/user-attachments/assets/a93e06a6-8d52-4f13-a1ba-8a222881d25f)
