### PR TITLE
Fix(Color): Clamp ColorReal components in toRGBA()

### DIFF
--- a/OpenTESArena/src/Utilities/Color.cpp
+++ b/OpenTESArena/src/Utilities/Color.cpp
@@ -107,10 +107,11 @@ std::string ColorReal::toString() const
 
 uint32_t ColorReal::toRGBA() const
 {
-	const uint8_t r = static_cast<uint8_t>(this->r * 255.0);
-	const uint8_t g = static_cast<uint8_t>(this->g * 255.0);
-	const uint8_t b = static_cast<uint8_t>(this->b * 255.0);
-	const uint8_t a = static_cast<uint8_t>(this->a * 255.0);
+	const ColorReal clampedColor = this->clamped(0.0, 1.0);
+	const uint8_t r = static_cast<uint8_t>(clampedColor.r * 255.0);
+	const uint8_t g = static_cast<uint8_t>(clampedColor.g * 255.0);
+	const uint8_t b = static_cast<uint8_t>(clampedColor.b * 255.0);
+	const uint8_t a = static_cast<uint8_t>(clampedColor.a * 255.0);
 	return static_cast<uint32_t>(
 		(r << Endian::RGBA_RedShift) |
 		(g << Endian::RGBA_GreenShift) |


### PR DESCRIPTION
The ColorReal::toRGBA() method did not clamp the red, green, blue, and alpha components to the [0.0, 1.0] range before converting them to uint8_t. This could lead to overflow and incorrect color representation when a component value was outside this range.

This commit fixes the bug by calling the clamped() method on the ColorReal object before the conversion, ensuring that the component values are always within the valid range.