### PR TITLE
Rasterizer optimization

### DIFF
--- a/OpenTESArena/src/Rendering/RenderEntityChunkManager.cpp
+++ b/OpenTESArena/src/Rendering/RenderEntityChunkManager.cpp
@@ -392,10 +392,16 @@ void RenderEntityChunkManager::loadTexturesForEntity(EntityDefID entityDefID, Te
 
 void RenderEntityChunkManager::populateCommandBuffer(RenderCommandBuffer &commandBuffer) const
 {
-	commandBuffer.addDrawCalls(this->drawCallsCache);
+	if (!this->drawCallsCache.empty())
+	{
+		commandBuffer.addDrawCalls(this->drawCallsCache);
+	}
 
-	// Puddles require two passes to avoid race conditions when rasterizing.
-	commandBuffer.addDrawCalls(this->puddleSecondPassDrawCallsCache);
+	if (!this->puddleSecondPassDrawCallsCache.empty())
+	{
+		// Puddles require two passes to avoid race conditions when rasterizing.
+		commandBuffer.addDrawCalls(this->puddleSecondPassDrawCallsCache);
+	}
 }
 
 void RenderEntityChunkManager::loadScene(TextureManager &textureManager, Renderer &renderer)

--- a/OpenTESArena/src/Rendering/RenderEntityChunkManager.h
+++ b/OpenTESArena/src/Rendering/RenderEntityChunkManager.h
@@ -47,6 +47,7 @@ private:
 
 	// All accumulated draw calls from entities each frame. This is sent to the renderer.
 	std::vector<RenderDrawCall> drawCallsCache;
+	std::vector<RenderDrawCall> puddleSecondPassDrawCallsCache;
 
 	ObjectTextureID getTextureID(EntityInstanceID entityInstID, const WorldDouble3 &cameraPosition, const EntityChunkManager &entityChunkManager) const;
 

--- a/OpenTESArena/src/Rendering/RenderShaderUtils.h
+++ b/OpenTESArena/src/Rendering/RenderShaderUtils.h
@@ -21,10 +21,11 @@ enum class PixelShaderType
 	AlphaTestedWithLightLevelColor, // Clouds, distant moons.
 	AlphaTestedWithLightLevelOpacity, // Ghosts, screen-space fog.
 	AlphaTestedWithPreviousBrightnessLimit, // Stars.
-	AlphaTestedWithHorizonMirror // Puddles.
+	AlphaTestedWithHorizonMirrorFirstPass, // Puddles without reflection.
+	AlphaTestedWithHorizonMirrorSecondPass // Puddle reflections.
 };
 
-static constexpr PixelShaderType PIXEL_SHADER_TYPE_MAX = PixelShaderType::AlphaTestedWithHorizonMirror;
+static constexpr PixelShaderType PIXEL_SHADER_TYPE_MAX = PixelShaderType::AlphaTestedWithHorizonMirrorSecondPass;
 static constexpr int PIXEL_SHADER_TYPE_COUNT = static_cast<int>(PIXEL_SHADER_TYPE_MAX) + 1;
 
 enum class DitheringMode

--- a/OpenTESArena/src/Rendering/SoftwareRenderer.cpp
+++ b/OpenTESArena/src/Rendering/SoftwareRenderer.cpp
@@ -1654,7 +1654,7 @@ namespace
 		g_skyBgTexture = &skyBgTexture;
 	}
 
-	uint8_t GetPerspectiveTexel(const PixelShaderTexture &texture, double perspectiveTexCoordU, double perspectiveTexCoordV)
+	uint8_t GetPerspectiveTexel(const PixelShaderTexture &__restrict texture, double perspectiveTexCoordU, double perspectiveTexCoordV)
 	{
 		const int texelX = FractToInt(perspectiveTexCoordU, texture.widthReal);
 		const int texelY = FractToInt(perspectiveTexCoordV, texture.heightReal);
@@ -1664,7 +1664,7 @@ namespace
 	}
 
 	constexpr int SCREEN_SPACE_ANIM_HEIGHT = 100; // @todo dehardcode w/ another parameter
-	uint8_t GetScreenSpaceAnimationTexel(const PixelShaderTexture &texture, double animPercent, double frameBufferPercentX, double frameBufferPercentY)
+	uint8_t GetScreenSpaceAnimationTexel(const PixelShaderTexture &__restrict texture, double animPercent, double frameBufferPercentX, double frameBufferPercentY)
 	{
 		// @todo chasms: determine how many pixels the original texture should cover, based on what percentage the original texture height is over the original screen height.		
 		const int texelX = std::clamp(static_cast<int>(frameBufferPercentX * texture.widthReal), 0, texture.widthMinusOne);
@@ -1683,19 +1683,19 @@ namespace
 		return texel;
 	}
 
-	uint8_t GetPaletteReplacementTexel(uint8_t texel, const PixelShaderTexture &lookupTexture)
+	uint8_t GetPaletteReplacementTexel(uint8_t texel, const PixelShaderTexture &__restrict lookupTexture)
 	{
 		return lookupTexture.texels[texel];
 	}
 
-	uint8_t GetTexelWithLightLevelLighting(uint8_t texel, int lightLevel, const PixelShaderLighting &lighting)
+	uint8_t GetTexelWithLightLevelLighting(uint8_t texel, int lightLevel, const PixelShaderLighting &__restrict lighting)
 	{
 		const int shadedTexelIndex = texel + (lightLevel * lighting.texelsPerLightLevel);
 		const uint8_t shadedTexel = lighting.lightTableTexels[shadedTexelIndex];
 		return shadedTexel;
 	}
 
-	uint8_t GetTexelWithLightTableLighting(uint8_t texel, int lightLevel, const PixelShaderLighting &lighting, int frameBufferPixelIndex)
+	uint8_t GetTexelWithLightTableLighting(uint8_t texel, int lightLevel, const PixelShaderLighting &__restrict lighting, int frameBufferPixelIndex)
 	{
 		int lightTableTexelIndex;
 		if (ArenaRenderUtils::isLightLevelTexel(texel))

--- a/OpenTESArena/src/Rendering/SoftwareRenderer.cpp
+++ b/OpenTESArena/src/Rendering/SoftwareRenderer.cpp
@@ -3315,9 +3315,15 @@ namespace
 
 						if constexpr (enableDepthRead)
 						{
+							double prevDepthBufferPixels[TYPICAL_LOOP_UNROLL];
 							for (int i = 0; i < TYPICAL_LOOP_UNROLL; i++)
 							{
-								isPixelCenterDepthLower[i] = ndcZDepth[i] < g_depthBuffer[frameBufferPixelIndex[i]];
+								prevDepthBufferPixels[i] = g_depthBuffer[frameBufferPixelIndex[i]];
+							}
+
+							for (int i = 0; i < TYPICAL_LOOP_UNROLL; i++)
+							{
+								isPixelCenterDepthLower[i] = ndcZDepth[i] < prevDepthBufferPixels[i];
 							}
 
 							totalDepthTests += TYPICAL_LOOP_UNROLL;
@@ -3501,6 +3507,13 @@ namespace
 						double shaderHomogeneousSpacePointY[TYPICAL_LOOP_UNROLL];
 						double shaderHomogeneousSpacePointZ[TYPICAL_LOOP_UNROLL];
 						double shaderHomogeneousSpacePointW[TYPICAL_LOOP_UNROLL];
+						double shaderCameraSpacePointX[TYPICAL_LOOP_UNROLL] = { 0.0 };
+						double shaderCameraSpacePointY[TYPICAL_LOOP_UNROLL] = { 0.0 };
+						double shaderCameraSpacePointZ[TYPICAL_LOOP_UNROLL] = { 0.0 };
+						double shaderCameraSpacePointW[TYPICAL_LOOP_UNROLL] = { 0.0 };
+						double shaderWorldSpacePointX[TYPICAL_LOOP_UNROLL] = { 0.0 };
+						double shaderWorldSpacePointY[TYPICAL_LOOP_UNROLL] = { 0.0 };
+						double shaderWorldSpacePointZ[TYPICAL_LOOP_UNROLL] = { 0.0 };
 
 						for (int i = 0; i < TYPICAL_LOOP_UNROLL; i++)
 						{
@@ -3522,10 +3535,6 @@ namespace
 							shaderHomogeneousSpacePointW[i] = shaderClipSpacePointWRecip[i];
 						}
 
-						double shaderCameraSpacePointX[TYPICAL_LOOP_UNROLL] = { 0.0 };
-						double shaderCameraSpacePointY[TYPICAL_LOOP_UNROLL] = { 0.0 };
-						double shaderCameraSpacePointZ[TYPICAL_LOOP_UNROLL] = { 0.0 };
-						double shaderCameraSpacePointW[TYPICAL_LOOP_UNROLL] = { 0.0 };
 						static_assert(sizeof(shaderCameraSpacePointX) == sizeof(g_invProjMatrixXX));
 						Matrix4_MultiplyVectorN<TYPICAL_LOOP_UNROLL>(
 							g_invProjMatrixXX, g_invProjMatrixXY, g_invProjMatrixXZ, g_invProjMatrixXW,
@@ -3535,9 +3544,6 @@ namespace
 							shaderHomogeneousSpacePointX, shaderHomogeneousSpacePointY, shaderHomogeneousSpacePointZ, shaderHomogeneousSpacePointW,
 							shaderCameraSpacePointX, shaderCameraSpacePointY, shaderCameraSpacePointZ, shaderCameraSpacePointW);
 
-						double shaderWorldSpacePointX[TYPICAL_LOOP_UNROLL] = { 0.0 };
-						double shaderWorldSpacePointY[TYPICAL_LOOP_UNROLL] = { 0.0 };
-						double shaderWorldSpacePointZ[TYPICAL_LOOP_UNROLL] = { 0.0 };
 						static_assert(sizeof(shaderWorldSpacePointX) == sizeof(g_invViewMatrixXX));
 						Matrix4_MultiplyVectorIgnoreW_N<TYPICAL_LOOP_UNROLL>(
 							g_invViewMatrixXX, g_invViewMatrixXY, g_invViewMatrixXZ,

--- a/OpenTESArena/src/Rendering/SoftwareRenderer.cpp
+++ b/OpenTESArena/src/Rendering/SoftwareRenderer.cpp
@@ -2769,6 +2769,8 @@ namespace
 	void GetPerspectiveTexel_N(const PixelShaderTexture &__restrict texture, const double *__restrict perspectiveTexCoordU, const double *__restrict perspectiveTexCoordV,
 		uint8_t *__restrict outTexel)
 	{
+		double uFract[N];
+		double vFract[N];
 		int texelX[N];
 		int texelY[N];
 		int texelIndex[N];
@@ -2776,12 +2778,22 @@ namespace
 
 		for (int i = 0; i < N; i++)
 		{
-			texelX[i] = FractToInt(perspectiveTexCoordU[i], texture.widthReal);
+			uFract[i] = perspectiveTexCoordU[i] - std::floor(perspectiveTexCoordU[i]);
 		}
 
 		for (int i = 0; i < N; i++)
 		{
-			texelY[i] = FractToInt(perspectiveTexCoordV[i], texture.heightReal);
+			vFract[i] = perspectiveTexCoordV[i] - std::floor(perspectiveTexCoordV[i]);
+		}
+
+		for (int i = 0; i < N; i++)
+		{
+			texelX[i] = static_cast<int>(uFract[i] * texture.widthReal);
+		}
+
+		for (int i = 0; i < N; i++)
+		{
+			texelY[i] = static_cast<int>(vFract[i] * texture.heightReal);
 		}
 
 		for (int i = 0; i < N; i++)

--- a/OpenTESArena/src/Rendering/SoftwareRenderer.h
+++ b/OpenTESArena/src/Rendering/SoftwareRenderer.h
@@ -125,7 +125,6 @@ class SoftwareRenderer : public RendererSystem3D
 {
 private:
 	Buffer2D<uint8_t> paletteIndexBuffer; // Intermediate buffer to support back-to-front transparencies.
-	Buffer2D<bool> coverageBuffer;
 	Buffer2D<double> depthBuffer;
 	Buffer3D<bool> ditherBuffer; // Stores N layers of pre-computed patterns depending on the option.
 	DitheringMode ditheringMode;


### PR DESCRIPTION
Converted all the pixel shader code into several `if constexpr` branches in the rasterizer.

Finally was able to get MSVC to produce vector instructions. The sad part is vectorizing did not change performance at 4k at all, which led me to believe it's very memory-bound. Tried changing doubles to floats but it was only a small improvement and caused several rendering bugs to appear, so discarded that.

Fixed puddle rendering by splitting into two passes so it doesn't sync on every single entity and severely slow down rendering.

For now this feels like the upper limit of rendering performance until a graphics API is integrated.