### PR TITLE
Fix newline insertion logic in distributeNewLines

### DIFF
--- a/components/utilities/String.cpp
+++ b/components/utilities/String.cpp
@@ -159,20 +159,19 @@ std::string String::distributeNewlines(const std::string &str, int charLimit)
 			mostRecentSpace = i;
 		}
 
-		// Only try to add a newline if it's not the last character.
-		if ((currentLineLength == charLimit) && (i != static_cast<int>(newStr.size() - 1)))
+		if (currentLineLength == charLimit)
 		{
 			if (mostRecentSpace == NO_SPACE)
 			{
-				newStr.insert(newStr.begin() + i + 1, String::NEWLINE);
+				newStr.insert(newStr.begin() + i, String::NEWLINE);
+				currentLineLength = -1;
 			}
 			else
 			{
 				newStr[mostRecentSpace] = String::NEWLINE;
+				currentLineLength = i - mostRecentSpace - 1;
 				mostRecentSpace = NO_SPACE;
 			}
-			
-			currentLineLength = 0;
 		}
 	}
 


### PR DESCRIPTION
Fixes #114. Also fixes a few other issues.

1. If the character limit were reached before any spaces had been encountered, the newline would have been added in the wrong place.
2. The `i != static_cast<int>(newStr.size() - 1))` would have prevented inserting a newline when the character limit was reached just before the end of the string. For example, if you called this function on a string `"ab"` with `charLimit` of 1, I think the desired outcome would be a string like `"a/nb"`, but it would have gone unmodified.