### PR TITLE
Initial enemy AI behavior

### DIFF
--- a/OpenTESArena/src/Entities/EntityAnimationInstance.cpp
+++ b/OpenTESArena/src/Entities/EntityAnimationInstance.cpp
@@ -10,6 +10,11 @@ EntityAnimationInstance::EntityAnimationInstance()
 	this->clear();
 }
 
+bool EntityAnimationInstance::isFinished() const
+{
+	return !this->isLooping && (this->progressPercent == 1.0);
+}
+
 void EntityAnimationInstance::addState(double targetSeconds, bool isLooping)
 {
 	if (this->stateCount >= MAX_STATES)

--- a/OpenTESArena/src/Entities/EntityAnimationInstance.h
+++ b/OpenTESArena/src/Entities/EntityAnimationInstance.h
@@ -20,6 +20,8 @@ struct EntityAnimationInstance
 
 	EntityAnimationInstance();
 
+	bool isFinished() const;
+
 	void addState(double targetSeconds, bool isLooping);
 
 	void setStateIndex(int index);

--- a/OpenTESArena/src/Entities/EntityChunkManager.cpp
+++ b/OpenTESArena/src/Entities/EntityChunkManager.cpp
@@ -1161,8 +1161,7 @@ void EntityChunkManager::updateCitizenStates(double dt, const WorldDouble2 &play
 				}
 			}
 
-			// Integrate by delta time.
-			const VoxelDouble2 entityVelocity = entityDir * ArenaCitizenUtils::MOVE_SPEED_PER_SECOND;
+			const Double2 entityVelocity = entityDir * ArenaCitizenUtils::MOVE_SPEED_PER_SECOND;
 			const WorldDouble2 newEntityPositionXZ = entityPositionXZ + (entityVelocity * dt);
 			entityPosition.x = newEntityPositionXZ.x;
 			entityPosition.z = newEntityPositionXZ.y;
@@ -1200,9 +1199,112 @@ void EntityChunkManager::updateEnemyStates(double dt, const WorldDouble2 &player
 		const Double2 dirToPlayer = playerPositionXZ - entityPositionXZ;
 		const double distToPlayerSqr = dirToPlayer.lengthSquared();
 
+		const EntityDefinition &entityDef = this->getEntityDef(entityInst.defID);
+		const EntityAnimationDefinition &animDef = entityDef.animDef;
+		EntityAnimationInstance &animInst = this->animInsts.get(entityInst.animInstID);
+		const int currentAnimStateIndex = animInst.currentStateIndex;
 
-		// @todo simulate enemy AI and state changes
+		const std::optional<int> idleStateIndex = animDef.findStateIndex(EntityAnimationUtils::STATE_IDLE.c_str());
+		if (!idleStateIndex.has_value())
+		{
+			DebugCrash("Couldn't get enemy idle state index.");
+		}
 
+		const std::optional<int> walkStateIndex = animDef.findStateIndex(EntityAnimationUtils::STATE_WALK.c_str());
+		if (!walkStateIndex.has_value())
+		{
+			DebugCrash("Couldn't get enemy walk state index.");
+		}
+
+		const std::optional<int> deathStateIndex = EntityUtils::tryGetDeathAnimStateIndex(animDef);
+		if (!deathStateIndex.has_value())
+		{
+			DebugCrash("Couldn't get enemy death state index.");
+		}
+
+		const bool isInDeathState = currentAnimStateIndex == *deathStateIndex; // @todo eventually this should check combatState.isInDeathState() but isDying isn't set by gameplay code yet due to existing bodyfall audio logic
+		if (isInDeathState)
+		{
+			continue;
+		}
+		
+		Double2 &entityDir = this->directions.get(entityInst.directionID);
+		EntityBehaviorState &behaviorState = this->behaviorStates.get(entityInst.behaviorStateID);
+		DebugAssert(behaviorState.type == EntityBehaviorStateType::Enemy);
+		EntityEnemyBehaviorState &enemyBehaviorState = behaviorState.enemy;
+		const EntityEnemyBehaviorStateType prevEnemyBehaviorStateType = enemyBehaviorState.type;
+
+		constexpr double detectionDistance = 3.0; // @todo split into "detection inner" and "detection outer" so there is padding between state changes
+		constexpr double attackDistance = 0.80; // @todo split into "attack inner" and "attack outer" so player can't just move 1 inch away to dodge
+		constexpr double detectionDistanceSqr = detectionDistance * detectionDistance;
+		constexpr double attackDistanceSqr = attackDistance * attackDistance;
+		const bool isCloseEnoughToDetectPlayer = distToPlayerSqr <= detectionDistanceSqr; // @todo add "isFarEnoughToStopDetectPlayer"
+		const bool isCloseEnoughToAttackPlayer = distToPlayerSqr <= attackDistanceSqr; // @todo add "isFarEnoughToStopAttackPlayer"
+
+		if (prevEnemyBehaviorStateType == EntityEnemyBehaviorStateType::Idle)
+		{
+			if (isCloseEnoughToDetectPlayer)
+			{
+				enemyBehaviorState.type = EntityEnemyBehaviorStateType::MovingToPlayer;
+				animInst.setStateIndex(*walkStateIndex);
+			}
+		}
+		else if (prevEnemyBehaviorStateType == EntityEnemyBehaviorStateType::MovingToPlayer)
+		{
+			if (isCloseEnoughToDetectPlayer)
+			{
+				entityDir = dirToPlayer;
+
+				bool isNextPositionValid = true;
+
+				// @todo check if chasm. maybe don't have to check walls because the collider will just hit it?
+
+				if (isNextPositionValid)
+				{
+					if (!isCloseEnoughToAttackPlayer)
+					{
+						if (currentAnimStateIndex != *walkStateIndex)
+						{
+							animInst.setStateIndex(*walkStateIndex);
+						}
+
+						constexpr double entityMoveSpeed = 1.50;
+						const Double2 entityVelocity = entityDir * entityMoveSpeed;
+						const WorldDouble2 newEntityPositionXZ = entityPositionXZ + (entityVelocity * dt);
+						entityPosition.x = newEntityPositionXZ.x;
+						entityPosition.z = newEntityPositionXZ.y;
+						curEntityChunkPos = VoxelUtils::worldPointToChunk(newEntityPositionXZ);
+
+						const JPH::BodyID &physicsBodyID = entityInst.physicsBodyID;
+						DebugAssert(!physicsBodyID.IsInvalid());
+
+						// @todo ideally Jolt would not let colliders overlap. maybe have to simulate with kinematics?
+						const JPH::RVec3 oldBodyPosition = bodyInterface.GetPosition(physicsBodyID);
+						const JPH::RVec3 newBodyPosition(
+							static_cast<float>(newEntityPositionXZ.x),
+							static_cast<float>(oldBodyPosition.GetY()),
+							static_cast<float>(newEntityPositionXZ.y));
+						bodyInterface.SetPosition(physicsBodyID, newBodyPosition, JPH::EActivation::Activate);
+					}
+					else
+					{
+						if (currentAnimStateIndex != *idleStateIndex)
+						{
+							animInst.setStateIndex(*idleStateIndex);
+						}
+					}
+				}
+			}
+			else
+			{
+				enemyBehaviorState.type = EntityEnemyBehaviorStateType::Idle;
+				animInst.setStateIndex(*idleStateIndex);
+			}
+		}
+		else
+		{
+			DebugNotImplemented();
+		}
 
 		if (curEntityChunkPos != prevEntityChunkPos)
 		{
@@ -1535,6 +1637,7 @@ void EntityChunkManager::updateEnemyDeathStates(JPH::PhysicsSystem &physicsSyste
 		}
 		else
 		{
+			// @todo technically they should be set dying by gameplay code (like when the player's attack is applied). This is just audio code which maybe should rely on an animation state change trigger?
 			if (!combatState.isDying)
 			{
 				combatState.isDying = true;

--- a/OpenTESArena/src/Entities/EntityChunkManager.cpp
+++ b/OpenTESArena/src/Entities/EntityChunkManager.cpp
@@ -1216,7 +1216,7 @@ void EntityChunkManager::updateEnemyStates(double dt, const WorldDouble2 &player
 			DebugCrash("Couldn't get enemy walk state index.");
 		}
 
-		const std::optional<int> deathStateIndex = EntityUtils::tryGetDeathAnimStateIndex(animDef);
+		const std::optional<int> deathStateIndex = animDef.findStateIndex(EntityAnimationUtils::STATE_DEATH.c_str());
 		if (!deathStateIndex.has_value())
 		{
 			DebugCrash("Couldn't get enemy death state index.");
@@ -1580,45 +1580,63 @@ void EntityChunkManager::updateFadedElevatedPlatforms(EntityChunk &entityChunk, 
 	}
 }
 
-void EntityChunkManager::updateEnemyDeathStates(JPH::PhysicsSystem &physicsSystem, AudioManager &audioManager)
+void EntityChunkManager::updateDeathStates(JPH::PhysicsSystem &physicsSystem, AudioManager &audioManager)
 {
 	JPH::BodyInterface &bodyInterface = physicsSystem.GetBodyInterface();
 
-	// @todo: just check an EntityChunkManager::dyingEntities list instead, added to when player swing kills them
-
+	// @todo citizens should actually leave a corpse but it's removed a moment afterwards when guards are called
+	// @todo maybe split this loop into citizenEntityInstIDs and enemyEntityInstIDs
+	
 	for (EntityInstance &entityInst : this->entities.values)
 	{
-		const EntityInstanceID entityInstID = entityInst.instanceID;
-		const EntityDefinition &entityDef = this->getEntityDef(entityInst.defID);
-		const EntityDefinitionType entityDefType = entityDef.type;
 		if (!entityInst.canBeKilledInCombat())
 		{
 			continue;
 		}
 
-		const std::optional<int> deathAnimStateIndex = EntityUtils::tryGetDeathAnimStateIndex(entityDef.animDef);
+		EntityCombatState &combatState = this->combatStates.get(entityInst.combatStateID);
+		if (!combatState.isDying)
+		{
+			continue;
+		}
+
+		const EntityInstanceID entityInstID = entityInst.instanceID;
+		const EntityDefinition &entityDef = this->getEntityDef(entityInst.defID);
+		const EntityAnimationDefinition &animDef = entityDef.animDef;
+		const std::optional<int> deathAnimStateIndex = animDef.findStateIndex(EntityAnimationUtils::STATE_DEATH.c_str());
 		if (!deathAnimStateIndex.has_value())
 		{
+			// No death animation.
+			this->queueEntityDestroy(entityInstID, true);
 			continue;
 		}
 
+		const bool entityLeavesCorpse = EntityUtils::leavesCorpse(entityDef);
 		EntityAnimationInstance &animInst = this->animInsts.get(entityInst.animInstID);
-		const bool isInDeathAnimState = animInst.currentStateIndex == *deathAnimStateIndex;
-		if (!isInDeathAnimState)
+		const bool inDeathAnim = animInst.currentStateIndex == *deathAnimStateIndex;
+		if (!inDeathAnim)
 		{
+			// Start death animation.
+			animInst.setStateIndex(*deathAnimStateIndex);
+
+			if (entityLeavesCorpse)
+			{
+				const WorldDouble3 entityPosition = this->positions.get(entityInst.positionID);
+				audioManager.playSoundOneShot(ArenaSoundName::BodyFall, entityPosition);
+			}
+
 			continue;
 		}
 
-		EntityCombatState &combatState = this->combatStates.get(entityInst.combatStateID);
-		const bool isDeathAnimComplete = animInst.progressPercent == 1.0;
-		if (isDeathAnimComplete)
+		if (animInst.isFinished())
 		{
 			if (!combatState.isDead)
 			{
+				// Entity is now a corpse.
 				combatState.isDying = false;
 				combatState.isDead = true;
 
-				if (EntityUtils::leavesCorpse(entityDef))
+				if (entityLeavesCorpse)
 				{
 					JPH::BodyID &physicsBodyID = entityInst.physicsBodyID;
 					if (!physicsBodyID.IsInvalid())
@@ -1631,21 +1649,6 @@ void EntityChunkManager::updateEnemyDeathStates(JPH::PhysicsSystem &physicsSyste
 				else
 				{
 					this->queueEntityDestroy(entityInstID, true);
-					// @todo remove from dyingEntities list once that is a thing
-				}
-			}
-		}
-		else
-		{
-			// @todo technically they should be set dying by gameplay code (like when the player's attack is applied). This is just audio code which maybe should rely on an animation state change trigger?
-			if (!combatState.isDying)
-			{
-				combatState.isDying = true;
-
-				if (EntityUtils::leavesCorpse(entityDef))
-				{
-					const WorldDouble3 entityPosition = this->positions.get(entityInst.positionID);
-					audioManager.playSoundOneShot(ArenaSoundName::BodyFall, entityPosition);
 				}
 			}
 		}
@@ -1665,8 +1668,7 @@ void EntityChunkManager::updateVfx()
 		}
 
 		const EntityAnimationInstance &animInst = this->animInsts.get(entityInst.animInstID);
-		const bool isVfxAnimComplete = animInst.progressPercent == 1.0;
-		if (isVfxAnimComplete)
+		if (animInst.isFinished())
 		{
 			this->queueEntityDestroy(entityInstID, true); // @todo shouldn't need to notify chunk, it should just be a loose entity in entitychunkmanager
 		}
@@ -1828,7 +1830,7 @@ void EntityChunkManager::update(double dt, Span<const ChunkInt2> activeChunkPosi
 	this->updateCitizenStates(dt, playerPositionXZ, isPlayerMoving, isPlayerWeaponSheathed, random, physicsSystem, voxelChunkManager);
 	this->updateEnemyStates(dt, playerPositionXZ, physicsSystem, voxelChunkManager);
 	this->updateCreatureSounds(dt, playerPosition, random, audioManager);
-	this->updateEnemyDeathStates(physicsSystem, audioManager);
+	this->updateDeathStates(physicsSystem, audioManager);
 	this->updateVfx();
 }
 

--- a/OpenTESArena/src/Entities/EntityChunkManager.cpp
+++ b/OpenTESArena/src/Entities/EntityChunkManager.cpp
@@ -1453,7 +1453,7 @@ void EntityChunkManager::getEntityObservedResult(EntityInstanceID id, const Worl
 
 	// Get animation angle based on relative facing to camera. Static entities always face the camera.
 	Radians animAngle = 0.0;
-	if (entityInst.isDynamic())
+	if (!entityInst.isTransformStatic())
 	{
 		const Double2 &entityDir = this->directions.get(entityInst.directionID);
 		const Double2 diffDir = (eyePositionXZ - entityPositionXZ).normalized();

--- a/OpenTESArena/src/Entities/EntityChunkManager.cpp
+++ b/OpenTESArena/src/Entities/EntityChunkManager.cpp
@@ -1916,7 +1916,7 @@ void EntityChunkManager::updatePrePhysicsStep(double dt, Span<const ChunkInt2> a
 	this->updateVfx();
 }
 
-void EntityChunkManager::updatePostPhysicsStep(JPH::PhysicsSystem &physicsSystem)
+void EntityChunkManager::updatePostPhysicsStep(const VoxelChunkManager &voxelChunkManager, JPH::PhysicsSystem &physicsSystem)
 {
 	JPH::BodyInterface &bodyInterface = physicsSystem.GetBodyInterface();
 
@@ -1936,22 +1936,45 @@ void EntityChunkManager::updatePostPhysicsStep(JPH::PhysicsSystem &physicsSystem
 		const float physicsColliderHeight = physicsColliderBBox.GetSize().GetY();
 		const float physicsColliderCenterToFeetDistance = physicsColliderHeight * 0.50f;
 
-		WorldDouble3 &entityPosition = this->positions.get(entityInst.positionID);
-		const WorldDouble3 oldPosition = entityPosition;
-		const WorldDouble3 newPosition(
-			static_cast<SNDouble>(physicsPosition.GetX()),
-			static_cast<double>(physicsPosition.GetY() - physicsColliderCenterToFeetDistance),
-			static_cast<WEDouble>(physicsPosition.GetZ()));
-		entityPosition = newPosition;
+		const CoordDouble2 physicsCoord = VoxelUtils::worldPointToCoord(WorldDouble2(physicsPosition.GetX(), physicsPosition.GetZ()));
+		const VoxelChunk *physicsVoxelChunk = voxelChunkManager.findChunkAtPosition(physicsCoord.chunk);
 
-		const WorldDouble2 oldPositionXZ = oldPosition.getXZ();
-		const WorldDouble2 newPositionXZ = newPosition.getXZ();
-
-		const ChunkInt2 prevEntityChunkPos = VoxelUtils::worldPointToChunk(oldPositionXZ);
-		const ChunkInt2 curEntityChunkPos = VoxelUtils::worldPointToChunk(newPositionXZ);
-		if (curEntityChunkPos != prevEntityChunkPos)
+		bool isPhysicsPositionOverChasm = false;
+		if (physicsVoxelChunk != nullptr)
 		{
-			this->queueEntityTransfer(entityInstID, prevEntityChunkPos, curEntityChunkPos);
+			const VoxelInt2 physicsVoxelXZ = VoxelUtils::pointToVoxel(physicsCoord.point);
+			const VoxelInt3 physicsFloorVoxel(physicsVoxelXZ.x, 0, physicsVoxelXZ.y);
+
+			const VoxelTraitsDefID physicsFloorVoxelTraitsDefID = physicsVoxelChunk->traitsDefIDs.get(physicsFloorVoxel.x, physicsFloorVoxel.y, physicsFloorVoxel.z);
+			DebugAssertIndex(physicsVoxelChunk->traitsDefs, physicsFloorVoxelTraitsDefID);
+			const VoxelTraitsDefinition &attemptedNextFloorVoxelTraitsDef = physicsVoxelChunk->traitsDefs[physicsFloorVoxelTraitsDefID];
+			isPhysicsPositionOverChasm = attemptedNextFloorVoxelTraitsDef.type == ArenaVoxelType::Chasm;
+		}
+
+		WorldDouble3 &entityPosition = this->positions.get(entityInst.positionID);
+		if (isPhysicsPositionOverChasm)
+		{
+			const JPH::RVec3 rewindedPhysicsPosition(entityPosition.x, physicsPosition.GetY(), entityPosition.z);
+			bodyInterface.SetPosition(physicsBodyID, rewindedPhysicsPosition, JPH::EActivation::Activate);
+		}
+		else
+		{
+			const WorldDouble3 oldPosition = entityPosition;
+			const WorldDouble3 newPosition(
+				static_cast<SNDouble>(physicsPosition.GetX()),
+				static_cast<double>(physicsPosition.GetY() - physicsColliderCenterToFeetDistance),
+				static_cast<WEDouble>(physicsPosition.GetZ()));
+			entityPosition = newPosition;
+
+			const WorldDouble2 oldPositionXZ = oldPosition.getXZ();
+			const WorldDouble2 newPositionXZ = newPosition.getXZ();
+
+			const ChunkInt2 prevEntityChunkPos = VoxelUtils::worldPointToChunk(oldPositionXZ);
+			const ChunkInt2 curEntityChunkPos = VoxelUtils::worldPointToChunk(newPositionXZ);
+			if (curEntityChunkPos != prevEntityChunkPos)
+			{
+				this->queueEntityTransfer(entityInstID, prevEntityChunkPos, curEntityChunkPos);
+			}
 		}
 	}
 

--- a/OpenTESArena/src/Entities/EntityChunkManager.cpp
+++ b/OpenTESArena/src/Entities/EntityChunkManager.cpp
@@ -1008,7 +1008,7 @@ void EntityChunkManager::queueEntityTransfer(EntityInstanceID entityInstID, Chun
 	}
 }
 
-void EntityChunkManager::updateCitizenStates(double dt, const WorldDouble2 &playerPositionXZ, bool isPlayerMoving, bool isPlayerWeaponSheathed,
+void EntityChunkManager::updateCitizenBehaviors(double dt, const WorldDouble2 &playerPositionXZ, bool isPlayerMoving, bool isPlayerWeaponSheathed,
 	Random &random, JPH::PhysicsSystem &physicsSystem, const VoxelChunkManager &voxelChunkManager)
 {
 	JPH::BodyInterface &bodyInterface = physicsSystem.GetBodyInterface();
@@ -1185,7 +1185,7 @@ void EntityChunkManager::updateCitizenStates(double dt, const WorldDouble2 &play
 	}
 }
 
-void EntityChunkManager::updateEnemyStates(double dt, const WorldDouble2 &playerPositionXZ, JPH::PhysicsSystem &physicsSystem, const VoxelChunkManager &voxelChunkManager)
+void EntityChunkManager::updateEnemyBehaviors(double dt, const WorldDouble2 &playerPositionXZ, JPH::PhysicsSystem &physicsSystem, const VoxelChunkManager &voxelChunkManager)
 {
 	JPH::BodyInterface &bodyInterface = physicsSystem.GetBodyInterface();
 
@@ -1827,8 +1827,8 @@ void EntityChunkManager::update(double dt, Span<const ChunkInt2> activeChunkPosi
 		animInst.update(dt);
 	}
 
-	this->updateCitizenStates(dt, playerPositionXZ, isPlayerMoving, isPlayerWeaponSheathed, random, physicsSystem, voxelChunkManager);
-	this->updateEnemyStates(dt, playerPositionXZ, physicsSystem, voxelChunkManager);
+	this->updateCitizenBehaviors(dt, playerPositionXZ, isPlayerMoving, isPlayerWeaponSheathed, random, physicsSystem, voxelChunkManager);
+	this->updateEnemyBehaviors(dt, playerPositionXZ, physicsSystem, voxelChunkManager);
 	this->updateCreatureSounds(dt, playerPosition, random, audioManager);
 	this->updateDeathStates(physicsSystem, audioManager);
 	this->updateVfx();

--- a/OpenTESArena/src/Entities/EntityChunkManager.cpp
+++ b/OpenTESArena/src/Entities/EntityChunkManager.cpp
@@ -136,6 +136,12 @@ namespace
 		const double shapeYPos = voxelShapeDef.box.yOffset + voxelShapeDef.box.height;
 		return MeshUtils::getScaledVertexY(shapeYPos, voxelShapeDef.scaleType, ceilingScale);
 	}
+
+	double GetEnemyNextWeaponSwingSeconds(Random &random)
+	{
+		// Arbitrary timing, tbd difficulty settings
+		return random.nextReal() * 0.75;
+	}
 }
 
 EntityCitizenName::EntityCitizenName(const char *name)
@@ -162,6 +168,7 @@ EntityEnemyBehaviorState::EntityEnemyBehaviorState()
 {
 	this->type = static_cast<EntityEnemyBehaviorStateType>(-1);
 	this->secondsTillNextCreatureSound = 0.0;
+	this->secondsTillNextAttack = 0.0;
 }
 
 EntityCitizenBehaviorState::EntityCitizenBehaviorState()
@@ -1193,7 +1200,8 @@ void EntityChunkManager::updateCitizenBehaviors(double dt, const WorldDouble2 &p
 	}
 }
 
-void EntityChunkManager::updateEnemyBehaviors(double dt, const WorldDouble2 &playerPositionXZ, JPH::PhysicsSystem &physicsSystem, const VoxelChunkManager &voxelChunkManager)
+void EntityChunkManager::updateEnemyBehaviors(double dt, const WorldDouble2 &playerPositionXZ, Player &player, Random &random,
+	JPH::PhysicsSystem &physicsSystem, const VoxelChunkManager &voxelChunkManager)
 {
 	JPH::BodyInterface &bodyInterface = physicsSystem.GetBodyInterface();
 
@@ -1227,6 +1235,12 @@ void EntityChunkManager::updateEnemyBehaviors(double dt, const WorldDouble2 &pla
 		{
 			DebugCrash("Couldn't get enemy walk state index.");
 		}
+
+		const std::optional<int> attackStateIndex = animDef.findStateIndex(EntityAnimationUtils::STATE_ATTACK.c_str());
+		if (!attackStateIndex.has_value())
+		{
+			DebugCrash("Couldn't get enemy attack state index.");
+		}
 		
 		Double2 &entityDir = this->directions.get(entityInst.directionID);
 		EntityBehaviorState &behaviorState = this->behaviorStates.get(entityInst.behaviorStateID);
@@ -1243,11 +1257,13 @@ void EntityChunkManager::updateEnemyBehaviors(double dt, const WorldDouble2 &pla
 
 		if (prevEnemyBehaviorStateType == EntityEnemyBehaviorStateType::Idle)
 		{
-			if (isCloseEnoughToDetectPlayer)
+			if (!isCloseEnoughToDetectPlayer)
 			{
-				enemyBehaviorState.type = EntityEnemyBehaviorStateType::MovingToPlayer;
-				animInst.setStateIndex(*walkStateIndex);
+				continue;
 			}
+
+			enemyBehaviorState.type = EntityEnemyBehaviorStateType::MovingToPlayer;
+			animInst.setStateIndex(*walkStateIndex);
 		}
 		else if (prevEnemyBehaviorStateType == EntityEnemyBehaviorStateType::MovingToPlayer)
 		{
@@ -1290,6 +1306,8 @@ void EntityChunkManager::updateEnemyBehaviors(double dt, const WorldDouble2 &pla
 				continue;
 			}
 
+			// @todo they currently get stuck attempting to move into a chasm even when player is close enough to attack
+
 			if (!isCloseEnoughToAttackPlayer)
 			{
 				if (currentAnimStateIndex != *walkStateIndex)
@@ -1302,14 +1320,67 @@ void EntityChunkManager::updateEnemyBehaviors(double dt, const WorldDouble2 &pla
 				continue;
 			}
 
-			if (currentAnimStateIndex != *idleStateIndex)
+			enemyBehaviorState.type = EntityEnemyBehaviorStateType::AttackPlayer;
+			enemyBehaviorState.secondsTillNextAttack = GetEnemyNextWeaponSwingSeconds(random);
+			animInst.setStateIndex(*idleStateIndex);
+			bodyInterface.SetLinearVelocity(physicsBodyID, JPH::RVec3::sZero());
+		}
+		else if (prevEnemyBehaviorStateType == EntityEnemyBehaviorStateType::AttackPlayer)
+		{
+			entityDir = dirToPlayer;
+
+			if (currentAnimStateIndex != *attackStateIndex)
 			{
-				animInst.setStateIndex(*idleStateIndex);
-				bodyInterface.SetLinearVelocity(physicsBodyID, JPH::RVec3::sZero());
+				if (!isCloseEnoughToAttackPlayer)
+				{
+					enemyBehaviorState.secondsTillNextAttack = 0.0;
+					enemyBehaviorState.type = EntityEnemyBehaviorStateType::MovingToPlayer;
+					animInst.setStateIndex(*walkStateIndex);
+					continue;
+				}
+
+				enemyBehaviorState.secondsTillNextAttack -= dt;
+				if (enemyBehaviorState.secondsTillNextAttack > 0.0)
+				{
+					continue;
+				}
+
+				enemyBehaviorState.secondsTillNextAttack = 0.0;
+				animInst.setStateIndex(*attackStateIndex);
+				continue;
 			}
 
-			// @todo the goal of this state is to get close enough to the player to attack them
-			// @todo set random attack seconds and once that time is hit, change to attack animation
+			const bool isHitAllowed = animInst.isFinished(); // @todo check if > 0.50 progress and check !hasAttemptedHit
+			if (isHitAllowed)
+			{
+				// @todo set hasAttemptedHit = true
+
+				if (isCloseEnoughToAttackPlayer)
+				{
+					const double damageAmount = random.nextReal() * 3.0; // @todo depend on original enemy values (entity def?)
+					player.currentHealth = std::max(player.currentHealth - damageAmount, 0.0);
+					
+					// @todo audio trigger, maybe want to set a bool true here and do after the enemy loop? or maybe we want every hit to play (3d position of each source matters for gameplay)
+				}
+			}
+
+			const bool isSwingFinished = animInst.isFinished();
+			if (!isSwingFinished)
+			{
+				continue;
+			}
+
+			if (!isCloseEnoughToAttackPlayer)
+			{
+				enemyBehaviorState.type = EntityEnemyBehaviorStateType::MovingToPlayer;
+				animInst.setStateIndex(*walkStateIndex);
+				continue;
+			}
+
+			enemyBehaviorState.secondsTillNextAttack = GetEnemyNextWeaponSwingSeconds(random);
+			animInst.setStateIndex(*idleStateIndex);
+
+			// @todo set hasAttemptedHit = false
 		}
 		else
 		{
@@ -1756,11 +1827,11 @@ void EntityChunkManager::setCitizenBehaviorState(EntityInstanceID id, EntityCiti
 }
 
 void EntityChunkManager::updatePrePhysicsStep(double dt, Span<const ChunkInt2> activeChunkPositions, Span<const ChunkInt2> newChunkPositions,
-	Span<const ChunkInt2> freedChunkPositions, const Player &player, const LevelDefinition *activeLevelDef,
-	const LevelInfoDefinition *activeLevelInfoDef, const MapSubDefinition &mapSubDef, Span<const LevelDefinition> levelDefs,
-	Span<const int> levelInfoDefIndices, Span<const LevelInfoDefinition> levelInfoDefs, const EntityGenInfo &entityGenInfo,
-	const std::optional<CitizenGenInfo> &citizenGenInfo, double ceilingScale, Random &random, const VoxelChunkManager &voxelChunkManager,
-	AudioManager &audioManager, JPH::PhysicsSystem &physicsSystem, TextureManager &textureManager, Renderer &renderer)
+	Span<const ChunkInt2> freedChunkPositions, Player &player, const LevelDefinition *activeLevelDef, const LevelInfoDefinition *activeLevelInfoDef,
+	const MapSubDefinition &mapSubDef, Span<const LevelDefinition> levelDefs, Span<const int> levelInfoDefIndices,
+	Span<const LevelInfoDefinition> levelInfoDefs, const EntityGenInfo &entityGenInfo, const std::optional<CitizenGenInfo> &citizenGenInfo,
+	double ceilingScale, Random &random, const VoxelChunkManager &voxelChunkManager, AudioManager &audioManager, JPH::PhysicsSystem &physicsSystem,
+	TextureManager &textureManager, Renderer &renderer)
 {
 	const EntityDefinitionLibrary &entityDefLibrary = EntityDefinitionLibrary::getInstance();
 
@@ -1833,7 +1904,7 @@ void EntityChunkManager::updatePrePhysicsStep(double dt, Span<const ChunkInt2> a
 	}
 
 	this->updateCitizenBehaviors(dt, playerPositionXZ, isPlayerMoving, isPlayerWeaponSheathed, random, physicsSystem, voxelChunkManager);
-	this->updateEnemyBehaviors(dt, playerPositionXZ, physicsSystem, voxelChunkManager);
+	this->updateEnemyBehaviors(dt, playerPositionXZ, player, random, physicsSystem, voxelChunkManager);
 	this->updateCreatureSounds(dt, playerPosition, random, audioManager);
 	this->updateDeathStates(physicsSystem, audioManager);
 	this->updateVfx();

--- a/OpenTESArena/src/Entities/EntityChunkManager.cpp
+++ b/OpenTESArena/src/Entities/EntityChunkManager.cpp
@@ -65,13 +65,15 @@ namespace
 			static_cast<float>(feetPosition.z));
 		const JPH::Quat capsuleJoltQuat = JPH::Quat::sRotation(JPH::Vec3Arg::sAxisY(), 0.0f);
 		const JPH::ObjectLayer capsuleObjectLayer = isSensor ? PhysicsLayers::SENSOR : PhysicsLayers::MOVING;
-		JPH::BodyCreationSettings capsuleSettings(capsuleShape, capsuleJoltPos, capsuleJoltQuat, JPH::EMotionType::Kinematic, capsuleObjectLayer);
+		JPH::BodyCreationSettings capsuleSettings(capsuleShape, capsuleJoltPos, capsuleJoltQuat, JPH::EMotionType::Dynamic, capsuleObjectLayer);
 		capsuleSettings.mIsSensor = isSensor;
 
-		if (isCharacter) // Enemies/citizens.
+		if (isCharacter) // Enemies.
 		{
+			capsuleSettings.mAllowedDOFs = JPH::EAllowedDOFs::TranslationX | JPH::EAllowedDOFs::TranslationZ; // Constant Y position.
 			capsuleSettings.mAllowSleeping = false;
-			capsuleSettings.mLinearDamping = 0.0f;
+			capsuleSettings.mFriction = 1.0f;
+			capsuleSettings.mLinearDamping = 10.0f; // Avoid sliding.
 			capsuleSettings.mGravityFactor = 0.0f;
 		}
 

--- a/OpenTESArena/src/Entities/EntityChunkManager.cpp
+++ b/OpenTESArena/src/Entities/EntityChunkManager.cpp
@@ -37,7 +37,7 @@
 
 namespace
 {
-	bool TryCreatePhysicsCollider(const WorldDouble3 &feetPosition, double colliderHeight, bool isSensor, JPH::PhysicsSystem &physicsSystem, JPH::BodyID *outBodyID)
+	bool TryCreatePhysicsCollider(const WorldDouble3 &feetPosition, double colliderHeight, bool isCharacter, bool isSensor, JPH::PhysicsSystem &physicsSystem, JPH::BodyID *outBodyID)
 	{
 		JPH::BodyInterface &bodyInterface = physicsSystem.GetBodyInterface();
 
@@ -54,7 +54,7 @@ namespace
 		JPH::ShapeSettings::ShapeResult capsuleShapeResult = capsuleShapeSettings.Create();
 		if (capsuleShapeResult.HasError())
 		{
-			DebugLogError("Couldn't create Jolt capsule shape settings: " + std::string(capsuleShapeResult.GetError().c_str()));
+			DebugLogErrorFormat("Couldn't create Jolt capsule shape settings: %s", capsuleShapeResult.GetError().c_str());
 			return false;
 		}
 
@@ -68,11 +68,18 @@ namespace
 		JPH::BodyCreationSettings capsuleSettings(capsuleShape, capsuleJoltPos, capsuleJoltQuat, JPH::EMotionType::Kinematic, capsuleObjectLayer);
 		capsuleSettings.mIsSensor = isSensor;
 
+		if (isCharacter) // Enemies/citizens.
+		{
+			capsuleSettings.mAllowSleeping = false;
+			capsuleSettings.mLinearDamping = 0.0f;
+			capsuleSettings.mGravityFactor = 0.0f;
+		}
+
 		const JPH::Body *capsule = bodyInterface.CreateBody(capsuleSettings);
 		if (capsule == nullptr)
 		{
 			const uint32_t totalBodyCount = physicsSystem.GetNumBodies();
-			DebugLogError("Couldn't create Jolt body for entity (total: " + std::to_string(totalBodyCount) + ").");
+			DebugLogErrorFormat("Couldn't create Jolt body for entity (total: %d).", totalBodyCount);
 			return false;
 		}
 
@@ -337,12 +344,12 @@ void EntityChunkManager::initializeEntity(EntityInstance &entityInst, EntityInst
 
 	animInst.setStateIndex(initInfo.initialAnimStateIndex);
 
-	if (!TryCreatePhysicsCollider(entityPosition, animMaxHeight, initInfo.isSensorCollider, physicsSystem, &entityInst.physicsBodyID))
+	const bool hasBehavior = initInfo.canBeKilled;
+	if (!TryCreatePhysicsCollider(entityPosition, animMaxHeight, hasBehavior, initInfo.isSensorCollider, physicsSystem, &entityInst.physicsBodyID))
 	{
 		DebugLogError("Couldn't allocate entity Jolt physics body.");
 	}
 
-	const bool hasBehavior = initInfo.canBeKilled;
 	if (hasBehavior)
 	{
 		entityInst.behaviorStateID = this->behaviorStates.alloc();

--- a/OpenTESArena/src/Entities/EntityChunkManager.cpp
+++ b/OpenTESArena/src/Entities/EntityChunkManager.cpp
@@ -1202,8 +1202,6 @@ void EntityChunkManager::updateEnemyBehaviors(double dt, const WorldDouble2 &pla
 		const EntityInstance &entityInst = this->entities.get(entityInstID);
 		WorldDouble3 &entityPosition = this->positions.get(entityInst.positionID);
 		const WorldDouble2 entityPositionXZ = entityPosition.getXZ();
-		const ChunkInt2 prevEntityChunkPos = VoxelUtils::worldPointToChunk(entityPositionXZ);
-		ChunkInt2 curEntityChunkPos = prevEntityChunkPos; // Potentially updated by entity movement.
 		const Double2 dirToPlayer = playerPositionXZ - entityPositionXZ;
 		const double distToPlayerSqr = dirToPlayer.lengthSquared();
 
@@ -1259,6 +1257,9 @@ void EntityChunkManager::updateEnemyBehaviors(double dt, const WorldDouble2 &pla
 		}
 		else if (prevEnemyBehaviorStateType == EntityEnemyBehaviorStateType::MovingToPlayer)
 		{
+			const JPH::BodyID &physicsBodyID = entityInst.physicsBodyID;
+			DebugAssert(!physicsBodyID.IsInvalid());
+
 			if (isCloseEnoughToDetectPlayer)
 			{
 				entityDir = dirToPlayer;
@@ -1277,28 +1278,17 @@ void EntityChunkManager::updateEnemyBehaviors(double dt, const WorldDouble2 &pla
 						}
 
 						constexpr double entityMoveSpeed = 1.50;
-						const Double2 entityVelocity = entityDir * entityMoveSpeed;
-						const WorldDouble2 newEntityPositionXZ = entityPositionXZ + (entityVelocity * dt);
-						entityPosition.x = newEntityPositionXZ.x;
-						entityPosition.z = newEntityPositionXZ.y;
-						curEntityChunkPos = VoxelUtils::worldPointToChunk(newEntityPositionXZ);
+						const Double2 entityVelocity = entityDir * entityMoveSpeed;						
 
-						const JPH::BodyID &physicsBodyID = entityInst.physicsBodyID;
-						DebugAssert(!physicsBodyID.IsInvalid());
-
-						// @todo ideally Jolt would not let colliders overlap. maybe have to simulate with kinematics?
-						const JPH::RVec3 oldBodyPosition = bodyInterface.GetPosition(physicsBodyID);
-						const JPH::RVec3 newBodyPosition(
-							static_cast<float>(newEntityPositionXZ.x),
-							static_cast<float>(oldBodyPosition.GetY()),
-							static_cast<float>(newEntityPositionXZ.y));
-						bodyInterface.SetPosition(physicsBodyID, newBodyPosition, JPH::EActivation::Activate);
+						const JPH::RVec3 physicsVelocity(static_cast<float>(entityVelocity.x), 0.0f, static_cast<float>(entityVelocity.y));
+						bodyInterface.SetLinearVelocity(physicsBodyID, physicsVelocity);
 					}
 					else
 					{
 						if (currentAnimStateIndex != *idleStateIndex)
 						{
 							animInst.setStateIndex(*idleStateIndex);
+							bodyInterface.SetLinearVelocity(physicsBodyID, JPH::RVec3::sZero());
 						}
 					}
 				}
@@ -1307,16 +1297,12 @@ void EntityChunkManager::updateEnemyBehaviors(double dt, const WorldDouble2 &pla
 			{
 				enemyBehaviorState.type = EntityEnemyBehaviorStateType::Idle;
 				animInst.setStateIndex(*idleStateIndex);
+				bodyInterface.SetLinearVelocity(physicsBodyID, JPH::RVec3::sZero());
 			}
 		}
 		else
 		{
-			DebugNotImplemented();
-		}
-
-		if (curEntityChunkPos != prevEntityChunkPos)
-		{
-			this->queueEntityTransfer(entityInstID, prevEntityChunkPos, curEntityChunkPos);
+			DebugNotImplementedMsg(std::to_string(static_cast<int>(prevEnemyBehaviorStateType)));
 		}
 	}
 }
@@ -1758,7 +1744,7 @@ void EntityChunkManager::setCitizenBehaviorState(EntityInstanceID id, EntityCiti
 	}
 }
 
-void EntityChunkManager::update(double dt, Span<const ChunkInt2> activeChunkPositions, Span<const ChunkInt2> newChunkPositions,
+void EntityChunkManager::updatePrePhysicsStep(double dt, Span<const ChunkInt2> activeChunkPositions, Span<const ChunkInt2> newChunkPositions,
 	Span<const ChunkInt2> freedChunkPositions, const Player &player, const LevelDefinition *activeLevelDef,
 	const LevelInfoDefinition *activeLevelInfoDef, const MapSubDefinition &mapSubDef, Span<const LevelDefinition> levelDefs,
 	Span<const int> levelInfoDefIndices, Span<const LevelInfoDefinition> levelInfoDefs, const EntityGenInfo &entityGenInfo,
@@ -1840,6 +1826,48 @@ void EntityChunkManager::update(double dt, Span<const ChunkInt2> activeChunkPosi
 	this->updateCreatureSounds(dt, playerPosition, random, audioManager);
 	this->updateDeathStates(physicsSystem, audioManager);
 	this->updateVfx();
+}
+
+void EntityChunkManager::updatePostPhysicsStep(JPH::PhysicsSystem &physicsSystem)
+{
+	JPH::BodyInterface &bodyInterface = physicsSystem.GetBodyInterface();
+
+	for (const EntityInstanceID entityInstID : this->enemyEntityInstIDs)
+	{
+		EntityInstance &entityInst = this->entities.get(entityInstID);
+		const EntityCombatState &combatState = this->combatStates.get(entityInst.combatStateID);
+		if (combatState.isInDeathState())
+		{
+			continue;
+		}
+
+		const JPH::BodyID &physicsBodyID = entityInst.physicsBodyID;
+		const JPH::RVec3 physicsPosition = bodyInterface.GetPosition(physicsBodyID);
+		const JPH::ShapeRefC physicsShape = bodyInterface.GetShape(physicsBodyID);
+		const JPH::AABox physicsColliderBBox = physicsShape->GetLocalBounds();
+		const float physicsColliderHeight = physicsColliderBBox.GetSize().GetY();
+		const float physicsColliderCenterToFeetDistance = physicsColliderHeight * 0.50f;
+
+		WorldDouble3 &entityPosition = this->positions.get(entityInst.positionID);
+		const WorldDouble3 oldPosition = entityPosition;
+		const WorldDouble3 newPosition(
+			static_cast<SNDouble>(physicsPosition.GetX()),
+			static_cast<double>(physicsPosition.GetY() - physicsColliderCenterToFeetDistance),
+			static_cast<WEDouble>(physicsPosition.GetZ()));
+		entityPosition = newPosition;
+
+		const WorldDouble2 oldPositionXZ = oldPosition.getXZ();
+		const WorldDouble2 newPositionXZ = newPosition.getXZ();
+
+		const ChunkInt2 prevEntityChunkPos = VoxelUtils::worldPointToChunk(oldPositionXZ);
+		const ChunkInt2 curEntityChunkPos = VoxelUtils::worldPointToChunk(newPositionXZ);
+		if (curEntityChunkPos != prevEntityChunkPos)
+		{
+			this->queueEntityTransfer(entityInstID, prevEntityChunkPos, curEntityChunkPos);
+		}
+	}
+
+	// @todo add citizens here once they are using linear velocity instead of SetPosition()
 }
 
 void EntityChunkManager::queueEntityDestroy(EntityInstanceID entityInstID, const ChunkInt2 *chunkToNotify)

--- a/OpenTESArena/src/Entities/EntityChunkManager.cpp
+++ b/OpenTESArena/src/Entities/EntityChunkManager.cpp
@@ -1200,6 +1200,12 @@ void EntityChunkManager::updateEnemyBehaviors(double dt, const WorldDouble2 &pla
 	for (const EntityInstanceID entityInstID : this->enemyEntityInstIDs)
 	{
 		const EntityInstance &entityInst = this->entities.get(entityInstID);
+		const EntityCombatState &combatState = this->combatStates.get(entityInst.combatStateID);
+		if (combatState.isInDeathState())
+		{
+			continue;
+		}
+
 		WorldDouble3 &entityPosition = this->positions.get(entityInst.positionID);
 		const WorldDouble2 entityPositionXZ = entityPosition.getXZ();
 		const Double2 dirToPlayer = playerPositionXZ - entityPositionXZ;
@@ -1220,18 +1226,6 @@ void EntityChunkManager::updateEnemyBehaviors(double dt, const WorldDouble2 &pla
 		if (!walkStateIndex.has_value())
 		{
 			DebugCrash("Couldn't get enemy walk state index.");
-		}
-
-		const std::optional<int> deathStateIndex = animDef.findStateIndex(EntityAnimationUtils::STATE_DEATH.c_str());
-		if (!deathStateIndex.has_value())
-		{
-			DebugCrash("Couldn't get enemy death state index.");
-		}
-
-		const bool isInDeathState = currentAnimStateIndex == *deathStateIndex; // @todo eventually this should check combatState.isInDeathState() but isDying isn't set by gameplay code yet due to existing bodyfall audio logic
-		if (isInDeathState)
-		{
-			continue;
 		}
 		
 		Double2 &entityDir = this->directions.get(entityInst.directionID);

--- a/OpenTESArena/src/Entities/EntityChunkManager.cpp
+++ b/OpenTESArena/src/Entities/EntityChunkManager.cpp
@@ -1281,41 +1281,34 @@ void EntityChunkManager::updateEnemyBehaviors(double dt, const WorldDouble2 &pla
 				continue;
 			}
 
-			entityDir = dirToPlayer;
-
-			constexpr double entityMoveSpeed = 1.50;
-			const Double2 entityVelocity = entityDir * entityMoveSpeed;
-
-			const WorldDouble2 attemptedNextPosition = entityPositionXZ + (entityVelocity * dt);
-			const CoordDouble2 attemptedNextCoord = VoxelUtils::worldPointToCoord(attemptedNextPosition);
-			const VoxelChunk *attemptedNextVoxelChunk = voxelChunkManager.findChunkAtPosition(attemptedNextCoord.chunk);
-
-			bool isAttemptedNextPositionValid = false;
-			if (attemptedNextVoxelChunk != nullptr)
-			{
-				const VoxelInt2 attemptedNextVoxelXZ = VoxelUtils::pointToVoxel(attemptedNextCoord.point);
-				const VoxelInt3 attemptedNextFloorVoxel(attemptedNextVoxelXZ.x, 0, attemptedNextVoxelXZ.y);
-
-				const VoxelTraitsDefID attemptedNextFloorVoxelTraitsDefID = attemptedNextVoxelChunk->traitsDefIDs.get(attemptedNextFloorVoxel.x, attemptedNextFloorVoxel.y, attemptedNextFloorVoxel.z);
-				DebugAssertIndex(attemptedNextVoxelChunk->traitsDefs, attemptedNextFloorVoxelTraitsDefID);
-				const VoxelTraitsDefinition &attemptedNextFloorVoxelTraitsDef = attemptedNextVoxelChunk->traitsDefs[attemptedNextFloorVoxelTraitsDefID];
-				isAttemptedNextPositionValid = attemptedNextFloorVoxelTraitsDef.type == ArenaVoxelType::Floor;
-			}
-
-			if (!isAttemptedNextPositionValid)
-			{
-				// Okay to stay in walk animation if being kept from going into chasm.
-				bodyInterface.SetLinearVelocity(physicsBodyID, JPH::RVec3::sZero());
-				continue;
-			}
-
-			// @todo they currently get stuck attempting to move into a chasm even when player is close enough to attack
-
 			if (!isCloseEnoughToAttackPlayer)
 			{
-				if (currentAnimStateIndex != *walkStateIndex)
+				entityDir = dirToPlayer;
+
+				constexpr double entityMoveSpeed = 1.50;
+				const Double2 entityVelocity = entityDir * entityMoveSpeed;
+
+				const WorldDouble2 attemptedNextPosition = entityPositionXZ + (entityVelocity * dt);
+				const CoordDouble2 attemptedNextCoord = VoxelUtils::worldPointToCoord(attemptedNextPosition);
+				const VoxelChunk *attemptedNextVoxelChunk = voxelChunkManager.findChunkAtPosition(attemptedNextCoord.chunk);
+
+				bool isAttemptedNextPositionValid = false;
+				if (attemptedNextVoxelChunk != nullptr)
 				{
-					animInst.setStateIndex(*walkStateIndex);
+					const VoxelInt2 attemptedNextVoxelXZ = VoxelUtils::pointToVoxel(attemptedNextCoord.point);
+					const VoxelInt3 attemptedNextFloorVoxel(attemptedNextVoxelXZ.x, 0, attemptedNextVoxelXZ.y);
+
+					const VoxelTraitsDefID attemptedNextFloorVoxelTraitsDefID = attemptedNextVoxelChunk->traitsDefIDs.get(attemptedNextFloorVoxel.x, attemptedNextFloorVoxel.y, attemptedNextFloorVoxel.z);
+					DebugAssertIndex(attemptedNextVoxelChunk->traitsDefs, attemptedNextFloorVoxelTraitsDefID);
+					const VoxelTraitsDefinition &attemptedNextFloorVoxelTraitsDef = attemptedNextVoxelChunk->traitsDefs[attemptedNextFloorVoxelTraitsDefID];
+					isAttemptedNextPositionValid = attemptedNextFloorVoxelTraitsDef.type == ArenaVoxelType::Floor;
+				}
+
+				if (!isAttemptedNextPositionValid)
+				{
+					// Okay to stay in walk animation if being kept from going into chasm.
+					bodyInterface.SetLinearVelocity(physicsBodyID, JPH::RVec3::sZero());
+					continue;
 				}
 
 				const JPH::RVec3 physicsVelocity(static_cast<float>(entityVelocity.x), 0.0f, static_cast<float>(entityVelocity.y));

--- a/OpenTESArena/src/Entities/EntityChunkManager.cpp
+++ b/OpenTESArena/src/Entities/EntityChunkManager.cpp
@@ -20,6 +20,7 @@
 #include "../Math/RandomUtils.h"
 #include "../Math/Random.h"
 #include "../Player/Player.h"
+#include "../Player/PlayerLogic.h"
 #include "../Player/WeaponAnimationLibrary.h"
 #include "../Rendering/Renderer.h"
 #include "../Voxels/VoxelChunk.h"
@@ -1525,7 +1526,7 @@ void EntityChunkManager::updateCreatureSounds(double dt, const WorldDouble3 &pla
 			const WorldDouble3 entityPosition = this->positions.get(entityInst.positionID);
 			const BoundingBox3D &entityBBox = this->boundingBoxes.get(entityInst.bboxID);
 			const WorldDouble3 entitySoundPosition(entityPosition.x, entityPosition.y + entityBBox.halfHeight, entityPosition.z);
-			if (EntityUtils::withinHearingDistance(playerPosition, entitySoundPosition))
+			if (PlayerLogic::canHearCreatureSound(playerPosition, entitySoundPosition))
 			{
 				// @todo: store some kind of sound def ID w/ the secondsTillCreatureSound instead of generating the sound filename here.
 				const std::string creatureSoundFilename = this->getCreatureSoundFilename(entityInst.defID);

--- a/OpenTESArena/src/Entities/EntityChunkManager.cpp
+++ b/OpenTESArena/src/Entities/EntityChunkManager.cpp
@@ -169,6 +169,7 @@ EntityEnemyBehaviorState::EntityEnemyBehaviorState()
 	this->type = static_cast<EntityEnemyBehaviorStateType>(-1);
 	this->secondsTillNextCreatureSound = 0.0;
 	this->secondsTillNextAttack = 0.0;
+	this->hasAttemptedHit = false;
 }
 
 EntityCitizenBehaviorState::EntityCitizenBehaviorState()
@@ -1201,7 +1202,7 @@ void EntityChunkManager::updateCitizenBehaviors(double dt, const WorldDouble2 &p
 }
 
 void EntityChunkManager::updateEnemyBehaviors(double dt, const WorldDouble2 &playerPositionXZ, Player &player, Random &random,
-	JPH::PhysicsSystem &physicsSystem, const VoxelChunkManager &voxelChunkManager)
+	JPH::PhysicsSystem &physicsSystem, AudioManager &audioManager, const VoxelChunkManager &voxelChunkManager)
 {
 	JPH::BodyInterface &bodyInterface = physicsSystem.GetBodyInterface();
 
@@ -1346,21 +1347,31 @@ void EntityChunkManager::updateEnemyBehaviors(double dt, const WorldDouble2 &pla
 				}
 
 				enemyBehaviorState.secondsTillNextAttack = 0.0;
+				enemyBehaviorState.hasAttemptedHit = false;
 				animInst.setStateIndex(*attackStateIndex);
 				continue;
 			}
 
-			const bool isHitAllowed = animInst.isFinished(); // @todo check if > 0.50 progress and check !hasAttemptedHit
+			const bool isHitAllowed = !enemyBehaviorState.hasAttemptedHit && (animInst.progressPercent >= 0.50);
 			if (isHitAllowed)
 			{
-				// @todo set hasAttemptedHit = true
+				enemyBehaviorState.hasAttemptedHit = true;
 
 				if (isCloseEnoughToAttackPlayer)
 				{
-					const double damageAmount = random.nextReal() * 3.0; // @todo depend on original enemy values (entity def?)
-					player.currentHealth = std::max(player.currentHealth - damageAmount, 0.0);
-					
-					// @todo audio trigger, maybe want to set a bool true here and do after the enemy loop? or maybe we want every hit to play (3d position of each source matters for gameplay)
+					const bool isPlayerHit = random.nextBool();
+
+					if (isPlayerHit)
+					{
+						const double damageAmount = random.nextReal() * 3.0; // @todo depend on original enemy values (entity def?)
+						player.currentHealth = std::max(player.currentHealth - damageAmount, 0.0);
+
+						audioManager.playSoundOneShot(ArenaSoundName::PlayerHit);
+					}
+					else
+					{
+						audioManager.playSoundOneShot(ArenaSoundName::Clank);
+					}
 				}
 			}
 
@@ -1373,14 +1384,14 @@ void EntityChunkManager::updateEnemyBehaviors(double dt, const WorldDouble2 &pla
 			if (!isCloseEnoughToAttackPlayer)
 			{
 				enemyBehaviorState.type = EntityEnemyBehaviorStateType::MovingToPlayer;
+				enemyBehaviorState.hasAttemptedHit = false;
 				animInst.setStateIndex(*walkStateIndex);
 				continue;
 			}
 
 			enemyBehaviorState.secondsTillNextAttack = GetEnemyNextWeaponSwingSeconds(random);
+			enemyBehaviorState.hasAttemptedHit = false;
 			animInst.setStateIndex(*idleStateIndex);
-
-			// @todo set hasAttemptedHit = false
 		}
 		else
 		{
@@ -1904,7 +1915,7 @@ void EntityChunkManager::updatePrePhysicsStep(double dt, Span<const ChunkInt2> a
 	}
 
 	this->updateCitizenBehaviors(dt, playerPositionXZ, isPlayerMoving, isPlayerWeaponSheathed, random, physicsSystem, voxelChunkManager);
-	this->updateEnemyBehaviors(dt, playerPositionXZ, player, random, physicsSystem, voxelChunkManager);
+	this->updateEnemyBehaviors(dt, playerPositionXZ, player, random, physicsSystem, audioManager, voxelChunkManager);
 	this->updateCreatureSounds(dt, playerPosition, random, audioManager);
 	this->updateDeathStates(physicsSystem, audioManager);
 	this->updateVfx();

--- a/OpenTESArena/src/Entities/EntityChunkManager.cpp
+++ b/OpenTESArena/src/Entities/EntityChunkManager.cpp
@@ -1260,45 +1260,62 @@ void EntityChunkManager::updateEnemyBehaviors(double dt, const WorldDouble2 &pla
 			const JPH::BodyID &physicsBodyID = entityInst.physicsBodyID;
 			DebugAssert(!physicsBodyID.IsInvalid());
 
-			if (isCloseEnoughToDetectPlayer)
-			{
-				entityDir = dirToPlayer;
-
-				bool isNextPositionValid = true;
-
-				// @todo check if chasm. maybe don't have to check walls because the collider will just hit it?
-
-				if (isNextPositionValid)
-				{
-					if (!isCloseEnoughToAttackPlayer)
-					{
-						if (currentAnimStateIndex != *walkStateIndex)
-						{
-							animInst.setStateIndex(*walkStateIndex);
-						}
-
-						constexpr double entityMoveSpeed = 1.50;
-						const Double2 entityVelocity = entityDir * entityMoveSpeed;						
-
-						const JPH::RVec3 physicsVelocity(static_cast<float>(entityVelocity.x), 0.0f, static_cast<float>(entityVelocity.y));
-						bodyInterface.SetLinearVelocity(physicsBodyID, physicsVelocity);
-					}
-					else
-					{
-						if (currentAnimStateIndex != *idleStateIndex)
-						{
-							animInst.setStateIndex(*idleStateIndex);
-							bodyInterface.SetLinearVelocity(physicsBodyID, JPH::RVec3::sZero());
-						}
-					}
-				}
-			}
-			else
+			if (!isCloseEnoughToDetectPlayer)
 			{
 				enemyBehaviorState.type = EntityEnemyBehaviorStateType::Idle;
 				animInst.setStateIndex(*idleStateIndex);
 				bodyInterface.SetLinearVelocity(physicsBodyID, JPH::RVec3::sZero());
+				continue;
 			}
+
+			entityDir = dirToPlayer;
+
+			constexpr double entityMoveSpeed = 1.50;
+			const Double2 entityVelocity = entityDir * entityMoveSpeed;
+
+			const WorldDouble2 attemptedNextPosition = entityPositionXZ + (entityVelocity * dt);
+			const CoordDouble2 attemptedNextCoord = VoxelUtils::worldPointToCoord(attemptedNextPosition);
+			const VoxelChunk *attemptedNextVoxelChunk = voxelChunkManager.findChunkAtPosition(attemptedNextCoord.chunk);
+
+			bool isAttemptedNextPositionValid = false;
+			if (attemptedNextVoxelChunk != nullptr)
+			{
+				const VoxelInt2 attemptedNextVoxelXZ = VoxelUtils::pointToVoxel(attemptedNextCoord.point);
+				const VoxelInt3 attemptedNextFloorVoxel(attemptedNextVoxelXZ.x, 0, attemptedNextVoxelXZ.y);
+
+				const VoxelTraitsDefID attemptedNextFloorVoxelTraitsDefID = attemptedNextVoxelChunk->traitsDefIDs.get(attemptedNextFloorVoxel.x, attemptedNextFloorVoxel.y, attemptedNextFloorVoxel.z);
+				DebugAssertIndex(attemptedNextVoxelChunk->traitsDefs, attemptedNextFloorVoxelTraitsDefID);
+				const VoxelTraitsDefinition &attemptedNextFloorVoxelTraitsDef = attemptedNextVoxelChunk->traitsDefs[attemptedNextFloorVoxelTraitsDefID];
+				isAttemptedNextPositionValid = attemptedNextFloorVoxelTraitsDef.type == ArenaVoxelType::Floor;
+			}
+
+			if (!isAttemptedNextPositionValid)
+			{
+				// Okay to stay in walk animation if being kept from going into chasm.
+				bodyInterface.SetLinearVelocity(physicsBodyID, JPH::RVec3::sZero());
+				continue;
+			}
+
+			if (!isCloseEnoughToAttackPlayer)
+			{
+				if (currentAnimStateIndex != *walkStateIndex)
+				{
+					animInst.setStateIndex(*walkStateIndex);
+				}
+
+				const JPH::RVec3 physicsVelocity(static_cast<float>(entityVelocity.x), 0.0f, static_cast<float>(entityVelocity.y));
+				bodyInterface.SetLinearVelocity(physicsBodyID, physicsVelocity);
+				continue;
+			}
+
+			if (currentAnimStateIndex != *idleStateIndex)
+			{
+				animInst.setStateIndex(*idleStateIndex);
+				bodyInterface.SetLinearVelocity(physicsBodyID, JPH::RVec3::sZero());
+			}
+
+			// @todo the goal of this state is to get close enough to the player to attack them
+			// @todo set random attack seconds and once that time is hit, change to attack animation
 		}
 		else
 		{

--- a/OpenTESArena/src/Entities/EntityChunkManager.h
+++ b/OpenTESArena/src/Entities/EntityChunkManager.h
@@ -73,13 +73,15 @@ enum class EntityBehaviorStateType
 enum class EntityEnemyBehaviorStateType
 {
 	Idle,
-	MovingToPlayer
+	MovingToPlayer,
+	AttackPlayer
 };
 
 struct EntityEnemyBehaviorState
 {
 	EntityEnemyBehaviorStateType type;
 	double secondsTillNextCreatureSound;
+	double secondsTillNextAttack;
 
 	EntityEnemyBehaviorState();
 };
@@ -217,7 +219,7 @@ private:
 	void updateCitizenBehaviors(double dt, const WorldDouble2 &playerPositionXZ, bool isPlayerMoving, bool isPlayerWeaponSheathed,
 		Random &random, JPH::PhysicsSystem &physicsSystem, const VoxelChunkManager &voxelChunkManager);
 
-	void updateEnemyBehaviors(double dt, const WorldDouble2 &playerPositionXZ, JPH::PhysicsSystem &physicsSystem, const VoxelChunkManager &voxelChunkManager);
+	void updateEnemyBehaviors(double dt, const WorldDouble2 &playerPositionXZ, Player &player, Random &random, JPH::PhysicsSystem &physicsSystem, const VoxelChunkManager &voxelChunkManager);
 
 	std::string getCreatureSoundFilename(const EntityDefID defID) const;
 	void updateCreatureSounds(double dt, const WorldDouble3 &playerPosition, Random &random, AudioManager &audioManager);
@@ -244,7 +246,7 @@ public:
 
 	void updatePrePhysicsStep(double dt, Span<const ChunkInt2> activeChunkPositions,
 		Span<const ChunkInt2> newChunkPositions, Span<const ChunkInt2> freedChunkPositions,
-		const Player &player, const LevelDefinition *activeLevelDef, const LevelInfoDefinition *activeLevelInfoDef,
+		Player &player, const LevelDefinition *activeLevelDef, const LevelInfoDefinition *activeLevelInfoDef,
 		const MapSubDefinition &mapSubDef, Span<const LevelDefinition> levelDefs,
 		Span<const int> levelInfoDefIndices, Span<const LevelInfoDefinition> levelInfoDefs,
 		const EntityGenInfo &entityGenInfo, const std::optional<CitizenGenInfo> &citizenGenInfo,

--- a/OpenTESArena/src/Entities/EntityChunkManager.h
+++ b/OpenTESArena/src/Entities/EntityChunkManager.h
@@ -121,7 +121,7 @@ struct EntityBehaviorState
 
 struct EntityCombatState
 {
-	bool isDying;
+	bool isDying; // Begins their death animation (if any) and removal from play.
 	bool isDead;
 	bool hasBeenLootedBefore; // For awarding gold from creature corpse.
 
@@ -222,7 +222,7 @@ private:
 	std::string getCreatureSoundFilename(const EntityDefID defID) const;
 	void updateCreatureSounds(double dt, const WorldDouble3 &playerPosition, Random &random, AudioManager &audioManager);
 	void updateFadedElevatedPlatforms(EntityChunk &entityChunk, const VoxelChunk &voxelChunk, double ceilingScale, JPH::PhysicsSystem &physicsSystem);
-	void updateEnemyDeathStates(JPH::PhysicsSystem &physicsSystem, AudioManager &audioManager);
+	void updateDeathStates(JPH::PhysicsSystem &physicsSystem, AudioManager &audioManager);
 	void updateVfx();
 public:
 	const EntityDefinition &getEntityDef(EntityDefID defID) const;

--- a/OpenTESArena/src/Entities/EntityChunkManager.h
+++ b/OpenTESArena/src/Entities/EntityChunkManager.h
@@ -82,6 +82,7 @@ struct EntityEnemyBehaviorState
 	EntityEnemyBehaviorStateType type;
 	double secondsTillNextCreatureSound;
 	double secondsTillNextAttack;
+	bool hasAttemptedHit;
 
 	EntityEnemyBehaviorState();
 };
@@ -219,7 +220,7 @@ private:
 	void updateCitizenBehaviors(double dt, const WorldDouble2 &playerPositionXZ, bool isPlayerMoving, bool isPlayerWeaponSheathed,
 		Random &random, JPH::PhysicsSystem &physicsSystem, const VoxelChunkManager &voxelChunkManager);
 
-	void updateEnemyBehaviors(double dt, const WorldDouble2 &playerPositionXZ, Player &player, Random &random, JPH::PhysicsSystem &physicsSystem, const VoxelChunkManager &voxelChunkManager);
+	void updateEnemyBehaviors(double dt, const WorldDouble2 &playerPositionXZ, Player &player, Random &random, JPH::PhysicsSystem &physicsSystem, AudioManager &audioManager, const VoxelChunkManager &voxelChunkManager);
 
 	std::string getCreatureSoundFilename(const EntityDefID defID) const;
 	void updateCreatureSounds(double dt, const WorldDouble3 &playerPosition, Random &random, AudioManager &audioManager);

--- a/OpenTESArena/src/Entities/EntityChunkManager.h
+++ b/OpenTESArena/src/Entities/EntityChunkManager.h
@@ -214,10 +214,10 @@ private:
 
 	void queueEntityTransfer(EntityInstanceID entityInstID, ChunkInt2 prevChunkPos, ChunkInt2 newChunkPos);
 
-	void updateCitizenStates(double dt, const WorldDouble2 &playerPositionXZ, bool isPlayerMoving, bool isPlayerWeaponSheathed,
+	void updateCitizenBehaviors(double dt, const WorldDouble2 &playerPositionXZ, bool isPlayerMoving, bool isPlayerWeaponSheathed,
 		Random &random, JPH::PhysicsSystem &physicsSystem, const VoxelChunkManager &voxelChunkManager);
 
-	void updateEnemyStates(double dt, const WorldDouble2 &playerPositionXZ, JPH::PhysicsSystem &physicsSystem, const VoxelChunkManager &voxelChunkManager);
+	void updateEnemyBehaviors(double dt, const WorldDouble2 &playerPositionXZ, JPH::PhysicsSystem &physicsSystem, const VoxelChunkManager &voxelChunkManager);
 
 	std::string getCreatureSoundFilename(const EntityDefID defID) const;
 	void updateCreatureSounds(double dt, const WorldDouble3 &playerPosition, Random &random, AudioManager &audioManager);

--- a/OpenTESArena/src/Entities/EntityChunkManager.h
+++ b/OpenTESArena/src/Entities/EntityChunkManager.h
@@ -254,7 +254,7 @@ public:
 		double ceilingScale, Random &random, const VoxelChunkManager &voxelChunkManager, AudioManager &audioManager,
 		JPH::PhysicsSystem &physicsSystem, TextureManager &textureManager, Renderer &renderer);
 
-	void updatePostPhysicsStep(JPH::PhysicsSystem &physicsSystem);
+	void updatePostPhysicsStep(const VoxelChunkManager &voxelChunkManager, JPH::PhysicsSystem &physicsSystem);
 
 	// Prepares an entity for destruction later this frame, optionally notifying its chunk to remove its reference.
 	// Don't need to notify the chunk if the chunk is being freed this frame.

--- a/OpenTESArena/src/Entities/EntityChunkManager.h
+++ b/OpenTESArena/src/Entities/EntityChunkManager.h
@@ -242,7 +242,7 @@ public:
 	void setEnemyBehaviorState(EntityInstanceID id, EntityEnemyBehaviorStateType stateType);
 	void setCitizenBehaviorState(EntityInstanceID id, EntityCitizenBehaviorStateType stateType);
 
-	void update(double dt, Span<const ChunkInt2> activeChunkPositions,
+	void updatePrePhysicsStep(double dt, Span<const ChunkInt2> activeChunkPositions,
 		Span<const ChunkInt2> newChunkPositions, Span<const ChunkInt2> freedChunkPositions,
 		const Player &player, const LevelDefinition *activeLevelDef, const LevelInfoDefinition *activeLevelInfoDef,
 		const MapSubDefinition &mapSubDef, Span<const LevelDefinition> levelDefs,
@@ -250,6 +250,8 @@ public:
 		const EntityGenInfo &entityGenInfo, const std::optional<CitizenGenInfo> &citizenGenInfo,
 		double ceilingScale, Random &random, const VoxelChunkManager &voxelChunkManager, AudioManager &audioManager,
 		JPH::PhysicsSystem &physicsSystem, TextureManager &textureManager, Renderer &renderer);
+
+	void updatePostPhysicsStep(JPH::PhysicsSystem &physicsSystem);
 
 	// Prepares an entity for destruction later this frame, optionally notifying its chunk to remove its reference.
 	// Don't need to notify the chunk if the chunk is being freed this frame.

--- a/OpenTESArena/src/Entities/EntityInstance.cpp
+++ b/OpenTESArena/src/Entities/EntityInstance.cpp
@@ -23,9 +23,9 @@ void EntityInstance::init(EntityInstanceID instanceID, EntityDefID defID, Entity
 	this->transformIndex = transformIndex;
 }
 
-bool EntityInstance::isDynamic() const
+bool EntityInstance::isTransformStatic() const
 {
-	return this->directionID >= 0;
+	return this->directionID < 0;
 }
 
 bool EntityInstance::canAcceptCombatHits() const
@@ -40,7 +40,7 @@ bool EntityInstance::canBeKilledInCombat() const
 
 bool EntityInstance::canUseElevatedPlatforms() const
 {
-	return !this->isDynamic();
+	return this->isTransformStatic();
 }
 
 bool EntityInstance::hasInventory() const

--- a/OpenTESArena/src/Entities/EntityInstance.h
+++ b/OpenTESArena/src/Entities/EntityInstance.h
@@ -40,8 +40,8 @@ struct EntityInstance
 	// All entities at least have an instance ID, definition, position, bounding box, and render transform.
 	void init(EntityInstanceID instanceID, EntityDefID defID, EntityPositionID positionID, EntityBoundingBoxID bboxID, int transformHeapIndex, int transformIndex);
 
-	// Whether the entity is capable of moving + looking.
-	bool isDynamic() const;
+	// Whether the entity is capable of moving and looking.
+	bool isTransformStatic() const;
 
 	bool canAcceptCombatHits() const;
 	bool canBeKilledInCombat() const;

--- a/OpenTESArena/src/Entities/EntityUtils.cpp
+++ b/OpenTESArena/src/Entities/EntityUtils.cpp
@@ -350,13 +350,6 @@ bool EntityUtils::tryGetDisplayName(const EntityDefinition &entityDef, const Cha
 	return true;
 }
 
-bool EntityUtils::withinHearingDistance(const WorldDouble3 &listenerPosition, const WorldDouble3 &soundPosition)
-{
-	const Double3 diff = soundPosition - listenerPosition;
-	constexpr double hearingDistanceSqr = EntityUtils::HearingDistance * EntityUtils::HearingDistance;
-	return diff.lengthSquared() < hearingDistanceSqr;
-}
-
 double EntityUtils::nextCreatureSoundWaitSeconds(Random &random)
 {
 	// Arbitrary amount of time.

--- a/OpenTESArena/src/Entities/EntityUtils.cpp
+++ b/OpenTESArena/src/Entities/EntityUtils.cpp
@@ -223,12 +223,6 @@ bool EntityUtils::canDie(const EntityDefinition &entityDef)
 	}
 }
 
-std::optional<int> EntityUtils::tryGetDeathAnimStateIndex(const EntityAnimationDefinition &animDef)
-{
-	const std::optional<int> deathStateIndex = animDef.findStateIndex(EntityAnimationUtils::STATE_DEATH.c_str());
-	return deathStateIndex;
-}
-
 bool EntityUtils::leavesCorpse(const EntityDefinition &entityDef)
 {
 	const EntityDefinitionType entityType = entityDef.type;

--- a/OpenTESArena/src/Entities/EntityUtils.h
+++ b/OpenTESArena/src/Entities/EntityUtils.h
@@ -39,7 +39,6 @@ namespace EntityUtils
 
 	bool hasCollision(const EntityDefinition &entityDef);
 	bool canDie(const EntityDefinition &entityDef);
-	std::optional<int> tryGetDeathAnimStateIndex(const EntityAnimationDefinition &animDef);
 	bool leavesCorpse(const EntityDefinition &entityDef);
 
 	// Returns the entity definition's light radius, if any.

--- a/OpenTESArena/src/Entities/EntityUtils.h
+++ b/OpenTESArena/src/Entities/EntityUtils.h
@@ -50,10 +50,6 @@ namespace EntityUtils
 	// Returns whether the entity definition has a display name.
 	bool tryGetDisplayName(const EntityDefinition &entityDef, const CharacterClassLibrary &charClassLibrary, std::string *outName);
 
-	// Arbitrary value for how far away a creature can be heard from.
-	// @todo: make this be part of the player, not creatures.
-	constexpr double HearingDistance = 6.0;
-
 	bool withinHearingDistance(const WorldDouble3 &listenerPosition, const WorldDouble3 &soundPosition);
 
 	double nextCreatureSoundWaitSeconds(Random &random);

--- a/OpenTESArena/src/Game/Game.cpp
+++ b/OpenTESArena/src/Game/Game.cpp
@@ -917,12 +917,13 @@ void Game::loop()
 				this->gameState.tickPlayerStamina(clampedDeltaTime, *this);
 				this->gameState.tickPlayerAttack(clampedDeltaTime, *this);
 				this->gameState.tickVoxels(clampedDeltaTime, *this);
-				this->gameState.tickEntities(clampedDeltaTime, *this);
 				this->gameState.tickCollision(clampedDeltaTime, this->physicsSystem, *this);
 
 				this->player.prePhysicsStep(clampedDeltaTime, *this);
+				this->gameState.tickEntitiesPrePhysicsStep(clampedDeltaTime, *this);
 				this->physicsSystem.Update(static_cast<float>(clampedDeltaTime), frameTimer.physicsSteps, &physicsAllocator, &physicsJobThreadPool);
 				this->player.postPhysicsStep(clampedDeltaTime, *this);
+				this->gameState.tickEntitiesPostPhysicsStep(*this);
 
 				if (this->gameState.hasPendingLevelTransitionCalculation())
 				{

--- a/OpenTESArena/src/Game/GameState.cpp
+++ b/OpenTESArena/src/Game/GameState.cpp
@@ -956,7 +956,7 @@ void GameState::tickEntitiesPrePhysicsStep(double dt, Game &game)
 	const ChunkManager &chunkManager = sceneManager.chunkManager;
 	const VoxelChunkManager &voxelChunkManager = sceneManager.voxelChunkManager;
 
-	const Player &player = game.player;
+	Player &player = game.player;
 
 	const MapDefinition &mapDef = this->getActiveMapDef();
 	const MapType mapType = mapDef.getMapType();

--- a/OpenTESArena/src/Game/GameState.cpp
+++ b/OpenTESArena/src/Game/GameState.cpp
@@ -668,7 +668,8 @@ void GameState::applyPendingSceneChange(Game &game, JPH::PhysicsSystem &physicsS
 	constexpr bool isFloatingOriginChanged = false; // Don't need special handling when everything is already dirty.
 
 	this->tickVoxels(0.0, game);
-	this->tickEntities(0.0, game);
+	this->tickEntitiesPrePhysicsStep(0.0, game);
+	this->tickEntitiesPostPhysicsStep(game);
 	this->tickCollision(0.0, physicsSystem, game);
 	this->tickSky(0.0, game);
 	this->tickVisibility(renderCamera, game);
@@ -949,7 +950,7 @@ void GameState::tickVoxels(double dt, Game &game)
 	voxelFaceCombineChunkManager.update(activeChunkPositions, newChunkPositions, voxelChunkManager, voxelFaceEnableChunkManager);
 }
 
-void GameState::tickEntities(double dt, Game &game)
+void GameState::tickEntitiesPrePhysicsStep(double dt, Game &game)
 {
 	SceneManager &sceneManager = game.sceneManager;
 	const ChunkManager &chunkManager = sceneManager.chunkManager;
@@ -993,10 +994,17 @@ void GameState::tickEntities(double dt, Game &game)
 	const double ceilingScale = this->getActiveCeilingScale();
 
 	EntityChunkManager &entityChunkManager = sceneManager.entityChunkManager;
-	entityChunkManager.update(dt, chunkManager.getActiveChunkPositions(), chunkManager.getNewChunkPositions(),
+	entityChunkManager.updatePrePhysicsStep(dt, chunkManager.getActiveChunkPositions(), chunkManager.getNewChunkPositions(),
 		chunkManager.getFreedChunkPositions(), player, &levelDef, &levelInfoDef, mapSubDef, levelDefs, levelInfoDefIndices,
 		levelInfoDefs, entityGenInfo, citizenGenInfo, ceilingScale, game.random, voxelChunkManager, game.audioManager,
 		game.physicsSystem, game.textureManager, game.renderer);
+}
+
+void GameState::tickEntitiesPostPhysicsStep(Game &game)
+{
+	SceneManager &sceneManager = game.sceneManager;
+	EntityChunkManager &entityChunkManager = sceneManager.entityChunkManager;
+	entityChunkManager.updatePostPhysicsStep(game.physicsSystem);
 }
 
 void GameState::tickCollision(double dt, JPH::PhysicsSystem &physicsSystem, Game &game)

--- a/OpenTESArena/src/Game/GameState.cpp
+++ b/OpenTESArena/src/Game/GameState.cpp
@@ -1003,8 +1003,10 @@ void GameState::tickEntitiesPrePhysicsStep(double dt, Game &game)
 void GameState::tickEntitiesPostPhysicsStep(Game &game)
 {
 	SceneManager &sceneManager = game.sceneManager;
+	const VoxelChunkManager &voxelChunkManager = sceneManager.voxelChunkManager;
+
 	EntityChunkManager &entityChunkManager = sceneManager.entityChunkManager;
-	entityChunkManager.updatePostPhysicsStep(game.physicsSystem);
+	entityChunkManager.updatePostPhysicsStep(voxelChunkManager, game.physicsSystem);
 }
 
 void GameState::tickCollision(double dt, JPH::PhysicsSystem &physicsSystem, Game &game)

--- a/OpenTESArena/src/Game/GameState.h
+++ b/OpenTESArena/src/Game/GameState.h
@@ -168,7 +168,8 @@ public:
 	void tickPlayerStamina(double dt, Game &game);
 	void tickPlayerAttack(double dt, Game &game);
 	void tickVoxels(double dt, Game &game);
-	void tickEntities(double dt, Game &game);
+	void tickEntitiesPrePhysicsStep(double dt, Game &game);
+	void tickEntitiesPostPhysicsStep(Game &game);
 	void tickCollision(double dt, JPH::PhysicsSystem &physicsSystem, Game &game);
 	void tickVisibility(const RenderCamera &renderCamera, Game &game);
 	void tickRendering(double dt, const RenderCamera &renderCamera, bool isFloatingOriginChanged, Game &game);

--- a/OpenTESArena/src/Player/Player.h
+++ b/OpenTESArena/src/Player/Player.h
@@ -48,6 +48,8 @@ namespace PlayerConstants
 
 	constexpr double MELEE_HIT_RANGE = 0.50;
 	constexpr double MELEE_HIT_SEARCH_RADIUS = 0.40;
+
+	constexpr double CREATURE_SOUND_MAX_DISTANCE = 6.0;
 }
 
 enum class PlayerMovementType

--- a/OpenTESArena/src/Player/PlayerLogic.cpp
+++ b/OpenTESArena/src/Player/PlayerLogic.cpp
@@ -757,6 +757,14 @@ CardinalDirectionName PlayerLogic::getRandomMeleeSwingDirection(Random &random)
 	return static_cast<CardinalDirectionName>(randomValue);
 }
 
+bool PlayerLogic::canHearCreatureSound(const Double3 &playerPosition, const Double3 &soundPosition)
+{
+	constexpr double maxSoundDistanceSqr = PlayerConstants::CREATURE_SOUND_MAX_DISTANCE * PlayerConstants::CREATURE_SOUND_MAX_DISTANCE;
+	const Double3 dirToSoundPosition = soundPosition - playerPosition;
+	const double soundDistanceSqr = dirToSoundPosition.lengthSquared();
+	return soundDistanceSqr <= maxSoundDistanceSqr;
+}
+
 bool PlayerLogic::tryGetMeleeSwingDirectionFromMouseDelta(const Int2 &mouseDelta, const Int2 &windowDims, CardinalDirectionName *outDirectionName)
 {
 	// Get smaller screen dimension so mouse delta is relative to a square.

--- a/OpenTESArena/src/Player/PlayerLogic.cpp
+++ b/OpenTESArena/src/Player/PlayerLogic.cpp
@@ -905,7 +905,7 @@ void PlayerLogic::handleAttack(Game &game, const Int2 &mouseDelta)
 				const EntityAnimationDefinition &hitEntityAnimDef = hitEntityDef.animDef;
 				EntityAnimationInstance &hitEntityAnimInst = entityChunkManager.animInsts.get(hitEntityInst.animInstID);
 
-				const EntityCombatState *hitEntityCombatState = nullptr;
+				EntityCombatState *hitEntityCombatState = nullptr;
 				bool canHitEntityBeKilled = false;
 				if (hitEntityInst.canBeKilledInCombat())
 				{
@@ -929,19 +929,7 @@ void PlayerLogic::handleAttack(Game &game, const Int2 &mouseDelta)
 
 					if (isHitEntityHpAtZero)
 					{
-						const std::optional<int> hitEntityDeathAnimStateIndex = EntityUtils::tryGetDeathAnimStateIndex(hitEntityAnimDef);
-						const bool hitEntityHasDeathAnim = hitEntityDeathAnimStateIndex.has_value();
-
-						// @todo this should set combat state isDying/isDead instead of relying on EntityChunkManager update
-
-						if (hitEntityHasDeathAnim)
-						{
-							hitEntityAnimInst.setStateIndex(*hitEntityDeathAnimStateIndex);
-						}
-						else
-						{
-							entityChunkManager.queueEntityDestroy(hitEntityInstID, true);
-						}
+						hitEntityCombatState->isDying = true;
 
 						const EntityBehaviorState &hitEntityBehaviorState = entityChunkManager.behaviorStates.get(hitEntityInst.behaviorStateID);
 						if (hitEntityBehaviorState.isCitizen())

--- a/OpenTESArena/src/Player/PlayerLogic.cpp
+++ b/OpenTESArena/src/Player/PlayerLogic.cpp
@@ -932,6 +932,8 @@ void PlayerLogic::handleAttack(Game &game, const Int2 &mouseDelta)
 						const std::optional<int> hitEntityDeathAnimStateIndex = EntityUtils::tryGetDeathAnimStateIndex(hitEntityAnimDef);
 						const bool hitEntityHasDeathAnim = hitEntityDeathAnimStateIndex.has_value();
 
+						// @todo this should set combat state isDying/isDead instead of relying on EntityChunkManager update
+
 						if (hitEntityHasDeathAnim)
 						{
 							hitEntityAnimInst.setStateIndex(*hitEntityDeathAnimStateIndex);

--- a/OpenTESArena/src/Player/PlayerLogic.h
+++ b/OpenTESArena/src/Player/PlayerLogic.h
@@ -34,6 +34,8 @@ namespace PlayerLogic
 
 	CardinalDirectionName getRandomMeleeSwingDirection(Random &random);
 
+	bool canHearCreatureSound(const Double3 &playerPosition, const Double3 &soundPosition);
+
 	// Can fail if mouse moves too slowly.
 	bool tryGetMeleeSwingDirectionFromMouseDelta(const Int2 &mouseDelta, const Int2 &windowDims, CardinalDirectionName *outDirectionName);
 

--- a/components/archives/archive.hpp
+++ b/components/archives/archive.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <iostream>
-#include <vector>
-#include <string>
-#include <memory>
 #include <array>
-
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
 
 namespace Archives
 {


### PR DESCRIPTION
Enemies now approach the player and attempt weapon swings at random intervals. The player can die which leads to the death cinematic.

I had to change entity colliders from kinematic to dynamic so they run into walls and each other properly. They still push each other around a bit too much, maybe a mass or friction issue.

This PR isn't an exact match to how the original game works but it's getting there.