### PR TITLE
Determine enemy gold amounts like original game

### DIFF
--- a/OpenTESArena/src/Assets/ExeData.cpp
+++ b/OpenTESArena/src/Assets/ExeData.cpp
@@ -472,7 +472,7 @@ bool ExeDataEntities::init(Span<const std::byte> exeBytes, const KeyValueFile &k
 	initInt8Array(this->creatureBlood, exeBytes, creatureBloodOffset);
 	initInt8Array(this->creatureDiseaseChances, exeBytes, creatureDiseaseChancesOffset);
 	init2DInt8Array(this->creatureAttributes, exeBytes, creatureAttributesOffset);
-	initInt16Array(this->creatureLootChances, exeBytes, creatureLootChancesOffset);
+	initInt32Array(this->creatureLootChances, exeBytes, creatureLootChancesOffset);
 	initStringArrayNullTerminated(this->creatureAnimationFilenames, exeBytes, creatureAnimFilenamesOffset);
 	this->finalBossName = GetExeStringNullTerminated(exeBytes, finalBossNameOffset);
 	init2DInt8Array(this->raceAttributes, exeBytes, raceAttributesOffset);

--- a/OpenTESArena/src/Assets/ExeData.h
+++ b/OpenTESArena/src/Assets/ExeData.h
@@ -139,7 +139,7 @@ struct ExeDataEntities
 	uint8_t creatureBlood[24]; // Indices into effects animation list.
 	int8_t creatureDiseaseChances[24]; // Negative values have special meaning.
 	uint8_t creatureAttributes[24][8]; // 255 == 100.
-	uint16_t creatureLootChances[24];
+	uint32_t creatureLootChances[24]; // Accessed by 1-based races
 
 	// Creature animations (i.e., their .CFA filenames). These are ordered the same
 	// as creature names, and there is an extra entry at the end for the final boss.

--- a/OpenTESArena/src/Entities/ArenaEntityUtils.cpp
+++ b/OpenTESArena/src/Entities/ArenaEntityUtils.cpp
@@ -6,9 +6,14 @@ int ArenaEntityUtils::getBaseSpeed(int speedAttribute)
 	return ((((speedAttribute * 20) / 256) * 256) / 256) + 20;
 }
 
-int ArenaEntityUtils::getCreatureCorpseGold(int creatureLevel, Random &random)
+int ArenaEntityUtils::getCreatureGold(int creatureLevel, int creatureLootChance, Random &random)
 {
-	return (1 + random.next(11)) * (creatureLevel + 1);
+	if (1 + random.next(100) <= (creatureLootChance & 0xFF) && random.next(101) >= (creatureLootChance & 0xFF))
+	{
+		return (1 + random.next(10)) * (creatureLevel + 1);
+	}
+	else
+		return 0;
 }
 
 int ArenaEntityUtils::getCreatureItemQualityLevel(int creatureLevel)

--- a/OpenTESArena/src/Entities/ArenaEntityUtils.h
+++ b/OpenTESArena/src/Entities/ArenaEntityUtils.h
@@ -8,7 +8,7 @@ namespace ArenaEntityUtils
 	// For monsters
 	int getBaseSpeed(int speedAttribute);
 
-	int getCreatureCorpseGold(int creatureLevel, Random &random);
+	int getCreatureGold(int creatureLevel, int creatureLootChance, Random &random);
 	int getCreatureItemQualityLevel(int creatureLevel);
 }
 

--- a/OpenTESArena/src/Entities/EntityDefinition.cpp
+++ b/OpenTESArena/src/Entities/EntityDefinition.cpp
@@ -33,6 +33,8 @@ void EnemyEntityDefinition::CreatureDefinition::init(int creatureIndex, bool isF
 	const auto &srcAttributes = entities.creatureAttributes[creatureIndex];
 	std::copy(std::begin(srcAttributes), std::end(srcAttributes), std::begin(this->attributes));
 
+	this->lootChances = isFinalBoss ? 0 : entities.creatureLootChances[creatureIndex + 1]; // @todo Figure out how final boss is handled
+
 	this->ghost = ArenaAnimUtils::isGhost(creatureIndex);
 }
 

--- a/OpenTESArena/src/Entities/EntityDefinition.h
+++ b/OpenTESArena/src/Entities/EntityDefinition.h
@@ -52,6 +52,7 @@ struct EnemyEntityDefinition
 		int bloodIndex; // @todo this should be an EntityDefID to the vfx in EntityDefinitionLibrary, or -1
 		int diseaseChances;
 		int attributes[8];
+		int lootChances;
 		bool ghost;
 
 		void init(int creatureIndex, bool isFinalBoss, const ExeData &exeData);

--- a/OpenTESArena/src/Interface/GameWorldUiController.cpp
+++ b/OpenTESArena/src/Interface/GameWorldUiController.cpp
@@ -374,7 +374,8 @@ void GameWorldUiController::onEnemyCorpseInteracted(Game &game, EntityInstanceID
 
 void GameWorldUiController::onEnemyCorpseInteractedFirstTime(Game &game, EntityInstanceID entityInstID, const EntityDefinition &entityDef)
 {
-	bool isCorpseAwardingGold = true;
+	int corpseGoldCount = 0;
+	Random& random = game.random;
 
 	int creatureLevel = 1;
 	if (entityDef.type == EntityDefinitionType::Enemy)
@@ -384,18 +385,14 @@ void GameWorldUiController::onEnemyCorpseInteractedFirstTime(Game &game, EntityI
 		{
 			creatureLevel = enemyDef.creature.level;
 		}
+		corpseGoldCount = ArenaEntityUtils::getCreatureGold(creatureLevel, enemyDef.creature.lootChances, random); // @todo This should be done at creature instantiation
 	}
 
-	Random &random = game.random;
-	isCorpseAwardingGold &= random.nextBool(); // @todo figure out actual chances per enemy
-
-	if (!isCorpseAwardingGold)
+	if (corpseGoldCount == 0)
 	{
 		GameWorldUiController::onEnemyCorpseInteracted(game, entityInstID, entityDef);
 		return;
 	}
-
-	const int corpseGoldCount = ArenaEntityUtils::getCreatureCorpseGold(creatureLevel, random);
 
 	Player &player = game.player;
 	player.gold += corpseGoldCount;


### PR DESCRIPTION
Addresses the todo in `GameWorldUiController.cpp` by determining gold chance for enemies according to the original game. It also corrects the amount of gold generated.

Gold is still generated at the time an enemy corpse is clicked on, the same as before this PR. In the original game, gold is calculated at the time an enemy is instantiated. This means if you save a game with an enemy near you and then load that game, the gold or other treasure they have won't change. I put in a todo note about this.

I confirmed the behavior here matches the original game (version 1.06), but it looks like a mistake to me. Every monster has a set chance for gold and other items to appear (this PR only handles gold). This is rolled against twice, like:

```
("random_range" is exclusive of the max value)
1st roll: If random_range(1,101) <= goldChance, then do the 2nd roll.
2nd roll: If random_range(0,101) >= goldChance, then add gold.
```

Since not only do two rolls happen, but the direction of the second check is reversed, there is a low chance for monsters to have gold, especially for higher-level monsters with high goldChance values. For example, the goblin has a goldChance of 25, so basically a 0.25 x 0.75 chance, or 0.1875% chance for gold. High-level monsters have values like 90, so 0.90 x 0.10, or only a 0.09% chance for gold.

The "LootChances" that are read in from the executable to get the goldChance are 4-byte values, with the least-significant bytes being the gold chances, and the other three being for items. The items don't have to pass a second roll, they just use the `random_range(1,101) <= chance` calculation. My guess is gold probably was supposed to be the same.

At some point I would like to check things like this against version 1.07, the CD version, just in case it has undocumented bug fixes in it.