### PR TITLE
Enable random encounters

### DIFF
--- a/OpenTESArena/src/Assets/ArenaTypes.h
+++ b/OpenTESArena/src/Assets/ArenaTypes.h
@@ -72,6 +72,16 @@ enum class ArenaCityType
 	Village
 };
 
+// Used with enemy encounter logic.
+enum class ArenaEnvironmentType
+{
+	City = 0,
+	Wilderness = 1,
+	MainQuestDungeon = 2,
+	WorldMapDungeon = 3,
+	Interior = 4
+};
+
 // Each type of voxel definition. These are mostly used with rendering, but also for determining how to
 // interpret the voxel data itself. If the type is None, then the voxel is empty and there is nothing
 // to render.

--- a/OpenTESArena/src/Assets/ArenaTypes.h
+++ b/OpenTESArena/src/Assets/ArenaTypes.h
@@ -39,16 +39,18 @@ enum class ArenaMenuType
 //   rulerIsMale, etc.. Might also have a variable for loot piles when sneaking in at night.
 enum class ArenaInteriorType
 {
-	Crypt, // WCRYPT
-	Dungeon, // DUNGEON
-	Equipment, // EQUIP
-	House, // BS
-	MagesGuild, // MAGE
-	Noble, // NOBLE
-	Palace, // PALACE
-	Tavern, // TAVERN
-	Temple, // TEMPLE
-	Tower // TOWER
+	None = 0,
+	Palace = 1, // PALACE
+	House = 2, // BS
+	Noble = 3, // NOBLE
+	Tavern = 4, // TAVERN
+	Temple = 5, // TEMPLE
+	Equipment = 6, // EQUIP
+	MagesGuild = 7, // MAGE
+	Crypt = 8, // WCRYPT
+	Dungeon = 9, // DUNGEON
+	Unused = 10,
+	Tower = 11, // TOWER
 };
 
 // Each location on a province map has a type.

--- a/OpenTESArena/src/Assets/ArenaTypes.h
+++ b/OpenTESArena/src/Assets/ArenaTypes.h
@@ -94,7 +94,7 @@ enum class ArenaEnvironmentType
 	Wilderness = 1,
 	MainQuestDungeon = 2,
 	WorldMapDungeon = 3,
-	Interior = 4
+	BuildingInterior = 4
 };
 
 // Each type of voxel definition. These are mostly used with rendering, but also for determining how to

--- a/OpenTESArena/src/Assets/ArenaTypes.h
+++ b/OpenTESArena/src/Assets/ArenaTypes.h
@@ -39,18 +39,33 @@ enum class ArenaMenuType
 //   rulerIsMale, etc.. Might also have a variable for loot piles when sneaking in at night.
 enum class ArenaInteriorType
 {
+	Crypt, // WCRYPT
+	Dungeon, // DUNGEON
+	Equipment, // EQUIP
+	House, // BS
+	MagesGuild, // MAGE
+	Noble, // NOBLE
+	Palace, // PALACE
+	Tavern, // TAVERN
+	Temple, // TEMPLE
+	Tower // TOWER
+};
+
+// Used with enemy encounters. TownPalace and VillagePalace are unused except for .MIF loading.
+enum class ArenaBuildingType
+{
 	None = 0,
-	Palace = 1, // PALACE
-	House = 2, // BS
-	Noble = 3, // NOBLE
-	Tavern = 4, // TAVERN
-	Temple = 5, // TEMPLE
-	Equipment = 6, // EQUIP
-	MagesGuild = 7, // MAGE
-	Crypt = 8, // WCRYPT
-	Dungeon = 9, // DUNGEON
-	Unused = 10,
-	Tower = 11, // TOWER
+	Palace = 1,
+	House = 2,
+	Noble = 3,
+	Tavern = 4,
+	Temple = 5,
+	Equipment = 6,
+	MagesGuild = 7,
+	Crypt = 8,
+	TownPalace = 9, // Unused
+	VillagePalace = 10, // Unused
+	Tower = 11
 };
 
 // Each location on a province map has a type.

--- a/OpenTESArena/src/Entities/ArenaAnimUtils.cpp
+++ b/OpenTESArena/src/Entities/ArenaAnimUtils.cpp
@@ -6,6 +6,7 @@
 #include "../Assets/BinaryAssetLibrary.h"
 #include "../Assets/MIFUtils.h"
 #include "../Assets/TextureManager.h"
+#include "../Entities/ArenaEntityUtils.h"
 #include "../Entities/EntityDefinition.h"
 #include "../Stats/CharacterClassDefinition.h"
 #include "../Stats/CharacterClassLibrary.h"
@@ -828,7 +829,7 @@ bool ArenaAnimUtils::isGhost(int creatureIndex)
 
 int ArenaAnimUtils::getCreatureIDFromItemIndex(ArenaItemIndex itemIndex)
 {
-	return ArenaAnimUtils::isFinalBossIndex(itemIndex) ? ArenaAnimUtils::FinalBossCreatureID : (itemIndex - 31);
+	return ArenaAnimUtils::isFinalBossIndex(itemIndex) ? ArenaEntityUtils::FinalBossCreatureID : (itemIndex - 31);
 }
 
 int ArenaAnimUtils::getCreatureIndexFromID(int creatureID)

--- a/OpenTESArena/src/Entities/ArenaAnimUtils.h
+++ b/OpenTESArena/src/Entities/ArenaAnimUtils.h
@@ -126,11 +126,6 @@ namespace ArenaAnimUtils
 	constexpr ArenaItemIndex KeyItemIndex = 1;
 	constexpr ArenaItemIndex QuestItemIndex = 13;
 
-	// The final boss is a special case, essentially hardcoded at the end of the creatures.
-	// Note that creature ID == creature index + 1.
-	constexpr int FinalBossCreatureID = 24;
-	constexpr int CreatureCount = FinalBossCreatureID;
-
 	// Creature IDs are 1-based (rat=1, goblin=2, etc.).
 	int getCreatureIDFromItemIndex(ArenaItemIndex itemIndex);
 

--- a/OpenTESArena/src/Entities/ArenaEntityUtils.cpp
+++ b/OpenTESArena/src/Entities/ArenaEntityUtils.cpp
@@ -1011,15 +1011,16 @@ int ArenaEntityUtils::getGuardShield(int guardType, const ExeData &exeData, Aren
 	return ArenaEntityUtils::pickNonMagicArmor(dummyQualityThreshold, plateMaterialID, guardShieldIDs[guardType], exeData, random);
 }
 
-void ArenaEntityUtils::getEncounterParameters(int currentEnvironmentType, int currentBuildingType, bool playerTrespassing, bool playerResting,
-	int terrainType, int hour, int dayOfYear, const ExeData &exeData, int *outEncounterChance, int *outEncounterTableIndex)
+void ArenaEntityUtils::getEncounterParameters(ArenaEnvironmentType currentEnvironmentType, ArenaBuildingType currentBuildingType,
+	bool playerTrespassing, bool playerResting, int terrainType, int hour, int dayOfYear, const ExeData &exeData,
+	int *outEncounterChance, int *outEncounterTableIndex)
 {
-	constexpr int cityEnvironment = 0;
-	constexpr int wildernessEnvironment = 1;
-	constexpr int buildingEnvironment = 4;
+	constexpr ArenaEnvironmentType cityEnvironmentType = ArenaEnvironmentType::City;
+	constexpr ArenaEnvironmentType wildernessEnvironmentType = ArenaEnvironmentType::Wilderness;
+	constexpr ArenaEnvironmentType buildingEnvironmentType = ArenaEnvironmentType::BuildingInterior;
 
-	constexpr int magesGuildBuilding = 7;
-	constexpr int cryptBuilding = 8;
+	constexpr ArenaBuildingType magesGuildBuildingType = ArenaBuildingType::MagesGuild;
+	constexpr ArenaBuildingType cryptBuildingType = ArenaBuildingType::Crypt;
 
 	Span<const uint8_t> enemyEncounterChances = exeData.entities.enemyEncounterChances;
 
@@ -1029,13 +1030,13 @@ void ArenaEntityUtils::getEncounterParameters(int currentEnvironmentType, int cu
 	const bool isNightTime = (hour <= 5) || (hour >= 18);
 	bool allowNightEncounters = isNightTime;
 
-	if (currentEnvironmentType == buildingEnvironment)
+	if (currentEnvironmentType == buildingEnvironmentType)
 	{
-		if (currentBuildingType < cryptBuilding)
+		if (currentBuildingType < cryptBuildingType)
 		{
 			if (playerTrespassing)
 			{
-				if (currentBuildingType != magesGuildBuilding)
+				if (currentBuildingType != magesGuildBuildingType)
 				{
 					encounterTableIndex = 6;
 				}
@@ -1044,7 +1045,7 @@ void ArenaEntityUtils::getEncounterParameters(int currentEnvironmentType, int cu
 				encounterChance = 20;
 			}
 		}
-		else if (currentBuildingType == cryptBuilding)
+		else if (currentBuildingType == cryptBuildingType)
 		{
 			if (playerResting)
 			{
@@ -1069,9 +1070,9 @@ void ArenaEntityUtils::getEncounterParameters(int currentEnvironmentType, int cu
 			allowNightEncounters = false;
 		}
 	}
-	else if (currentEnvironmentType == cityEnvironment || currentEnvironmentType == wildernessEnvironment)
+	else if (currentEnvironmentType == cityEnvironmentType || currentEnvironmentType == wildernessEnvironmentType)
 	{
-		if (currentEnvironmentType == wildernessEnvironment)
+		if (currentEnvironmentType == wildernessEnvironmentType)
 		{
 			encounterTableIndex = terrainType;
 		}
@@ -1080,7 +1081,7 @@ void ArenaEntityUtils::getEncounterParameters(int currentEnvironmentType, int cu
 			encounterTableIndex = 6;
 		}
 
-		encounterChancesIndex = currentEnvironmentType;
+		encounterChancesIndex = static_cast<int>(currentEnvironmentType);
 		if (allowNightEncounters)
 		{
 			encounterChancesIndex += 5;
@@ -1088,7 +1089,7 @@ void ArenaEntityUtils::getEncounterParameters(int currentEnvironmentType, int cu
 
 		encounterChance = enemyEncounterChances[encounterChancesIndex];
 
-		if (currentEnvironmentType == cityEnvironment)
+		if (currentEnvironmentType == cityEnvironmentType)
 		{
 			// City environment adds 5 to the chances index at night but then turns off this bool.
 			// If it didn't, encounterTableIndex would become 13 below and no encounter would happen.
@@ -1097,7 +1098,7 @@ void ArenaEntityUtils::getEncounterParameters(int currentEnvironmentType, int cu
 	}
 	else // Main quest dungeon or random dungeon
 	{
-		encounterChancesIndex = currentEnvironmentType;
+		encounterChancesIndex = static_cast<int>(currentEnvironmentType);
 		if (playerResting)
 		{
 			encounterChancesIndex += 5;

--- a/OpenTESArena/src/Entities/ArenaEntityUtils.cpp
+++ b/OpenTESArena/src/Entities/ArenaEntityUtils.cpp
@@ -7,6 +7,7 @@
 #include "../Math/ArenaMathUtils.h"
 #include "../Math/Random.h"
 #include "../Stats/CharacterClassLibrary.h"
+#include "../World/MapType.h"
 
 namespace
 {
@@ -1009,6 +1010,46 @@ int ArenaEntityUtils::getGuardShield(int guardType, const ExeData &exeData, Aren
 	constexpr int plateMaterialID = 0;
 	const Span<const uint8_t> guardShieldIDs = exeData.entities.guardShieldIDs;
 	return ArenaEntityUtils::pickNonMagicArmor(dummyQualityThreshold, plateMaterialID, guardShieldIDs[guardType], exeData, random);
+}
+
+bool ArenaEntityUtils::isEnemyEncounterAllowedOnMinuteChanged(MapType mapType, bool areCitizensPresent, bool isPlayerCamping, bool isPlayerOnRaisedPlatform)
+{
+	if (isPlayerOnRaisedPlatform)
+	{
+		return false;
+	}
+
+	if (mapType == MapType::City)
+	{
+		return !areCitizensPresent; // During night
+	}
+
+	if (mapType == MapType::Interior)
+	{
+		return !isPlayerCamping;
+	}
+
+	return false;
+}
+
+bool ArenaEntityUtils::isEnemyEncounterAllowedOnHourChanged(MapType mapType, bool isPlayerCamping, bool isPlayerOnRaisedPlatform)
+{
+	if (isPlayerOnRaisedPlatform)
+	{
+		return false;
+	}
+
+	if (mapType == MapType::Wilderness)
+	{
+		return true;
+	}
+
+	if (isPlayerCamping)
+	{
+		return true;
+	}
+
+	return false;
 }
 
 void ArenaEntityUtils::getEncounterParameters(ArenaEnvironmentType currentEnvironmentType, ArenaBuildingType currentBuildingType,

--- a/OpenTESArena/src/Entities/ArenaEntityUtils.cpp
+++ b/OpenTESArena/src/Entities/ArenaEntityUtils.cpp
@@ -1214,10 +1214,11 @@ ArenaEnemyEncounter ArenaEntityUtils::chooseEncounterEnemy(int encounterTableInd
 		encounterLevel = playerLevel - random.next(3);
 	}
 
+	DebugAssertIndex(exeData.entities.enemyEncounterTableIndices, encounterTableIndex);
 	const Span<const uint8_t> chosenEncounterTableIndices = exeData.entities.enemyEncounterTableIndices[encounterTableIndex];
 	int matches[] = { -1, -1 };
 	int count = 0;
-	for (int i = 0; (i < 85) && (count < 2); i++)
+	for (int i = 0; (i < chosenEncounterTableIndices.getCount()) && (count < 2); i++)
 	{
 		if (chosenEncounterTableIndices[i] == encounterLevel)
 		{
@@ -1230,6 +1231,7 @@ ArenaEnemyEncounter ArenaEntityUtils::chooseEncounterEnemy(int encounterTableInd
 	const int chosen = matches[random.next() & 1];
 	DebugAssert(chosen != -1);
 
+	DebugAssertIndex(exeData.entities.enemyEncounterTable, chosen);
 	const Span<const uint8_t> chosenEncounterTable = exeData.entities.enemyEncounterTable[chosen];
 
 	ArenaEnemyEncounter chosenEnemyEncounter;

--- a/OpenTESArena/src/Entities/ArenaEntityUtils.cpp
+++ b/OpenTESArena/src/Entities/ArenaEntityUtils.cpp
@@ -1201,7 +1201,7 @@ ArenaEnemyEncounter ArenaEntityUtils::chooseEncounterEnemy(int encounterTableInd
 			break;
 		}
 
-		encounterLevel *= 2;
+		encounterLevel = (encounterLevel >> 1) * 2;
 	}
 
 	if (playerLevel == 0 && encounterLevel >= 2)

--- a/OpenTESArena/src/Entities/ArenaEntityUtils.cpp
+++ b/OpenTESArena/src/Entities/ArenaEntityUtils.cpp
@@ -1012,19 +1012,20 @@ int ArenaEntityUtils::getGuardShield(int guardType, const ExeData &exeData, Aren
 	return ArenaEntityUtils::pickNonMagicArmor(dummyQualityThreshold, plateMaterialID, guardShieldIDs[guardType], exeData, random);
 }
 
-bool ArenaEntityUtils::isEnemyEncounterAllowedOnMinuteChanged(MapType mapType, bool areCitizensPresent, bool isPlayerCamping, bool isPlayerOnRaisedPlatform)
+bool ArenaEntityUtils::isEnemyEncounterAllowedOnMinuteChanged(ArenaEnvironmentType environmentType, bool areCitizensPresent,
+	bool isPlayerCamping, bool isPlayerOnRaisedPlatform)
 {
 	if (isPlayerOnRaisedPlatform)
 	{
 		return false;
 	}
 
-	if (mapType == MapType::City)
+	if (environmentType == ArenaEnvironmentType::City)
 	{
 		return !areCitizensPresent; // During night
 	}
 
-	if (mapType == MapType::Interior)
+	if (environmentType == ArenaEnvironmentType::BuildingInterior)
 	{
 		return !isPlayerCamping;
 	}
@@ -1032,14 +1033,14 @@ bool ArenaEntityUtils::isEnemyEncounterAllowedOnMinuteChanged(MapType mapType, b
 	return false;
 }
 
-bool ArenaEntityUtils::isEnemyEncounterAllowedOnHourChanged(MapType mapType, bool isPlayerCamping, bool isPlayerOnRaisedPlatform)
+bool ArenaEntityUtils::isEnemyEncounterAllowedOnHourChanged(ArenaEnvironmentType environmentType, bool isPlayerCamping, bool isPlayerOnRaisedPlatform)
 {
 	if (isPlayerOnRaisedPlatform)
 	{
 		return false;
 	}
 
-	if (mapType == MapType::Wilderness)
+	if (environmentType == ArenaEnvironmentType::Wilderness)
 	{
 		return true;
 	}

--- a/OpenTESArena/src/Entities/ArenaEntityUtils.h
+++ b/OpenTESArena/src/Entities/ArenaEntityUtils.h
@@ -11,7 +11,9 @@
 class ArenaRandom;
 class Random;
 
+enum class ArenaBuildingType;
 enum class ArenaCityType;
+enum class ArenaEnvironmentType;
 enum class ArenaInteriorType;
 enum class ArmorMaterialType;
 
@@ -112,7 +114,7 @@ namespace ArenaEntityUtils
 	int getGuardWeapon(const ExeData &exeData, ArenaRandom &random);
 	int getGuardShield(int guardType, const ExeData &exeData, ArenaRandom &random);
 
-	void getEncounterParameters(int currentEnvironmentType, int currentBuildingType, bool playerTrespassing, bool isResting, int terrainType, int gameHour, int dayOfYear, const ExeData &exeData, int *outEncounterChance, int *outEncounterTableIndex);
+	void getEncounterParameters(ArenaEnvironmentType currentEnvironmentType, ArenaBuildingType currentBuildingType, bool playerTrespassing, bool isResting, int terrainType, int gameHour, int dayOfYear, const ExeData &exeData, int *outEncounterChance, int *outEncounterTableIndex);
 	int rollWeightedEncounterLevel(int encounterLevel, ArenaRandom &random);
 	ArenaEnemyEncounter chooseEncounterEnemy(int encounterTableIndex, int encounterLevel, int playerLevel, bool mainQuestEncounter, ArenaRandom &random, const ExeData &exeData);
 

--- a/OpenTESArena/src/Entities/ArenaEntityUtils.h
+++ b/OpenTESArena/src/Entities/ArenaEntityUtils.h
@@ -54,6 +54,11 @@ struct ArenaEnemyEncounter
 
 namespace ArenaEntityUtils
 {
+	// Note that creature ID == creature index + 1.
+	// The final boss is a special case, essentially hardcoded at the end of the creatures.
+	constexpr int FinalBossCreatureID = 24;
+	constexpr int CreatureCount = FinalBossCreatureID;
+
 	// For monsters
 	int getBaseSpeed(int speedAttribute);
 

--- a/OpenTESArena/src/Entities/ArenaEntityUtils.h
+++ b/OpenTESArena/src/Entities/ArenaEntityUtils.h
@@ -16,6 +16,7 @@ enum class ArenaCityType;
 enum class ArenaEnvironmentType;
 enum class ArenaInteriorType;
 enum class ArmorMaterialType;
+enum class MapType;
 
 struct ExeData;
 
@@ -114,6 +115,8 @@ namespace ArenaEntityUtils
 	int getGuardWeapon(const ExeData &exeData, ArenaRandom &random);
 	int getGuardShield(int guardType, const ExeData &exeData, ArenaRandom &random);
 
+	bool isEnemyEncounterAllowedOnMinuteChanged(MapType mapType, bool areCitizensPresent, bool isPlayerCamping, bool isPlayerOnRaisedPlatform);
+	bool isEnemyEncounterAllowedOnHourChanged(MapType mapType, bool isPlayerCamping, bool isPlayerOnRaisedPlatform);
 	void getEncounterParameters(ArenaEnvironmentType currentEnvironmentType, ArenaBuildingType currentBuildingType, bool playerTrespassing, bool isResting, int terrainType, int gameHour, int dayOfYear, const ExeData &exeData, int *outEncounterChance, int *outEncounterTableIndex);
 	int rollWeightedEncounterLevel(int encounterLevel, ArenaRandom &random);
 	ArenaEnemyEncounter chooseEncounterEnemy(int encounterTableIndex, int encounterLevel, int playerLevel, bool mainQuestEncounter, ArenaRandom &random, const ExeData &exeData);

--- a/OpenTESArena/src/Entities/ArenaEntityUtils.h
+++ b/OpenTESArena/src/Entities/ArenaEntityUtils.h
@@ -16,7 +16,6 @@ enum class ArenaCityType;
 enum class ArenaEnvironmentType;
 enum class ArenaInteriorType;
 enum class ArmorMaterialType;
-enum class MapType;
 
 struct ExeData;
 
@@ -115,8 +114,8 @@ namespace ArenaEntityUtils
 	int getGuardWeapon(const ExeData &exeData, ArenaRandom &random);
 	int getGuardShield(int guardType, const ExeData &exeData, ArenaRandom &random);
 
-	bool isEnemyEncounterAllowedOnMinuteChanged(MapType mapType, bool areCitizensPresent, bool isPlayerCamping, bool isPlayerOnRaisedPlatform);
-	bool isEnemyEncounterAllowedOnHourChanged(MapType mapType, bool isPlayerCamping, bool isPlayerOnRaisedPlatform);
+	bool isEnemyEncounterAllowedOnMinuteChanged(ArenaEnvironmentType environmentType, bool areCitizensPresent, bool isPlayerCamping, bool isPlayerOnRaisedPlatform);
+	bool isEnemyEncounterAllowedOnHourChanged(ArenaEnvironmentType environmentType, bool isPlayerCamping, bool isPlayerOnRaisedPlatform);
 	void getEncounterParameters(ArenaEnvironmentType currentEnvironmentType, ArenaBuildingType currentBuildingType, bool playerTrespassing, bool isResting, int terrainType, int gameHour, int dayOfYear, const ExeData &exeData, int *outEncounterChance, int *outEncounterTableIndex);
 	int rollWeightedEncounterLevel(int encounterLevel, ArenaRandom &random);
 	ArenaEnemyEncounter chooseEncounterEnemy(int encounterTableIndex, int encounterLevel, int playerLevel, bool mainQuestEncounter, ArenaRandom &random, const ExeData &exeData);

--- a/OpenTESArena/src/Entities/CreatureDefinitionLibrary.cpp
+++ b/OpenTESArena/src/Entities/CreatureDefinitionLibrary.cpp
@@ -3,16 +3,18 @@
 #include <cstring>
 
 #include "ArenaAnimUtils.h"
+#include "ArenaEntityUtils.h"
 #include "CreatureDefinitionLibrary.h"
 #include "../Assets/BinaryAssetLibrary.h"
 
 #include "components/debug/Debug.h"
 
-// @todo why does this need an isFinalBoss parameter? isn't it if creatureIndex == 25? check
-
-void CreatureDefinition::init(int creatureIndex, bool isFinalBoss, const ExeData &exeData)
+void CreatureDefinition::init(int creatureIndex, const ExeData &exeData)
 {
 	const auto &entities = exeData.entities;
+
+	const int finalBossCreatureIndex = ArenaAnimUtils::getCreatureIndexFromID(ArenaEntityUtils::FinalBossCreatureID);
+	const bool isFinalBoss = creatureIndex == finalBossCreatureIndex;
 
 	const std::string &nameStr = isFinalBoss ? entities.finalBossName : entities.creatureNames[creatureIndex];
 	std::snprintf(std::begin(this->name), std::size(this->name), "%s", nameStr.c_str());
@@ -35,8 +37,8 @@ void CreatureDefinition::init(int creatureIndex, bool isFinalBoss, const ExeData
 	this->bloodIndex = entities.creatureBlood[creatureIndex];
 	this->diseaseChances = entities.creatureDiseaseChances[creatureIndex];
 
-	const auto &srcAttributes = entities.creatureAttributes[creatureIndex];
-	std::copy(std::begin(srcAttributes), std::end(srcAttributes), std::begin(this->attributes));
+	const Span<const uint8_t> srcAttributes = entities.creatureAttributes[creatureIndex];
+	std::copy(srcAttributes.begin(), srcAttributes.end(), std::begin(this->attributes));
 
 	if (isFinalBoss)
 	{
@@ -154,12 +156,10 @@ bool CreatureDefinition::operator==(const CreatureDefinition &other) const
 
 void CreatureDefinitionLibrary::init(const ExeData &exeData)
 {
-	for (int creatureIndex = 0; creatureIndex < ArenaAnimUtils::CreatureCount; creatureIndex++)
+	for (int creatureIndex = 0; creatureIndex < ArenaEntityUtils::CreatureCount; creatureIndex++)
 	{
-		const bool isFinalBoss = creatureIndex == (ArenaAnimUtils::FinalBossCreatureID - 1);
-
 		CreatureDefinition creatureDef;
-		creatureDef.init(creatureIndex, isFinalBoss, exeData);
+		creatureDef.init(creatureIndex, exeData);
 		this->entries.emplace_back(std::move(creatureDef));
 	}
 }
@@ -173,4 +173,10 @@ const CreatureDefinition &CreatureDefinitionLibrary::getDefinition(CreatureDefin
 {
 	DebugAssertIndex(this->entries, id);
 	return this->entries[id];
+}
+
+CreatureDefinitionID CreatureDefinitionLibrary::getDefinitionIdFromOriginalID(int creatureID) const
+{
+	const int creatureIndex = ArenaAnimUtils::getCreatureIndexFromID(creatureID);
+	return static_cast<CreatureDefinitionID>(creatureIndex);
 }

--- a/OpenTESArena/src/Entities/CreatureDefinitionLibrary.h
+++ b/OpenTESArena/src/Entities/CreatureDefinitionLibrary.h
@@ -30,7 +30,7 @@ struct CreatureDefinition
 	uint32_t lootChances;
 	bool ghost;
 
-	void init(int creatureIndex, bool isFinalBoss, const ExeData &exeData);
+	void init(int creatureIndex, const ExeData &exeData);
 
 	bool operator==(const CreatureDefinition &other) const;
 };
@@ -47,4 +47,7 @@ public:
 	int getDefinitionCount() const;
 
 	const CreatureDefinition &getDefinition(CreatureDefinitionID id) const;
+
+	// From the 1-based creature ID.
+	CreatureDefinitionID getDefinitionIdFromOriginalID(int creatureID) const;
 };

--- a/OpenTESArena/src/Entities/EntityDefinitionLibrary.cpp
+++ b/OpenTESArena/src/Entities/EntityDefinitionLibrary.cpp
@@ -1,4 +1,5 @@
 #include "ArenaAnimUtils.h"
+#include "ArenaEntityUtils.h"
 #include "EntityAnimationLibrary.h"
 #include "EntityDefinitionLibrary.h"
 #include "../Assets/ArenaTypes.h"
@@ -220,7 +221,7 @@ void EntityDefinitionLibrary::init(const ExeData &exeData, const CharacterClassL
 	};
 
 	// Iterate all creatures + final boss.
-	for (int i = 0; i < ArenaAnimUtils::CreatureCount; i++)
+	for (int i = 0; i < ArenaEntityUtils::CreatureCount; i++)
 	{
 		addCreatureDef(i);
 	}

--- a/OpenTESArena/src/Game/GameState.cpp
+++ b/OpenTESArena/src/Game/GameState.cpp
@@ -376,20 +376,43 @@ ArenaEnvironmentType GameState::getEnvironmentType() const
 	return environmentType;
 }
 
-ArenaInteriorType GameState::getInteriorType() const
+ArenaBuildingType GameState::getBuildingType() const
 {
-	ArenaInteriorType interiorType = ArenaInteriorType::None;
-
 	const MapType mapType = this->getActiveMapType();
-	if (mapType == MapType::Interior)
+	if (mapType != MapType::Interior)
 	{
-		const MapDefinition &mapDef = this->getActiveMapDef();
-		const MapSubDefinition &mapSubDef = mapDef.getSubDefinition();
-		const MapDefinitionInterior &interiorDef = mapSubDef.interior;
-		return interiorDef.interiorType;
+		return ArenaBuildingType::None;
 	}
 
-	return interiorType;
+	const MapDefinition &mapDef = this->getActiveMapDef();
+	const MapSubDefinition &mapSubDef = mapDef.getSubDefinition();
+	const MapDefinitionInterior &interiorDef = mapSubDef.interior;
+	const ArenaInteriorType interiorType = interiorDef.interiorType;
+
+	constexpr std::pair<ArenaInteriorType, ArenaBuildingType> interiorTypeMappings[] =
+	{
+		{ ArenaInteriorType::Crypt, ArenaBuildingType::Crypt },
+		{ ArenaInteriorType::Dungeon, ArenaBuildingType::None },
+		{ ArenaInteriorType::Equipment, ArenaBuildingType::Equipment },
+		{ ArenaInteriorType::House, ArenaBuildingType::House },
+		{ ArenaInteriorType::MagesGuild, ArenaBuildingType::MagesGuild },
+		{ ArenaInteriorType::Noble, ArenaBuildingType::Noble },
+		{ ArenaInteriorType::Palace, ArenaBuildingType::Palace },
+		{ ArenaInteriorType::Tavern, ArenaBuildingType::Tavern },
+		{ ArenaInteriorType::Temple, ArenaBuildingType::Temple },
+		{ ArenaInteriorType::Tower, ArenaBuildingType::Tower }
+	};
+
+	const auto mappingsBegin = std::begin(interiorTypeMappings);
+	const auto mappingsEnd = std::end(interiorTypeMappings);
+	const auto iter = std::find_if(mappingsBegin, mappingsEnd,
+		[interiorType](const std::pair<ArenaInteriorType, ArenaBuildingType> &pair)
+	{
+		return pair.first == interiorType;
+	});
+
+	DebugAssert(iter != mappingsEnd);
+	return iter->second;
 }
 
 WorldMapInstance &GameState::getWorldMapInstance()
@@ -1050,14 +1073,14 @@ void GameState::tickGameClock(double dt, Game &game)
 		// Roll for random encounter.
 		const ArenaEnvironmentType environmentType = this->getEnvironmentType();
 		const int environmentTypeValue = static_cast<int>(environmentType);
-		const ArenaInteriorType interiorType = this->getInteriorType();
-		const int interiorTypeValue = static_cast<int>(interiorType);
+		const ArenaBuildingType buildingType = this->getBuildingType();
+		const int buildingTypeValue = static_cast<int>(buildingType);
 		//@todo: The original game checks for trespassing at the moment of entering an interior, not every hour as done here.
-		const bool isTrespassing = ArenaInteriorUtils::isPlayerTrespassing(interiorType, isNightForEncounters);
+		const bool isTrespassing = ArenaInteriorUtils::isPlayerTrespassing(buildingType, isNightForEncounters);
 		const int terrainType = 0; //@todo: Pass in terrain type
 		int encounterChance;
 		int encounterChanceTableIndex;
-		ArenaEntityUtils::getEncounterParameters(environmentTypeValue, interiorTypeValue, isTrespassing, this->isCamping, terrainType, newHour, currentDay, exeData, &encounterChance, &encounterChanceTableIndex);
+		ArenaEntityUtils::getEncounterParameters(environmentTypeValue, buildingTypeValue, isTrespassing, this->isCamping, terrainType, newHour, currentDay, exeData, &encounterChance, &encounterChanceTableIndex);
 
 		if (encounterChance > arenaRandom.next(100))
 		{

--- a/OpenTESArena/src/Game/GameState.cpp
+++ b/OpenTESArena/src/Game/GameState.cpp
@@ -346,6 +346,52 @@ bool GameState::isActiveMapNested() const
 	return this->prevMapDef.isValid();
 }
 
+ArenaEnvironmentType GameState::getEnvironmentType() const
+{
+	ArenaEnvironmentType environmentType = ArenaEnvironmentType::City;
+
+	const MapType mapType = this->getActiveMapType();
+	if (mapType == MapType::Wilderness)
+	{
+		environmentType = ArenaEnvironmentType::Wilderness;
+	}
+	else if (mapType == MapType::Interior)
+	{
+		const LocationDefinition &locationDef = this->getLocationDefinition();
+		const LocationDefinitionType locationType = locationDef.getType();
+		if (locationType == LocationDefinitionType::MainQuestDungeon)
+		{
+			environmentType = ArenaEnvironmentType::MainQuestDungeon;
+		}
+		else if (locationType == LocationDefinitionType::Dungeon)
+		{
+			environmentType = ArenaEnvironmentType::WorldMapDungeon;
+		}
+		else if (locationType == LocationDefinitionType::City)
+		{
+			environmentType = ArenaEnvironmentType::Interior;
+		}
+	}
+
+	return environmentType;
+}
+
+ArenaInteriorType GameState::getInteriorType() const
+{
+	ArenaInteriorType interiorType = ArenaInteriorType::None;
+
+	const MapType mapType = this->getActiveMapType();
+	if (mapType == MapType::Interior)
+	{
+		const MapDefinition &mapDef = this->getActiveMapDef();
+		const MapSubDefinition &mapSubDef = mapDef.getSubDefinition();
+		const MapDefinitionInterior &interiorDef = mapSubDef.interior;
+		return interiorDef.interiorType;
+	}
+
+	return interiorType;
+}
+
 WorldMapInstance &GameState::getWorldMapInstance()
 {
 	return this->worldMapInst;
@@ -668,10 +714,10 @@ void GameState::queueGuardSpawn(Game &game)
 
 void GameState::spawnEnemies(Game &game, int spawnId, int spawnLevel, int spawnCount) const
 {
-	const Player& player = game.player;
-	ArenaRandom& arenaRandom = game.arenaRandom;
+	const Player &player = game.player;
+	ArenaRandom &arenaRandom = game.arenaRandom;
 
-	const VoxelChunkManager& voxelChunkManager = game.sceneManager.voxelChunkManager;
+	const VoxelChunkManager &voxelChunkManager = game.sceneManager.voxelChunkManager;
 	const MapType mapType = this->getActiveMapType();
 	const double ceilingScale = this->getActiveCeilingScale();
 	const WorldDouble3 playerFeetPosition = player.getFeetPosition();
@@ -704,24 +750,24 @@ void GameState::spawnEnemies(Game &game, int spawnId, int spawnLevel, int spawnC
 		const VoxelInt3 spawnedEnemyVoxel = spawnedEnemyVoxelCoord.voxel;
 		const VoxelShapeDefID spawnedEnemyVoxelShapeDefID = spawnedEnemyVoxelChunk->shapeDefIDs.get(spawnedEnemyVoxel.x, 1, spawnedEnemyVoxel.z);
 		const VoxelTraitsDefID spawnedEnemyFloorVoxelTraitsDefID = spawnedEnemyVoxelChunk->traitsDefIDs.get(spawnedEnemyVoxel.x, 0, spawnedEnemyVoxel.z);
-		const VoxelShapeDefinition& spawnedEnemyVoxelShapeDef = spawnedEnemyVoxelChunk->shapeDefs[spawnedEnemyVoxelShapeDefID];
-		const VoxelTraitsDefinition& spawnedEnemyFloorVoxelTraitsDef = spawnedEnemyVoxelChunk->traitsDefs[spawnedEnemyFloorVoxelTraitsDefID];
+		const VoxelShapeDefinition &spawnedEnemyVoxelShapeDef = spawnedEnemyVoxelChunk->shapeDefs[spawnedEnemyVoxelShapeDefID];
+		const VoxelTraitsDefinition &spawnedEnemyFloorVoxelTraitsDef = spawnedEnemyVoxelChunk->traitsDefs[spawnedEnemyFloorVoxelTraitsDefID];
 		const bool isSpawnVoxelValid = spawnedEnemyVoxelShapeDef.mesh.isEmpty() && spawnedEnemyFloorVoxelTraitsDef.type == ArenaVoxelType::Floor;
 		if (!isSpawnVoxelValid)
 		{
 			continue;
 		}
 
-		const EntityDefinitionLibrary& entityDefLibrary = EntityDefinitionLibrary::getInstance();
+		const EntityDefinitionLibrary &entityDefLibrary = EntityDefinitionLibrary::getInstance();
 		const EntityDefID spawnedEnemyEntityDefID = entityDefLibrary.findDefinitionIdIf(
-			[spawnId](const EntityDefinition& entityDef)
+			[spawnId](const EntityDefinition &entityDef)
 			{
 				if (entityDef.type != EntityDefinitionType::Enemy)
 				{
 					return false;
 				}
 
-				const EnemyEntityDefinition& enemyDef = entityDef.enemy;
+				const EnemyEntityDefinition &enemyDef = entityDef.enemy;
 				constexpr int lastCreatureID = 23;
 				if (spawnId > lastCreatureID)
 				{
@@ -730,9 +776,9 @@ void GameState::spawnEnemies(Game &game, int spawnId, int spawnLevel, int spawnC
 						return false;
 					}
 
-					const EnemyEntityHumanDefinition& humanEnemyDef = enemyDef.human;
-					const CharacterClassLibrary& charClassLibrary = CharacterClassLibrary::getInstance();
-					const CharacterClassDefinition& charClassDef = charClassLibrary.getDefinition(humanEnemyDef.charClassID);
+					const EnemyEntityHumanDefinition &humanEnemyDef = enemyDef.human;
+					const CharacterClassLibrary &charClassLibrary = CharacterClassLibrary::getInstance();
+					const CharacterClassDefinition &charClassDef = charClassLibrary.getDefinition(humanEnemyDef.charClassID);
 					constexpr int spawnIdToClassNumberDifference = 24;
 					const int originalEnemyClassNumber = spawnId - spawnIdToClassNumberDifference;
 					return charClassDef.originalClassIndex == originalEnemyClassNumber;
@@ -745,8 +791,8 @@ void GameState::spawnEnemies(Game &game, int spawnId, int spawnLevel, int spawnC
 				return enemyDef.creatureDefID == spawnId;
 			});
 
-		const EntityDefinition& spawnedEnemyEntityDef = entityDefLibrary.getDefinition(spawnedEnemyEntityDefID);
-		const EntityAnimationDefinition& spawnedEnemyAnimDef = spawnedEnemyEntityDef.animDef;
+		const EntityDefinition &spawnedEnemyEntityDef = entityDefLibrary.getDefinition(spawnedEnemyEntityDefID);
+		const EntityAnimationDefinition &spawnedEnemyAnimDef = spawnedEnemyEntityDef.animDef;
 
 		const WorldDouble2 spawnedEnemyFeetPositionXZ = VoxelUtils::getVoxelCenter(spawnedEnemyWorldVoxelXZ);
 		const WorldDouble3 spawnedEnemyFeetPosition(spawnedEnemyFeetPositionXZ.x, ceilingScale, spawnedEnemyFeetPositionXZ.y);
@@ -765,11 +811,11 @@ void GameState::spawnEnemies(Game &game, int spawnId, int spawnLevel, int spawnC
 		else
 			spawnedEnemyEntityInitInfo.hasCreatureSound = true;
 
-		Renderer& renderer = game.renderer;
-		EntityChunkManager& entityChunkManager = game.sceneManager.entityChunkManager;
+		Renderer &renderer = game.renderer;
+		EntityChunkManager &entityChunkManager = game.sceneManager.entityChunkManager;
 		entityChunkManager.createEntity(spawnedEnemyEntityInitInfo, game.random, game.physicsSystem, renderer);
 
-		RenderEntityManager& renderEntityManager = game.sceneManager.renderEntityManager;
+		RenderEntityManager &renderEntityManager = game.sceneManager.renderEntityManager;
 		renderEntityManager.loadMaterialsForEntity(spawnedEnemyEntityDefID, game.textureManager, renderer);
 
 		actualSpawnedEnemyCount++;
@@ -964,36 +1010,8 @@ void GameState::tickGameClock(double dt, Game &game)
 	const Clock prevClock = this->clock;
 	const double timeScale = GameState::GAME_TIME_SCALE * (this->isCamping ? 250.0 : 1.0);
 	this->clock.incrementTime(dt * timeScale);
-
 	const int prevHour = prevClock.hours;
 	const int newHour = this->clock.hours;
-	bool isNight = (newHour < 6 || newHour > 18);
-	const Player &player = game.player;
-	const auto &exeData = BinaryAssetLibrary::getInstance().getExeData();
-	if (newHour != prevHour)
-	{
-		// Update possible weathers list.
-		this->updateWeatherList(game.arenaRandom, exeData);
-
-		// Roll for random encounter
-		if ((this->isCamping || this->getActiveMapType() == MapType::Wilderness) && !player.groundState.onRaisedPlatform)
-		{
-			int encounterChance;
-			int encounterChanceTableIndex;
-			int arenaEnvironmentType = getArenaEnvironmentType();
-			int arenaBuildingType = getArenaBuildingType();
-			//@todo: The original game checks for trespassing at the moment of entering an interior, not every hour as done here.
-			bool isTrespassing = getIsTrespassing(arenaBuildingType, isNight);
-
-			//@todo: Pass in terrain type
-			ArenaEntityUtils::getEncounterParameters(arenaEnvironmentType, arenaBuildingType, isTrespassing, this->isCamping, 0, newHour, this->date.getDay(), exeData, &encounterChance, &encounterChanceTableIndex);
-			if (encounterChance > game.arenaRandom.next() % 100)
-			{
-				ArenaEnemyEncounter encounter = ArenaEntityUtils::chooseEncounterEnemy(encounterChanceTableIndex, player.level, player.level, false, game.arenaRandom, exeData);
-				spawnEnemies(game, encounter.id, encounter.level, encounter.count);
-			}
-		}
-	}
 
 	// Check if the clock hour looped back around.
 	if (newHour < prevHour)
@@ -1001,28 +1019,52 @@ void GameState::tickGameClock(double dt, Game &game)
 		this->date.incrementDay();
 	}
 
-	const int prevMinute = prevClock.minutes;
-	const int newMinute = this->clock.minutes;
-	if (newMinute != prevMinute)
-	{
-		// Roll for random encounter. In the original game, the presence of citizens in city maps prevents encounters from spawning during the day.
-		// Here this is being done through a check that it is night.
-		if (((this->getActiveMapType() == MapType::City && isNight) || (this->getActiveMapType() == MapType::Interior && !isCamping)) && !player.groundState.onRaisedPlatform)
-		{
-			int encounterChance;
-			int encounterChanceTableIndex;
+	const int currentDay = this->date.getDay();
+	const bool isNightForEncounters = (newHour < 6) || (newHour > 18);
+	const Player &player = game.player;
+	const MapDefinition &activeMapDef = this->getActiveMapDef();
+	const MapType activeMapType = activeMapDef.getMapType();
+	const ExeData &exeData = BinaryAssetLibrary::getInstance().getExeData();
+	ArenaRandom &arenaRandom = game.arenaRandom;
 
-			int arenaEnvironmentType = getArenaEnvironmentType();
-			int arenaBuildingType = getArenaBuildingType();
-			//@todo: The original game checks for trespassing at the moment of entering an interior, not every minute as done here.
-			bool isTrespassing = getIsTrespassing(arenaBuildingType, isNight);
-			//@todo: Pass in terrain type.
-			ArenaEntityUtils::getEncounterParameters(arenaEnvironmentType, arenaBuildingType, isTrespassing, this->isCamping, 0, newHour, this->date.getDay(), exeData, &encounterChance, &encounterChanceTableIndex);
-			if (encounterChance > game.arenaRandom.next() % 100)
-			{
-				ArenaEnemyEncounter encounter = ArenaEntityUtils::chooseEncounterEnemy(encounterChanceTableIndex, player.level, player.level, false, game.arenaRandom, exeData);
-				spawnEnemies(game, encounter.id, encounter.level, encounter.count);
-			}
+	bool canAttemptEnemyEncounterThisHour = false;
+	if (newHour != prevHour)
+	{
+		canAttemptEnemyEncounterThisHour = (this->isCamping || activeMapType == MapType::Wilderness) && !player.groundState.onRaisedPlatform;
+
+		this->updateWeatherList(arenaRandom, exeData);
+	}
+
+	const int prevMinutes = prevClock.minutes;
+	const int newMinutes = this->clock.minutes;
+	bool canAttemptEnemyEncounterThisMinute = false;
+	if (newMinutes != prevMinutes)
+	{
+		// In the original game, the presence of citizens in city maps prevents encounters from spawning during the day.
+		// Here this is being done through a check that it is night.
+		const bool areCitizensPresent = !isNightForEncounters;
+		canAttemptEnemyEncounterThisMinute = ((activeMapType == MapType::City && !areCitizensPresent) || (activeMapType == MapType::Interior && !this->isCamping)) && !player.groundState.onRaisedPlatform;
+	}
+
+	const bool canAttemptEnemyEncounter = canAttemptEnemyEncounterThisHour || canAttemptEnemyEncounterThisMinute;
+	if (canAttemptEnemyEncounter)
+	{
+		// Roll for random encounter.
+		const ArenaEnvironmentType environmentType = this->getEnvironmentType();
+		const int environmentTypeValue = static_cast<int>(environmentType);
+		const ArenaInteriorType interiorType = this->getInteriorType();
+		const int interiorTypeValue = static_cast<int>(interiorType);
+		//@todo: The original game checks for trespassing at the moment of entering an interior, not every hour as done here.
+		const bool isTrespassing = this->isPlayerTrespassing(interiorType, isNightForEncounters);
+		const int terrainType = 0; //@todo: Pass in terrain type
+		int encounterChance;
+		int encounterChanceTableIndex;
+		ArenaEntityUtils::getEncounterParameters(environmentTypeValue, interiorTypeValue, isTrespassing, this->isCamping, terrainType, newHour, currentDay, exeData, &encounterChance, &encounterChanceTableIndex);
+
+		if (encounterChance > arenaRandom.next(100))
+		{
+			const ArenaEnemyEncounter encounter = ArenaEntityUtils::chooseEncounterEnemy(encounterChanceTableIndex, player.level, player.level, false, arenaRandom, exeData);
+			this->spawnEnemies(game, encounter.id, encounter.level, encounter.count);
 		}
 	}
 
@@ -1048,8 +1090,6 @@ void GameState::tickGameClock(double dt, Game &game)
 	}
 
 	// Check for changes in exterior music depending on the time.
-	const MapDefinition &activeMapDef = this->getActiveMapDef();
-	const MapType activeMapType = activeMapDef.getMapType();
 	if ((activeMapType != MapType::Interior) && !player.groundState.isSwimming)
 	{
 		const Clock &dayMusicStartClock = clockLibrary.getClock(ArenaClockUtils::MusicSwitchToDay);
@@ -1094,109 +1134,19 @@ void GameState::tickGameClock(double dt, Game &game)
 	}
 }
 
-int GameState::getArenaEnvironmentType() const
+bool GameState::isPlayerTrespassing(ArenaInteriorType interiorType, bool isNight) const
 {
-	const ProvinceDefinition& provinceDef = this->worldMapDef.getProvinceDef(provinceIndex);
-	const LocationDefinition& locationDef = provinceDef.getLocationDef(locationIndex);
-
-	int arenaEnvironmentType = -1;
-	if (this->getActiveMapType() == MapType::City)
-	{
-		arenaEnvironmentType = 0;
-	}
-	if (this->getActiveMapType() == MapType::Wilderness)
-	{
-		arenaEnvironmentType = 1;
-	}
-	else if (this->getActiveMapType() == MapType::Interior)
-	{
-		LocationDefinitionType locationType = locationDef.getType();
-		if (locationType == LocationDefinitionType::MainQuestDungeon)
-		{
-			arenaEnvironmentType = 2;
-		}
-		else if (locationType == LocationDefinitionType::Dungeon)
-		{
-			arenaEnvironmentType = 3;
-		}
-		else if (locationType == LocationDefinitionType::City)
-		{
-			arenaEnvironmentType = 4;
-		}
-	}
-
-	DebugAssert(arenaEnvironmentType != -1);
-	return arenaEnvironmentType;
-}
-
-int GameState::getArenaBuildingType() const
-{
-	const MapDefinition& mapDef = this->getActiveMapDef();
-	const MapSubDefinition& mapSubDef = mapDef.getSubDefinition();
-	int arenaBuildingType = -1;
-
-	if (mapSubDef.type == MapType::Interior)
-	{
-		ArenaInteriorType lootInteriorType = mapSubDef.interior.interiorType;
-
-		switch (lootInteriorType)
-		{
-		case ArenaInteriorType::Crypt:
-		{
-			arenaBuildingType = 8;
-			break;
-		}
-		case ArenaInteriorType::Equipment:
-		{
-			arenaBuildingType = 6;
-			break;
-		}
-		case ArenaInteriorType::House:
-		{
-			arenaBuildingType = 2;
-			break;
-		}
-		case ArenaInteriorType::MagesGuild:
-		{
-			arenaBuildingType = 7;
-			break;
-		}
-		case ArenaInteriorType::Noble:
-		{
-			arenaBuildingType = 3;
-			break;
-		}
-		case ArenaInteriorType::Palace:
-		{
-			arenaBuildingType = 1;
-			break;
-		}
-		case ArenaInteriorType::Tavern:
-		{
-			arenaBuildingType = 4;
-			break;
-		}
-		case ArenaInteriorType::Temple:
-		{
-			arenaBuildingType = 5;
-			break;
-		}
-		case ArenaInteriorType::Tower:
-		{
-			arenaBuildingType = 11;
-		}
-		}
-	}
-
-	return arenaBuildingType;
-}
-
-bool GameState::getIsTrespassing(int arenaBuildingType, bool isNight)
-{
-	// The player is trespassing if they enter a common or noble house, or any building but a tavern, crypt or tower at night.
-	if (arenaBuildingType == 2 || arenaBuildingType == 3 || (isNight && (arenaBuildingType != 4 && arenaBuildingType != 8 && arenaBuildingType != 11)))
+	if (interiorType == ArenaInteriorType::House || interiorType == ArenaInteriorType::Noble)
 	{
 		return true;
+	}
+
+	if (isNight)
+	{
+		if (interiorType != ArenaInteriorType::Tavern && interiorType != ArenaInteriorType::Crypt && interiorType != ArenaInteriorType::Tower)
+		{
+			return true;
+		}
 	}
 
 	return false;

--- a/OpenTESArena/src/Game/GameState.cpp
+++ b/OpenTESArena/src/Game/GameState.cpp
@@ -336,8 +336,7 @@ double GameState::getActiveCeilingScale() const
 		return 0.0;
 	}
 
-	Span<const LevelInfoDefinition> levelInfoDefs = this->activeMapDef.getLevelInfos();
-	const LevelInfoDefinition &levelInfoDef = levelInfoDefs[this->activeLevelIndex];
+	const LevelInfoDefinition &levelInfoDef = this->activeMapDef.getLevelInfoForLevel(this->activeLevelIndex);
 	return levelInfoDef.getCeilingScale();
 }
 

--- a/OpenTESArena/src/Game/GameState.cpp
+++ b/OpenTESArena/src/Game/GameState.cpp
@@ -714,6 +714,7 @@ void GameState::queueGuardSpawn(Game &game)
 
 void GameState::spawnEnemies(Game &game, int spawnId, int spawnLevel, int spawnCount) const
 {
+	// @todo deduplicate this code by combining with queueSpawnGuard()
 	const Player &player = game.player;
 	ArenaRandom &arenaRandom = game.arenaRandom;
 
@@ -806,10 +807,7 @@ void GameState::spawnEnemies(Game &game, int spawnId, int spawnLevel, int spawnC
 		spawnedEnemyEntityInitInfo.direction = CardinalDirection::North;
 		spawnedEnemyEntityInitInfo.humanEnemyLevel = spawnLevel;
 		spawnedEnemyEntityInitInfo.hasInventory = true;
-		if (spawnId > 23)
-			spawnedEnemyEntityInitInfo.hasCreatureSound = false;
-		else
-			spawnedEnemyEntityInitInfo.hasCreatureSound = true;
+		spawnedEnemyEntityInitInfo.hasCreatureSound = spawnId <= 23;
 
 		Renderer &renderer = game.renderer;
 		EntityChunkManager &entityChunkManager = game.sceneManager.entityChunkManager;

--- a/OpenTESArena/src/Game/GameState.cpp
+++ b/OpenTESArena/src/Game/GameState.cpp
@@ -1042,6 +1042,8 @@ void GameState::tickGameClock(double dt, Game &game)
 
 	const int currentDay = this->date.getDay();
 	const bool isNightForEncounters = (newHour < 6) || (newHour > 18);
+	const ArenaEnvironmentType environmentType = this->getEnvironmentType();
+	const ArenaBuildingType buildingType = this->getBuildingType();
 	const Player &player = game.player;
 	const MapDefinition &activeMapDef = this->getActiveMapDef();
 	const MapType activeMapType = activeMapDef.getMapType();
@@ -1051,7 +1053,7 @@ void GameState::tickGameClock(double dt, Game &game)
 	bool canAttemptEnemyEncounterThisHour = false;
 	if (newHour != prevHour)
 	{
-		canAttemptEnemyEncounterThisHour = ArenaEntityUtils::isEnemyEncounterAllowedOnHourChanged(activeMapType, this->isCamping, player.groundState.onRaisedPlatform);
+		canAttemptEnemyEncounterThisHour = ArenaEntityUtils::isEnemyEncounterAllowedOnHourChanged(environmentType, this->isCamping, player.groundState.onRaisedPlatform);
 
 		this->updateWeatherList(arenaRandom, exeData);
 	}
@@ -1064,15 +1066,13 @@ void GameState::tickGameClock(double dt, Game &game)
 		// In the original game, the presence of citizens in city maps prevents encounters from spawning during the day.
 		// Here this is being done through a check that it is night.
 		const bool areCitizensPresent = !isNightForEncounters;
-		canAttemptEnemyEncounterThisMinute = ArenaEntityUtils::isEnemyEncounterAllowedOnMinuteChanged(activeMapType, areCitizensPresent, this->isCamping, player.groundState.onRaisedPlatform);
+		canAttemptEnemyEncounterThisMinute = ArenaEntityUtils::isEnemyEncounterAllowedOnMinuteChanged(environmentType, areCitizensPresent, this->isCamping, player.groundState.onRaisedPlatform);
 	}
 
 	const bool canAttemptEnemyEncounter = canAttemptEnemyEncounterThisHour || canAttemptEnemyEncounterThisMinute;
 	if (canAttemptEnemyEncounter)
 	{
 		// Roll for random encounter.
-		const ArenaEnvironmentType environmentType = this->getEnvironmentType();
-		const ArenaBuildingType buildingType = this->getBuildingType();
 		//@todo: The original game checks for trespassing at the moment of entering an interior, not every hour as done here.
 		const bool isTrespassing = ArenaInteriorUtils::isPlayerTrespassing(buildingType, isNightForEncounters);
 		const int terrainType = 0; //@todo: Pass in terrain type

--- a/OpenTESArena/src/Game/GameState.cpp
+++ b/OpenTESArena/src/Game/GameState.cpp
@@ -1051,7 +1051,7 @@ void GameState::tickGameClock(double dt, Game &game)
 	bool canAttemptEnemyEncounterThisHour = false;
 	if (newHour != prevHour)
 	{
-		canAttemptEnemyEncounterThisHour = (this->isCamping || activeMapType == MapType::Wilderness) && !player.groundState.onRaisedPlatform;
+		canAttemptEnemyEncounterThisHour = ArenaEntityUtils::isEnemyEncounterAllowedOnHourChanged(activeMapType, this->isCamping, player.groundState.onRaisedPlatform);
 
 		this->updateWeatherList(arenaRandom, exeData);
 	}
@@ -1064,7 +1064,7 @@ void GameState::tickGameClock(double dt, Game &game)
 		// In the original game, the presence of citizens in city maps prevents encounters from spawning during the day.
 		// Here this is being done through a check that it is night.
 		const bool areCitizensPresent = !isNightForEncounters;
-		canAttemptEnemyEncounterThisMinute = ((activeMapType == MapType::City && !areCitizensPresent) || (activeMapType == MapType::Interior && !this->isCamping)) && !player.groundState.onRaisedPlatform;
+		canAttemptEnemyEncounterThisMinute = ArenaEntityUtils::isEnemyEncounterAllowedOnMinuteChanged(activeMapType, areCitizensPresent, this->isCamping, player.groundState.onRaisedPlatform);
 	}
 
 	const bool canAttemptEnemyEncounter = canAttemptEnemyEncounterThisHour || canAttemptEnemyEncounterThisMinute;

--- a/OpenTESArena/src/Game/GameState.cpp
+++ b/OpenTESArena/src/Game/GameState.cpp
@@ -369,7 +369,7 @@ ArenaEnvironmentType GameState::getEnvironmentType() const
 		}
 		else if (locationType == LocationDefinitionType::City)
 		{
-			environmentType = ArenaEnvironmentType::Interior;
+			environmentType = ArenaEnvironmentType::BuildingInterior;
 		}
 	}
 
@@ -1072,15 +1072,13 @@ void GameState::tickGameClock(double dt, Game &game)
 	{
 		// Roll for random encounter.
 		const ArenaEnvironmentType environmentType = this->getEnvironmentType();
-		const int environmentTypeValue = static_cast<int>(environmentType);
 		const ArenaBuildingType buildingType = this->getBuildingType();
-		const int buildingTypeValue = static_cast<int>(buildingType);
 		//@todo: The original game checks for trespassing at the moment of entering an interior, not every hour as done here.
 		const bool isTrespassing = ArenaInteriorUtils::isPlayerTrespassing(buildingType, isNightForEncounters);
 		const int terrainType = 0; //@todo: Pass in terrain type
 		int encounterChance;
 		int encounterChanceTableIndex;
-		ArenaEntityUtils::getEncounterParameters(environmentTypeValue, buildingTypeValue, isTrespassing, this->isCamping, terrainType, newHour, currentDay, exeData, &encounterChance, &encounterChanceTableIndex);
+		ArenaEntityUtils::getEncounterParameters(environmentType, buildingType, isTrespassing, this->isCamping, terrainType, newHour, currentDay, exeData, &encounterChance, &encounterChanceTableIndex);
 
 		if (encounterChance > arenaRandom.next(100))
 		{

--- a/OpenTESArena/src/Game/GameState.cpp
+++ b/OpenTESArena/src/Game/GameState.cpp
@@ -46,6 +46,64 @@
 #include "components/debug/Debug.h"
 #include "components/utilities/String.h"
 
+namespace
+{
+	bool CityGuardEntityDefinitionPredicate(const EntityDefinition &entityDef)
+	{
+		if (entityDef.type != EntityDefinitionType::Enemy)
+		{
+			return false;
+		}
+
+		const EnemyEntityDefinition &enemyDef = entityDef.enemy;
+		if (enemyDef.type != EnemyEntityDefinitionType::Human)
+		{
+			return false;
+		}
+
+		const EnemyEntityHumanDefinition &humanEnemyDef = enemyDef.human;
+		const CharacterClassLibrary &charClassLibrary = CharacterClassLibrary::getInstance();
+		const CharacterClassDefinition &charClassDef = charClassLibrary.getDefinition(humanEnemyDef.charClassID);
+		constexpr int originalGuardClassNumber = 16;
+		return charClassDef.originalClassIndex == originalGuardClassNumber;
+	}
+
+	EntityDefinitionPredicate MakeOriginalSpawnEntityDefinitionPredicate(int spawnID)
+	{
+		return [spawnID](const EntityDefinition &entityDef)
+		{
+			if (entityDef.type != EntityDefinitionType::Enemy)
+			{
+				return false;
+			}
+
+			const EnemyEntityDefinition &enemyDef = entityDef.enemy;
+			if (spawnID >= ArenaEntityUtils::FinalBossCreatureID)
+			{
+				if (enemyDef.type != EnemyEntityDefinitionType::Human)
+				{
+					return false;
+				}
+
+				const EnemyEntityHumanDefinition &humanEnemyDef = enemyDef.human;
+				const CharacterClassLibrary &charClassLibrary = CharacterClassLibrary::getInstance();
+				const CharacterClassDefinition &charClassDef = charClassLibrary.getDefinition(humanEnemyDef.charClassID);
+				constexpr int spawnIdToClassNumberDifference = ArenaEntityUtils::FinalBossCreatureID;
+				const int originalEnemyClassNumber = spawnID - spawnIdToClassNumberDifference;
+				return charClassDef.originalClassIndex == originalEnemyClassNumber;
+			}
+			else if (enemyDef.type != EnemyEntityDefinitionType::Creature)
+			{
+				return false;
+			}
+
+			const CreatureDefinitionLibrary &creatureDefLibrary = CreatureDefinitionLibrary::getInstance();
+			const CreatureDefinitionID spawnCreatureDefID = creatureDefLibrary.getDefinitionIdFromOriginalID(spawnID);
+			return enemyDef.creatureDefID == spawnCreatureDefID;
+		};
+	}
+}
+
 GuardSpawnState::GuardSpawnState()
 {
 	this->clearQueue();
@@ -60,6 +118,34 @@ void GuardSpawnState::clearQueue()
 {
 	this->secondsTillSpawn = Constants::Infinity;
 	this->spawnFunc = []() { };
+}
+
+EntityEncounterSpawnInfo::EntityEncounterSpawnInfo()
+{
+	this->guardType = -1;
+	this->level = 0;
+	this->count = 0;
+}
+
+void EntityEncounterSpawnInfo::initCreaturesOrHumans(int spawnID, int level, int count)
+{
+	this->guardType = -1;
+	this->level = level;
+	this->count = count;
+	this->entityDefPredicate = MakeOriginalSpawnEntityDefinitionPredicate(spawnID);
+}
+
+void EntityEncounterSpawnInfo::initCityGuards(int guardType, int level, int count)
+{
+	this->guardType = guardType;
+	this->level = level;
+	this->count = count;
+	this->entityDefPredicate = CityGuardEntityDefinitionPredicate;
+}
+
+bool EntityEncounterSpawnInfo::isCityGuards() const
+{
+	return this->guardType >= 0;
 }
 
 GameState::WorldMapLocationIDs::WorldMapLocationIDs(int provinceID, int locationID)
@@ -604,7 +690,107 @@ void GameState::updateWeatherList(ArenaRandom &random, const ExeData &exeData)
 	}
 }
 
-void GameState::queueGuardSpawn(Game &game)
+void GameState::spawnEncounterEnemies(Game &game, const EntityEncounterSpawnInfo &spawnInfo) const
+{
+	const Player &player = game.player;
+	ArenaRandom &arenaRandom = game.arenaRandom;
+	SceneManager &sceneManager = game.sceneManager;
+	const VoxelChunkManager &voxelChunkManager = sceneManager.voxelChunkManager;
+	const MapType mapType = this->getActiveMapType();
+	const double ceilingScale = this->getActiveCeilingScale();
+	const WorldDouble3 playerFeetPosition = player.getFeetPosition();
+	const WorldInt3 playerFeetVoxel = VoxelUtils::pointToVoxel(playerFeetPosition, ceilingScale);
+	const OriginalInt2 playerFeetVoxelOriginalXZ = VoxelUtils::worldVoxelToOriginalVoxel(playerFeetVoxel.getXZ());
+	const OriginalInt2 originalPlayerPositionArenaUnits = GameWorldUiModel::getOriginalPlayerPositionArenaUnits(playerFeetPosition, mapType);
+	const int16_t originalPlayerPositionArenaUnitsX = static_cast<int16_t>(originalPlayerPositionArenaUnits.y);
+	const int16_t originalPlayerPositionArenaUnitsZ = static_cast<int16_t>(originalPlayerPositionArenaUnits.x);
+
+	const EntityDefinitionLibrary &entityDefLibrary = EntityDefinitionLibrary::getInstance();
+	const EntityDefID spawnEntityDefID = entityDefLibrary.findDefinitionIdIf(spawnInfo.entityDefPredicate);
+	const EntityDefinition &spawnEntityDef = entityDefLibrary.getDefinition(spawnEntityDefID);
+	const EntityAnimationDefinition &spawnAnimDef = spawnEntityDef.animDef;
+
+	DebugAssert(spawnEntityDef.type == EntityDefinitionType::Enemy);
+	const bool isCreature = spawnEntityDef.enemy.type == EnemyEntityDefinitionType::Creature;
+
+	int actualSpawnCount = 0;
+	for (int i = 0; i < spawnInfo.count; i++)
+	{
+		const ArenaEntitySpawnPoint spawnPositionArenaUnits = ArenaEntityUtils::findRandomSpawnLocationAroundPlayer(originalPlayerPositionArenaUnitsX, originalPlayerPositionArenaUnitsZ, arenaRandom);
+		const OriginalInt2 playerToSpawnOriginalVoxel(
+			(spawnPositionArenaUnits.x - originalPlayerPositionArenaUnitsX) / 128,
+			(spawnPositionArenaUnits.z - originalPlayerPositionArenaUnitsZ) / 128);
+		const OriginalInt2 spawnOriginalVoxel(
+			playerFeetVoxelOriginalXZ.x + playerToSpawnOriginalVoxel.x,
+			playerFeetVoxelOriginalXZ.y + playerToSpawnOriginalVoxel.y);
+		const WorldInt2 spawnWorldVoxelXZ = VoxelUtils::originalVoxelToWorldVoxel(spawnOriginalVoxel);
+		const WorldInt3 spawnWorldVoxel(spawnWorldVoxelXZ.x, 1, spawnWorldVoxelXZ.y);
+		const CoordInt3 spawnVoxelCoord = VoxelUtils::worldVoxelToCoord(spawnWorldVoxel);
+		const VoxelChunk *spawnVoxelChunk = voxelChunkManager.findChunkAtPosition(spawnVoxelCoord.chunk);
+		if (spawnVoxelChunk == nullptr)
+		{
+			continue;
+		}
+
+		const VoxelInt3 spawnVoxel = spawnVoxelCoord.voxel;
+		const VoxelShapeDefID spawnVoxelShapeDefID = spawnVoxelChunk->shapeDefIDs.get(spawnVoxel.x, 1, spawnVoxel.z);
+		const VoxelTraitsDefID spawnFloorVoxelTraitsDefID = spawnVoxelChunk->traitsDefIDs.get(spawnVoxel.x, 0, spawnVoxel.z);
+		const VoxelShapeDefinition &spawnVoxelShapeDef = spawnVoxelChunk->shapeDefs[spawnVoxelShapeDefID];
+		const VoxelTraitsDefinition &spawnFloorVoxelTraitsDef = spawnVoxelChunk->traitsDefs[spawnFloorVoxelTraitsDefID];
+		const bool isSpawnVoxelValid = spawnVoxelShapeDef.mesh.isEmpty() && spawnFloorVoxelTraitsDef.type == ArenaVoxelType::Floor;
+		if (!isSpawnVoxelValid)
+		{
+			continue;
+		}
+
+		const WorldDouble2 spawnFeetPositionXZ = VoxelUtils::getVoxelCenter(spawnWorldVoxelXZ);
+		const WorldDouble3 spawnFeetPosition(spawnFeetPositionXZ.x, ceilingScale, spawnFeetPositionXZ.y);
+
+		EntityInitInfo spawnEntityInitInfo;
+		spawnEntityInitInfo.defID = spawnEntityDefID;
+		spawnEntityInitInfo.feetPosition = spawnFeetPosition;
+		spawnEntityInitInfo.initialAnimStateIndex = *spawnAnimDef.findStateIndex(spawnAnimDef.initialStateName);
+		spawnEntityInitInfo.isSensorCollider = false;
+		spawnEntityInitInfo.canBeKilled = true;
+		spawnEntityInitInfo.direction = CardinalDirection::North;
+
+		if (!isCreature)
+		{
+			spawnEntityInitInfo.humanEnemyLevel = spawnInfo.level;
+		}
+		
+		spawnEntityInitInfo.hasInventory = true;
+		spawnEntityInitInfo.hasCreatureSound = isCreature;
+
+		if (spawnInfo.isCityGuards())
+		{
+			spawnEntityInitInfo.guardType = spawnInfo.guardType;
+		}
+
+		Renderer &renderer = game.renderer;
+		EntityChunkManager &entityChunkManager = sceneManager.entityChunkManager;
+		entityChunkManager.createEntity(spawnEntityInitInfo, game.random, game.physicsSystem, renderer);
+
+		RenderEntityManager &renderEntityManager = sceneManager.renderEntityManager;
+		renderEntityManager.loadMaterialsForEntity(spawnEntityDefID, game.textureManager, renderer);
+
+		if (spawnInfo.isCityGuards())
+		{
+			const bool isFirstSpawnedGuard = actualSpawnCount == 0;
+			if (isFirstSpawnedGuard)
+			{
+				const WorldDouble3 spawnSoundPosition = VoxelUtils::getVoxelCenter(spawnWorldVoxel, ceilingScale);
+
+				AudioManager &audioManager = game.audioManager;
+				audioManager.playSoundOneShot(ArenaSoundName::Halt, spawnSoundPosition);
+			}
+		}
+
+		actualSpawnCount++;
+	}
+}
+
+void GameState::queueCityGuardEncounter(Game &game)
 {
 	if (this->guardSpawnState.isQueued())
 	{
@@ -623,226 +809,21 @@ void GameState::queueGuardSpawn(Game &game)
 		if (!ArenaEntityUtils::doGuardsAppearForViolence(player.level, arenaRandom))
 		{
 			DebugLog("Decided not to spawn guards.");
+			return;
 		}
-
-		const VoxelChunkManager &voxelChunkManager = game.sceneManager.voxelChunkManager;
-		const ArenaCityType cityType = this->getLocationDefinition().getCityDefinition().type;
-		const MapType mapType = this->getActiveMapType();
-		const double ceilingScale = this->getActiveCeilingScale();
-		const WorldDouble3 playerFeetPosition = player.getFeetPosition();
-		const WorldInt3 playerFeetVoxel = VoxelUtils::pointToVoxel(playerFeetPosition, ceilingScale);
-		const OriginalInt2 playerFeetVoxelOriginalXZ = VoxelUtils::worldVoxelToOriginalVoxel(playerFeetVoxel.getXZ());
-		const OriginalInt2 originalPlayerPositionArenaUnits = GameWorldUiModel::getOriginalPlayerPositionArenaUnits(playerFeetPosition, mapType);
-		const int16_t originalPlayerPositionArenaUnitsX = static_cast<int16_t>(originalPlayerPositionArenaUnits.y);
-		const int16_t originalPlayerPositionArenaUnitsZ = static_cast<int16_t>(originalPlayerPositionArenaUnits.x);
 
 		const ExeData &exeData = BinaryAssetLibrary::getInstance().getExeData();
-		const int spawnedGuardType = ArenaEntityUtils::getGuardType(exeData, arenaRandom);
-		const int spawnedGuardLevel = ArenaEntityUtils::getGuardLevel(cityType, spawnedGuardType, exeData, arenaRandom);
-		const int spawnedGuardAttemptCount = ArenaEntityUtils::getNumberOfGuardsToSpawn(arenaRandom);
-		int actualSpawnedGuardCount = 0;
+		const LocationDefinition &locationDef = this->getLocationDefinition();
+		const LocationCityDefinition &cityDef = locationDef.getCityDefinition();
+		const ArenaCityType cityType = cityDef.type;
+		const int guardType = ArenaEntityUtils::getGuardType(exeData, arenaRandom);
+		const int guardLevel = ArenaEntityUtils::getGuardLevel(cityType, guardType, exeData, arenaRandom);
+		const int guardCount = ArenaEntityUtils::getNumberOfGuardsToSpawn(arenaRandom);
 
-		for (int i = 0; i < spawnedGuardAttemptCount; i++)
-		{
-			const ArenaEntitySpawnPoint spawnedGuardPositionArenaUnits = ArenaEntityUtils::findRandomSpawnLocationAroundPlayer(originalPlayerPositionArenaUnitsX, originalPlayerPositionArenaUnitsZ, arenaRandom);
-			const OriginalInt2 playerToSpawnedGuardOriginalVoxel(
-				(spawnedGuardPositionArenaUnits.x - originalPlayerPositionArenaUnitsX) / 128,
-				(spawnedGuardPositionArenaUnits.z - originalPlayerPositionArenaUnitsZ) / 128);
-			const OriginalInt2 spawnedGuardOriginalVoxel(
-				playerFeetVoxelOriginalXZ.x + playerToSpawnedGuardOriginalVoxel.x,
-				playerFeetVoxelOriginalXZ.y + playerToSpawnedGuardOriginalVoxel.y);
-			const WorldInt2 spawnedGuardWorldVoxelXZ = VoxelUtils::originalVoxelToWorldVoxel(spawnedGuardOriginalVoxel);
-			const WorldInt3 spawnedGuardWorldVoxel(spawnedGuardWorldVoxelXZ.x, 1, spawnedGuardWorldVoxelXZ.y);
-			const CoordInt3 spawnedGuardVoxelCoord = VoxelUtils::worldVoxelToCoord(spawnedGuardWorldVoxel);
-			const VoxelChunk *spawnedGuardVoxelChunk = voxelChunkManager.findChunkAtPosition(spawnedGuardVoxelCoord.chunk);
-			if (spawnedGuardVoxelChunk == nullptr)
-			{
-				continue;
-			}
-
-			const VoxelInt3 spawnedGuardVoxel = spawnedGuardVoxelCoord.voxel;
-			const VoxelShapeDefID spawnedGuardVoxelShapeDefID = spawnedGuardVoxelChunk->shapeDefIDs.get(spawnedGuardVoxel.x, 1, spawnedGuardVoxel.z);
-			const VoxelTraitsDefID spawnedGuardFloorVoxelTraitsDefID = spawnedGuardVoxelChunk->traitsDefIDs.get(spawnedGuardVoxel.x, 0, spawnedGuardVoxel.z);
-			const VoxelShapeDefinition &spawnedGuardVoxelShapeDef = spawnedGuardVoxelChunk->shapeDefs[spawnedGuardVoxelShapeDefID];
-			const VoxelTraitsDefinition &spawnedGuardFloorVoxelTraitsDef = spawnedGuardVoxelChunk->traitsDefs[spawnedGuardFloorVoxelTraitsDefID];
-			const bool isSpawnVoxelValid = spawnedGuardVoxelShapeDef.mesh.isEmpty() && spawnedGuardFloorVoxelTraitsDef.type == ArenaVoxelType::Floor;
-			if (!isSpawnVoxelValid)
-			{
-				continue;
-			}
-
-			const EntityDefinitionLibrary &entityDefLibrary = EntityDefinitionLibrary::getInstance();			
-			const EntityDefID spawnedGuardEntityDefID = entityDefLibrary.findDefinitionIdIf(
-				[](const EntityDefinition &entityDef)
-			{
-				if (entityDef.type != EntityDefinitionType::Enemy)
-				{
-					return false;
-				}
-
-				const EnemyEntityDefinition &enemyDef = entityDef.enemy;
-				if (enemyDef.type != EnemyEntityDefinitionType::Human)
-				{
-					return false;
-				}
-
-				const EnemyEntityHumanDefinition &humanEnemyDef = enemyDef.human;
-				const CharacterClassLibrary &charClassLibrary = CharacterClassLibrary::getInstance();
-				const CharacterClassDefinition &charClassDef = charClassLibrary.getDefinition(humanEnemyDef.charClassID);
-				constexpr int originalGuardClassNumber = 16;
-				return charClassDef.originalClassIndex == originalGuardClassNumber;
-			});
-
-			const EntityDefinition &spawnedGuardEntityDef = entityDefLibrary.getDefinition(spawnedGuardEntityDefID);
-			const EntityAnimationDefinition &spawnedGuardAnimDef = spawnedGuardEntityDef.animDef;
-
-			const WorldDouble2 spawnedGuardFeetPositionXZ = VoxelUtils::getVoxelCenter(spawnedGuardWorldVoxelXZ);
-			const WorldDouble3 spawnedGuardFeetPosition(spawnedGuardFeetPositionXZ.x, ceilingScale, spawnedGuardFeetPositionXZ.y);
-
-			EntityInitInfo spawnedGuardEntityInitInfo;
-			spawnedGuardEntityInitInfo.defID = spawnedGuardEntityDefID;
-			spawnedGuardEntityInitInfo.feetPosition = spawnedGuardFeetPosition;
-			spawnedGuardEntityInitInfo.initialAnimStateIndex = *spawnedGuardAnimDef.findStateIndex(spawnedGuardAnimDef.initialStateName);
-			spawnedGuardEntityInitInfo.isSensorCollider = false;
-			spawnedGuardEntityInitInfo.canBeKilled = true;
-			spawnedGuardEntityInitInfo.direction = CardinalDirection::North;
-			spawnedGuardEntityInitInfo.humanEnemyLevel = spawnedGuardLevel;
-			spawnedGuardEntityInitInfo.hasInventory = true;
-			spawnedGuardEntityInitInfo.hasCreatureSound = false;
-			spawnedGuardEntityInitInfo.guardType = spawnedGuardType;
-
-			Renderer &renderer = game.renderer;
-			EntityChunkManager &entityChunkManager = game.sceneManager.entityChunkManager;
-			entityChunkManager.createEntity(spawnedGuardEntityInitInfo, game.random, game.physicsSystem, renderer);
-
-			RenderEntityManager &renderEntityManager = game.sceneManager.renderEntityManager;
-			renderEntityManager.loadMaterialsForEntity(spawnedGuardEntityDefID, game.textureManager, renderer);
-
-			const bool isFirstSpawnedGuard = actualSpawnedGuardCount == 0;
-			if (isFirstSpawnedGuard)
-			{
-				const WorldDouble3 spawnedGuardSoundPosition = VoxelUtils::getVoxelCenter(spawnedGuardWorldVoxel, ceilingScale);
-
-				AudioManager &audioManager = game.audioManager;
-				audioManager.playSoundOneShot(ArenaSoundName::Halt, spawnedGuardSoundPosition);
-			}
-
-			actualSpawnedGuardCount++;
-		}
-
-		// @todo for all entityChunkManager.citizens, queueEntityDestroy()
-		// ^ not in this pull request but soon
+		EntityEncounterSpawnInfo encounterSpawnInfo;
+		encounterSpawnInfo.initCityGuards(guardType, guardLevel, guardCount);
+		this->spawnEncounterEnemies(game, encounterSpawnInfo);
 	};
-}
-
-void GameState::spawnEnemies(Game &game, int spawnId, int spawnLevel, int spawnCount) const
-{
-	// @todo deduplicate this code by combining with queueSpawnGuard()
-	const Player &player = game.player;
-	ArenaRandom &arenaRandom = game.arenaRandom;
-
-	SceneManager &sceneManager = game.sceneManager;
-	const VoxelChunkManager &voxelChunkManager = sceneManager.voxelChunkManager;
-	const MapType mapType = this->getActiveMapType();
-	const double ceilingScale = this->getActiveCeilingScale();
-	const WorldDouble3 playerFeetPosition = player.getFeetPosition();
-	const WorldInt3 playerFeetVoxel = VoxelUtils::pointToVoxel(playerFeetPosition, ceilingScale);
-	const OriginalInt2 playerFeetVoxelOriginalXZ = VoxelUtils::worldVoxelToOriginalVoxel(playerFeetVoxel.getXZ());
-	const OriginalInt2 originalPlayerPositionArenaUnits = GameWorldUiModel::getOriginalPlayerPositionArenaUnits(playerFeetPosition, mapType);
-	const int16_t originalPlayerPositionArenaUnitsX = static_cast<int16_t>(originalPlayerPositionArenaUnits.y);
-	const int16_t originalPlayerPositionArenaUnitsZ = static_cast<int16_t>(originalPlayerPositionArenaUnits.x);
-
-	int actualSpawnedEnemyCount = 0;
-
-	for (int i = 0; i < spawnCount; i++)
-	{
-		const ArenaEntitySpawnPoint spawnedEnemyPositionArenaUnits = ArenaEntityUtils::findRandomSpawnLocationAroundPlayer(originalPlayerPositionArenaUnitsX, originalPlayerPositionArenaUnitsZ, arenaRandom);
-		const OriginalInt2 playerToSpawnedEnemyOriginalVoxel(
-			(spawnedEnemyPositionArenaUnits.x - originalPlayerPositionArenaUnitsX) / 128,
-			(spawnedEnemyPositionArenaUnits.z - originalPlayerPositionArenaUnitsZ) / 128);
-		const OriginalInt2 spawnedEnemyOriginalVoxel(
-			playerFeetVoxelOriginalXZ.x + playerToSpawnedEnemyOriginalVoxel.x,
-			playerFeetVoxelOriginalXZ.y + playerToSpawnedEnemyOriginalVoxel.y);
-		const WorldInt2 spawnedEnemyWorldVoxelXZ = VoxelUtils::originalVoxelToWorldVoxel(spawnedEnemyOriginalVoxel);
-		const WorldInt3 spawnedEnemyWorldVoxel(spawnedEnemyWorldVoxelXZ.x, 1, spawnedEnemyWorldVoxelXZ.y);
-		const CoordInt3 spawnedEnemyVoxelCoord = VoxelUtils::worldVoxelToCoord(spawnedEnemyWorldVoxel);
-		const VoxelChunk* spawnedEnemyVoxelChunk = voxelChunkManager.findChunkAtPosition(spawnedEnemyVoxelCoord.chunk);
-		if (spawnedEnemyVoxelChunk == nullptr)
-		{
-			continue;
-		}
-
-		const VoxelInt3 spawnedEnemyVoxel = spawnedEnemyVoxelCoord.voxel;
-		const VoxelShapeDefID spawnedEnemyVoxelShapeDefID = spawnedEnemyVoxelChunk->shapeDefIDs.get(spawnedEnemyVoxel.x, 1, spawnedEnemyVoxel.z);
-		const VoxelTraitsDefID spawnedEnemyFloorVoxelTraitsDefID = spawnedEnemyVoxelChunk->traitsDefIDs.get(spawnedEnemyVoxel.x, 0, spawnedEnemyVoxel.z);
-		const VoxelShapeDefinition &spawnedEnemyVoxelShapeDef = spawnedEnemyVoxelChunk->shapeDefs[spawnedEnemyVoxelShapeDefID];
-		const VoxelTraitsDefinition &spawnedEnemyFloorVoxelTraitsDef = spawnedEnemyVoxelChunk->traitsDefs[spawnedEnemyFloorVoxelTraitsDefID];
-		const bool isSpawnVoxelValid = spawnedEnemyVoxelShapeDef.mesh.isEmpty() && spawnedEnemyFloorVoxelTraitsDef.type == ArenaVoxelType::Floor;
-		if (!isSpawnVoxelValid)
-		{
-			continue;
-		}
-
-		const EntityDefinitionLibrary &entityDefLibrary = EntityDefinitionLibrary::getInstance();
-		const EntityDefID spawnedEnemyEntityDefID = entityDefLibrary.findDefinitionIdIf(
-			[spawnId](const EntityDefinition &entityDef)
-			{
-				if (entityDef.type != EntityDefinitionType::Enemy)
-				{
-					return false;
-				}
-
-				const EnemyEntityDefinition &enemyDef = entityDef.enemy;
-				if (spawnId >= ArenaEntityUtils::FinalBossCreatureID)
-				{
-					if (enemyDef.type != EnemyEntityDefinitionType::Human)
-					{
-						return false;
-					}
-
-					const EnemyEntityHumanDefinition &humanEnemyDef = enemyDef.human;
-					const CharacterClassLibrary &charClassLibrary = CharacterClassLibrary::getInstance();
-					const CharacterClassDefinition &charClassDef = charClassLibrary.getDefinition(humanEnemyDef.charClassID);
-					constexpr int spawnIdToClassNumberDifference = ArenaEntityUtils::FinalBossCreatureID;
-					const int originalEnemyClassNumber = spawnId - spawnIdToClassNumberDifference;
-					return charClassDef.originalClassIndex == originalEnemyClassNumber;
-				}
-				else if (enemyDef.type != EnemyEntityDefinitionType::Creature)
-				{
-					return false;
-				}
-
-				const CreatureDefinitionLibrary &creatureDefLibrary = CreatureDefinitionLibrary::getInstance();
-				const CreatureDefinitionID spawnCreatureDefID = creatureDefLibrary.getDefinitionIdFromOriginalID(spawnId);
-				return enemyDef.creatureDefID == spawnCreatureDefID;
-			});
-
-		const EntityDefinition &spawnedEnemyEntityDef = entityDefLibrary.getDefinition(spawnedEnemyEntityDefID);
-		const EntityAnimationDefinition &spawnedEnemyAnimDef = spawnedEnemyEntityDef.animDef;
-
-		const WorldDouble2 spawnedEnemyFeetPositionXZ = VoxelUtils::getVoxelCenter(spawnedEnemyWorldVoxelXZ);
-		const WorldDouble3 spawnedEnemyFeetPosition(spawnedEnemyFeetPositionXZ.x, ceilingScale, spawnedEnemyFeetPositionXZ.y);
-
-		EntityInitInfo spawnedEnemyEntityInitInfo;
-		spawnedEnemyEntityInitInfo.defID = spawnedEnemyEntityDefID;
-		spawnedEnemyEntityInitInfo.feetPosition = spawnedEnemyFeetPosition;
-		spawnedEnemyEntityInitInfo.initialAnimStateIndex = *spawnedEnemyAnimDef.findStateIndex(spawnedEnemyAnimDef.initialStateName);
-		spawnedEnemyEntityInitInfo.isSensorCollider = false;
-		spawnedEnemyEntityInitInfo.canBeKilled = true;
-		spawnedEnemyEntityInitInfo.direction = CardinalDirection::North;
-		spawnedEnemyEntityInitInfo.humanEnemyLevel = spawnLevel;
-		spawnedEnemyEntityInitInfo.hasInventory = true;
-		spawnedEnemyEntityInitInfo.hasCreatureSound = spawnId < ArenaEntityUtils::FinalBossCreatureID;
-
-		Renderer &renderer = game.renderer;
-		EntityChunkManager &entityChunkManager = sceneManager.entityChunkManager;
-		entityChunkManager.createEntity(spawnedEnemyEntityInitInfo, game.random, game.physicsSystem, renderer);
-
-		RenderEntityManager &renderEntityManager = sceneManager.renderEntityManager;
-		renderEntityManager.loadMaterialsForEntity(spawnedEnemyEntityDefID, game.textureManager, renderer);
-
-		actualSpawnedEnemyCount++;
-	}
 }
 
 void GameState::applyPendingSceneChange(Game &game, JPH::PhysicsSystem &physicsSystem, double dt)
@@ -1085,7 +1066,10 @@ void GameState::tickGameClock(double dt, Game &game)
 		if (encounterChance > arenaRandom.next(100))
 		{
 			const ArenaEnemyEncounter encounter = ArenaEntityUtils::chooseEncounterEnemy(encounterChanceTableIndex, player.level, player.level, false, arenaRandom, exeData);
-			this->spawnEnemies(game, encounter.id, encounter.level, encounter.count);
+
+			EntityEncounterSpawnInfo encounterSpawnInfo;
+			encounterSpawnInfo.initCreaturesOrHumans(encounter.id, encounter.level, encounter.count);
+			this->spawnEncounterEnemies(game, encounterSpawnInfo);
 		}
 	}
 

--- a/OpenTESArena/src/Game/GameState.cpp
+++ b/OpenTESArena/src/Game/GameState.cpp
@@ -741,7 +741,8 @@ void GameState::spawnEnemies(Game &game, int spawnId, int spawnLevel, int spawnC
 	const Player &player = game.player;
 	ArenaRandom &arenaRandom = game.arenaRandom;
 
-	const VoxelChunkManager &voxelChunkManager = game.sceneManager.voxelChunkManager;
+	SceneManager &sceneManager = game.sceneManager;
+	const VoxelChunkManager &voxelChunkManager = sceneManager.voxelChunkManager;
 	const MapType mapType = this->getActiveMapType();
 	const double ceilingScale = this->getActiveCeilingScale();
 	const WorldDouble3 playerFeetPosition = player.getFeetPosition();
@@ -792,8 +793,7 @@ void GameState::spawnEnemies(Game &game, int spawnId, int spawnLevel, int spawnC
 				}
 
 				const EnemyEntityDefinition &enemyDef = entityDef.enemy;
-				constexpr int lastCreatureID = 23;
-				if (spawnId > lastCreatureID)
+				if (spawnId >= ArenaEntityUtils::FinalBossCreatureID)
 				{
 					if (enemyDef.type != EnemyEntityDefinitionType::Human)
 					{
@@ -803,7 +803,7 @@ void GameState::spawnEnemies(Game &game, int spawnId, int spawnLevel, int spawnC
 					const EnemyEntityHumanDefinition &humanEnemyDef = enemyDef.human;
 					const CharacterClassLibrary &charClassLibrary = CharacterClassLibrary::getInstance();
 					const CharacterClassDefinition &charClassDef = charClassLibrary.getDefinition(humanEnemyDef.charClassID);
-					constexpr int spawnIdToClassNumberDifference = 24;
+					constexpr int spawnIdToClassNumberDifference = ArenaEntityUtils::FinalBossCreatureID;
 					const int originalEnemyClassNumber = spawnId - spawnIdToClassNumberDifference;
 					return charClassDef.originalClassIndex == originalEnemyClassNumber;
 				}
@@ -812,7 +812,9 @@ void GameState::spawnEnemies(Game &game, int spawnId, int spawnLevel, int spawnC
 					return false;
 				}
 
-				return enemyDef.creatureDefID == spawnId;
+				const CreatureDefinitionLibrary &creatureDefLibrary = CreatureDefinitionLibrary::getInstance();
+				const CreatureDefinitionID spawnCreatureDefID = creatureDefLibrary.getDefinitionIdFromOriginalID(spawnId);
+				return enemyDef.creatureDefID == spawnCreatureDefID;
 			});
 
 		const EntityDefinition &spawnedEnemyEntityDef = entityDefLibrary.getDefinition(spawnedEnemyEntityDefID);
@@ -830,13 +832,13 @@ void GameState::spawnEnemies(Game &game, int spawnId, int spawnLevel, int spawnC
 		spawnedEnemyEntityInitInfo.direction = CardinalDirection::North;
 		spawnedEnemyEntityInitInfo.humanEnemyLevel = spawnLevel;
 		spawnedEnemyEntityInitInfo.hasInventory = true;
-		spawnedEnemyEntityInitInfo.hasCreatureSound = spawnId <= 23;
+		spawnedEnemyEntityInitInfo.hasCreatureSound = spawnId < ArenaEntityUtils::FinalBossCreatureID;
 
 		Renderer &renderer = game.renderer;
-		EntityChunkManager &entityChunkManager = game.sceneManager.entityChunkManager;
+		EntityChunkManager &entityChunkManager = sceneManager.entityChunkManager;
 		entityChunkManager.createEntity(spawnedEnemyEntityInitInfo, game.random, game.physicsSystem, renderer);
 
-		RenderEntityManager &renderEntityManager = game.sceneManager.renderEntityManager;
+		RenderEntityManager &renderEntityManager = sceneManager.renderEntityManager;
 		renderEntityManager.loadMaterialsForEntity(spawnedEnemyEntityDefID, game.textureManager, renderer);
 
 		actualSpawnedEnemyCount++;

--- a/OpenTESArena/src/Game/GameState.cpp
+++ b/OpenTESArena/src/Game/GameState.cpp
@@ -666,6 +666,116 @@ void GameState::queueGuardSpawn(Game &game)
 	};
 }
 
+void GameState::spawnEnemies(Game &game, int spawnId, int spawnLevel, int spawnCount) const
+{
+	const Player& player = game.player;
+	ArenaRandom& arenaRandom = game.arenaRandom;
+
+	const VoxelChunkManager& voxelChunkManager = game.sceneManager.voxelChunkManager;
+	const MapType mapType = this->getActiveMapType();
+	const double ceilingScale = this->getActiveCeilingScale();
+	const WorldDouble3 playerFeetPosition = player.getFeetPosition();
+	const WorldInt3 playerFeetVoxel = VoxelUtils::pointToVoxel(playerFeetPosition, ceilingScale);
+	const OriginalInt2 playerFeetVoxelOriginalXZ = VoxelUtils::worldVoxelToOriginalVoxel(playerFeetVoxel.getXZ());
+	const OriginalInt2 originalPlayerPositionArenaUnits = GameWorldUiModel::getOriginalPlayerPositionArenaUnits(playerFeetPosition, mapType);
+	const int16_t originalPlayerPositionArenaUnitsX = static_cast<int16_t>(originalPlayerPositionArenaUnits.y);
+	const int16_t originalPlayerPositionArenaUnitsZ = static_cast<int16_t>(originalPlayerPositionArenaUnits.x);
+
+	int actualSpawnedEnemyCount = 0;
+
+	for (int i = 0; i < spawnCount; i++)
+	{
+		const ArenaEntitySpawnPoint spawnedEnemyPositionArenaUnits = ArenaEntityUtils::findRandomSpawnLocationAroundPlayer(originalPlayerPositionArenaUnitsX, originalPlayerPositionArenaUnitsZ, arenaRandom);
+		const OriginalInt2 playerToSpawnedEnemyOriginalVoxel(
+			(spawnedEnemyPositionArenaUnits.x - originalPlayerPositionArenaUnitsX) / 128,
+			(spawnedEnemyPositionArenaUnits.z - originalPlayerPositionArenaUnitsZ) / 128);
+		const OriginalInt2 spawnedEnemyOriginalVoxel(
+			playerFeetVoxelOriginalXZ.x + playerToSpawnedEnemyOriginalVoxel.x,
+			playerFeetVoxelOriginalXZ.y + playerToSpawnedEnemyOriginalVoxel.y);
+		const WorldInt2 spawnedEnemyWorldVoxelXZ = VoxelUtils::originalVoxelToWorldVoxel(spawnedEnemyOriginalVoxel);
+		const WorldInt3 spawnedEnemyWorldVoxel(spawnedEnemyWorldVoxelXZ.x, 1, spawnedEnemyWorldVoxelXZ.y);
+		const CoordInt3 spawnedEnemyVoxelCoord = VoxelUtils::worldVoxelToCoord(spawnedEnemyWorldVoxel);
+		const VoxelChunk* spawnedEnemyVoxelChunk = voxelChunkManager.findChunkAtPosition(spawnedEnemyVoxelCoord.chunk);
+		if (spawnedEnemyVoxelChunk == nullptr)
+		{
+			continue;
+		}
+
+		const VoxelInt3 spawnedEnemyVoxel = spawnedEnemyVoxelCoord.voxel;
+		const VoxelShapeDefID spawnedEnemyVoxelShapeDefID = spawnedEnemyVoxelChunk->shapeDefIDs.get(spawnedEnemyVoxel.x, 1, spawnedEnemyVoxel.z);
+		const VoxelTraitsDefID spawnedEnemyFloorVoxelTraitsDefID = spawnedEnemyVoxelChunk->traitsDefIDs.get(spawnedEnemyVoxel.x, 0, spawnedEnemyVoxel.z);
+		const VoxelShapeDefinition& spawnedEnemyVoxelShapeDef = spawnedEnemyVoxelChunk->shapeDefs[spawnedEnemyVoxelShapeDefID];
+		const VoxelTraitsDefinition& spawnedEnemyFloorVoxelTraitsDef = spawnedEnemyVoxelChunk->traitsDefs[spawnedEnemyFloorVoxelTraitsDefID];
+		const bool isSpawnVoxelValid = spawnedEnemyVoxelShapeDef.mesh.isEmpty() && spawnedEnemyFloorVoxelTraitsDef.type == ArenaVoxelType::Floor;
+		if (!isSpawnVoxelValid)
+		{
+			continue;
+		}
+
+		const EntityDefinitionLibrary& entityDefLibrary = EntityDefinitionLibrary::getInstance();
+		const EntityDefID spawnedEnemyEntityDefID = entityDefLibrary.findDefinitionIdIf(
+			[spawnId](const EntityDefinition& entityDef)
+			{
+				if (entityDef.type != EntityDefinitionType::Enemy)
+				{
+					return false;
+				}
+
+				const EnemyEntityDefinition& enemyDef = entityDef.enemy;
+				constexpr int lastCreatureID = 23;
+				if (spawnId > lastCreatureID)
+				{
+					if (enemyDef.type != EnemyEntityDefinitionType::Human)
+					{
+						return false;
+					}
+
+					const EnemyEntityHumanDefinition& humanEnemyDef = enemyDef.human;
+					const CharacterClassLibrary& charClassLibrary = CharacterClassLibrary::getInstance();
+					const CharacterClassDefinition& charClassDef = charClassLibrary.getDefinition(humanEnemyDef.charClassID);
+					constexpr int spawnIdToClassNumberDifference = 24;
+					const int originalEnemyClassNumber = spawnId - spawnIdToClassNumberDifference;
+					return charClassDef.originalClassIndex == originalEnemyClassNumber;
+				}
+				else if (enemyDef.type != EnemyEntityDefinitionType::Creature)
+				{
+					return false;
+				}
+
+				return enemyDef.creatureDefID == spawnId;
+			});
+
+		const EntityDefinition& spawnedEnemyEntityDef = entityDefLibrary.getDefinition(spawnedEnemyEntityDefID);
+		const EntityAnimationDefinition& spawnedEnemyAnimDef = spawnedEnemyEntityDef.animDef;
+
+		const WorldDouble2 spawnedEnemyFeetPositionXZ = VoxelUtils::getVoxelCenter(spawnedEnemyWorldVoxelXZ);
+		const WorldDouble3 spawnedEnemyFeetPosition(spawnedEnemyFeetPositionXZ.x, ceilingScale, spawnedEnemyFeetPositionXZ.y);
+
+		EntityInitInfo spawnedEnemyEntityInitInfo;
+		spawnedEnemyEntityInitInfo.defID = spawnedEnemyEntityDefID;
+		spawnedEnemyEntityInitInfo.feetPosition = spawnedEnemyFeetPosition;
+		spawnedEnemyEntityInitInfo.initialAnimStateIndex = *spawnedEnemyAnimDef.findStateIndex(spawnedEnemyAnimDef.initialStateName);
+		spawnedEnemyEntityInitInfo.isSensorCollider = false;
+		spawnedEnemyEntityInitInfo.canBeKilled = true;
+		spawnedEnemyEntityInitInfo.direction = CardinalDirection::North;
+		spawnedEnemyEntityInitInfo.humanEnemyLevel = spawnLevel;
+		spawnedEnemyEntityInitInfo.hasInventory = true;
+		if (spawnId > 23)
+			spawnedEnemyEntityInitInfo.hasCreatureSound = false;
+		else
+			spawnedEnemyEntityInitInfo.hasCreatureSound = true;
+
+		Renderer& renderer = game.renderer;
+		EntityChunkManager& entityChunkManager = game.sceneManager.entityChunkManager;
+		entityChunkManager.createEntity(spawnedEnemyEntityInitInfo, game.random, game.physicsSystem, renderer);
+
+		RenderEntityManager& renderEntityManager = game.sceneManager.renderEntityManager;
+		renderEntityManager.loadMaterialsForEntity(spawnedEnemyEntityDefID, game.textureManager, renderer);
+
+		actualSpawnedEnemyCount++;
+	}
+}
+
 void GameState::applyPendingSceneChange(Game &game, JPH::PhysicsSystem &physicsSystem, double dt)
 {
 	Player &player = game.player;
@@ -857,17 +967,63 @@ void GameState::tickGameClock(double dt, Game &game)
 
 	const int prevHour = prevClock.hours;
 	const int newHour = this->clock.hours;
+	bool isNight = (newHour < 6 || newHour > 18);
+	const Player &player = game.player;
+	const auto &exeData = BinaryAssetLibrary::getInstance().getExeData();
 	if (newHour != prevHour)
 	{
 		// Update possible weathers list.
-		const auto &exeData = BinaryAssetLibrary::getInstance().getExeData();
 		this->updateWeatherList(game.arenaRandom, exeData);
+
+		// Roll for random encounter
+		if ((this->isCamping || this->getActiveMapType() == MapType::Wilderness) && !player.groundState.onRaisedPlatform)
+		{
+			int encounterChance;
+			int encounterChanceTableIndex;
+			int arenaEnvironmentType = getArenaEnvironmentType();
+			int arenaBuildingType = getArenaBuildingType();
+			//@todo: The original game checks for trespassing at the moment of entering an interior, not every hour as done here.
+			bool isTrespassing = getIsTrespassing(arenaBuildingType, isNight);
+
+			//@todo: Pass in terrain type
+			ArenaEntityUtils::getEncounterParameters(arenaEnvironmentType, arenaBuildingType, isTrespassing, this->isCamping, 0, newHour, this->date.getDay(), exeData, &encounterChance, &encounterChanceTableIndex);
+			if (encounterChance > game.arenaRandom.next() % 100)
+			{
+				ArenaEnemyEncounter encounter = ArenaEntityUtils::chooseEncounterEnemy(encounterChanceTableIndex, player.level, player.level, false, game.arenaRandom, exeData);
+				spawnEnemies(game, encounter.id, encounter.level, encounter.count);
+			}
+		}
 	}
 
 	// Check if the clock hour looped back around.
 	if (newHour < prevHour)
 	{
 		this->date.incrementDay();
+	}
+
+	const int prevMinute = prevClock.minutes;
+	const int newMinute = this->clock.minutes;
+	if (newMinute != prevMinute)
+	{
+		// Roll for random encounter. In the original game, the presence of citizens in city maps prevents encounters from spawning during the day.
+		// Here this is being done through a check that it is night.
+		if (((this->getActiveMapType() == MapType::City && isNight) || (this->getActiveMapType() == MapType::Interior && !isCamping)) && !player.groundState.onRaisedPlatform)
+		{
+			int encounterChance;
+			int encounterChanceTableIndex;
+
+			int arenaEnvironmentType = getArenaEnvironmentType();
+			int arenaBuildingType = getArenaBuildingType();
+			//@todo: The original game checks for trespassing at the moment of entering an interior, not every minute as done here.
+			bool isTrespassing = getIsTrespassing(arenaBuildingType, isNight);
+			//@todo: Pass in terrain type.
+			ArenaEntityUtils::getEncounterParameters(arenaEnvironmentType, arenaBuildingType, isTrespassing, this->isCamping, 0, newHour, this->date.getDay(), exeData, &encounterChance, &encounterChanceTableIndex);
+			if (encounterChance > game.arenaRandom.next() % 100)
+			{
+				ArenaEnemyEncounter encounter = ArenaEntityUtils::chooseEncounterEnemy(encounterChanceTableIndex, player.level, player.level, false, game.arenaRandom, exeData);
+				spawnEnemies(game, encounter.id, encounter.level, encounter.count);
+			}
+		}
 	}
 
 	// See if the clock passed the boundary between night and day, and vice versa.
@@ -894,7 +1050,6 @@ void GameState::tickGameClock(double dt, Game &game)
 	// Check for changes in exterior music depending on the time.
 	const MapDefinition &activeMapDef = this->getActiveMapDef();
 	const MapType activeMapType = activeMapDef.getMapType();
-	const Player &player = game.player;
 	if ((activeMapType != MapType::Interior) && !player.groundState.isSwimming)
 	{
 		const Clock &dayMusicStartClock = clockLibrary.getClock(ArenaClockUtils::MusicSwitchToDay);
@@ -937,6 +1092,114 @@ void GameState::tickGameClock(double dt, Game &game)
 			audioManager.setMusic(musicDef);
 		}
 	}
+}
+
+int GameState::getArenaEnvironmentType() const
+{
+	const ProvinceDefinition& provinceDef = this->worldMapDef.getProvinceDef(provinceIndex);
+	const LocationDefinition& locationDef = provinceDef.getLocationDef(locationIndex);
+
+	int arenaEnvironmentType = -1;
+	if (this->getActiveMapType() == MapType::City)
+	{
+		arenaEnvironmentType = 0;
+	}
+	if (this->getActiveMapType() == MapType::Wilderness)
+	{
+		arenaEnvironmentType = 1;
+	}
+	else if (this->getActiveMapType() == MapType::Interior)
+	{
+		LocationDefinitionType locationType = locationDef.getType();
+		if (locationType == LocationDefinitionType::MainQuestDungeon)
+		{
+			arenaEnvironmentType = 2;
+		}
+		else if (locationType == LocationDefinitionType::Dungeon)
+		{
+			arenaEnvironmentType = 3;
+		}
+		else if (locationType == LocationDefinitionType::City)
+		{
+			arenaEnvironmentType = 4;
+		}
+	}
+
+	DebugAssert(arenaEnvironmentType != -1);
+	return arenaEnvironmentType;
+}
+
+int GameState::getArenaBuildingType() const
+{
+	const MapDefinition& mapDef = this->getActiveMapDef();
+	const MapSubDefinition& mapSubDef = mapDef.getSubDefinition();
+	int arenaBuildingType = -1;
+
+	if (mapSubDef.type == MapType::Interior)
+	{
+		ArenaInteriorType lootInteriorType = mapSubDef.interior.interiorType;
+
+		switch (lootInteriorType)
+		{
+		case ArenaInteriorType::Crypt:
+		{
+			arenaBuildingType = 8;
+			break;
+		}
+		case ArenaInteriorType::Equipment:
+		{
+			arenaBuildingType = 6;
+			break;
+		}
+		case ArenaInteriorType::House:
+		{
+			arenaBuildingType = 2;
+			break;
+		}
+		case ArenaInteriorType::MagesGuild:
+		{
+			arenaBuildingType = 7;
+			break;
+		}
+		case ArenaInteriorType::Noble:
+		{
+			arenaBuildingType = 3;
+			break;
+		}
+		case ArenaInteriorType::Palace:
+		{
+			arenaBuildingType = 1;
+			break;
+		}
+		case ArenaInteriorType::Tavern:
+		{
+			arenaBuildingType = 4;
+			break;
+		}
+		case ArenaInteriorType::Temple:
+		{
+			arenaBuildingType = 5;
+			break;
+		}
+		case ArenaInteriorType::Tower:
+		{
+			arenaBuildingType = 11;
+		}
+		}
+	}
+
+	return arenaBuildingType;
+}
+
+bool GameState::getIsTrespassing(int arenaBuildingType, bool isNight)
+{
+	// The player is trespassing if they enter a common or noble house, or any building but a tavern, crypt or tower at night.
+	if (arenaBuildingType == 2 || arenaBuildingType == 3 || (isNight && (arenaBuildingType != 4 && arenaBuildingType != 8 && arenaBuildingType != 11)))
+	{
+		return true;
+	}
+
+	return false;
 }
 
 void GameState::tickChasmAnimation(double dt)

--- a/OpenTESArena/src/Game/GameState.cpp
+++ b/OpenTESArena/src/Game/GameState.cpp
@@ -35,6 +35,7 @@
 #include "../Voxels/ArenaVoxelUtils.h"
 #include "../Weather/ArenaWeatherUtils.h"
 #include "../Weather/WeatherUtils.h"
+#include "../World/ArenaInteriorUtils.h"
 #include "../World/CardinalDirection.h"
 #include "../World/MapLogic.h"
 #include "../World/MapType.h"
@@ -1052,7 +1053,7 @@ void GameState::tickGameClock(double dt, Game &game)
 		const ArenaInteriorType interiorType = this->getInteriorType();
 		const int interiorTypeValue = static_cast<int>(interiorType);
 		//@todo: The original game checks for trespassing at the moment of entering an interior, not every hour as done here.
-		const bool isTrespassing = this->isPlayerTrespassing(interiorType, isNightForEncounters);
+		const bool isTrespassing = ArenaInteriorUtils::isPlayerTrespassing(interiorType, isNightForEncounters);
 		const int terrainType = 0; //@todo: Pass in terrain type
 		int encounterChance;
 		int encounterChanceTableIndex;
@@ -1129,24 +1130,6 @@ void GameState::tickGameClock(double dt, Game &game)
 			audioManager.setMusic(musicDef);
 		}
 	}
-}
-
-bool GameState::isPlayerTrespassing(ArenaInteriorType interiorType, bool isNight) const
-{
-	if (interiorType == ArenaInteriorType::House || interiorType == ArenaInteriorType::Noble)
-	{
-		return true;
-	}
-
-	if (isNight)
-	{
-		if (interiorType != ArenaInteriorType::Tavern && interiorType != ArenaInteriorType::Crypt && interiorType != ArenaInteriorType::Tower)
-		{
-			return true;
-		}
-	}
-
-	return false;
 }
 
 void GameState::tickChasmAnimation(double dt)

--- a/OpenTESArena/src/Game/GameState.h
+++ b/OpenTESArena/src/Game/GameState.h
@@ -8,6 +8,7 @@
 #include "Jolt/Jolt.h"
 #include "Jolt/Physics/PhysicsSystem.h"
 
+#include "../Entities/EntityDefinitionLibrary.h"
 #include "../Interface/ProvinceMapUiMVC.h"
 #include "../Math/Random.h"
 #include "../Math/Vector2.h"
@@ -40,6 +41,21 @@ struct GuardSpawnState
 	bool isQueued() const;
 
 	void clearQueue();
+};
+
+struct EntityEncounterSpawnInfo
+{
+	int guardType; // Non-negative if for city guards.
+	int level;
+	int count;
+	EntityDefinitionPredicate entityDefPredicate; // Filters to matching definitions from library.
+
+	EntityEncounterSpawnInfo();
+
+	void initCreaturesOrHumans(int spawnID, int level, int count);
+	void initCityGuards(int guardType, int level, int count);
+
+	bool isCityGuards() const;
 };
 
 // Container for currently loaded game/world data.
@@ -174,8 +190,8 @@ public:
 	// Recalculates the weather for each global quarter (done hourly).
 	void updateWeatherList(ArenaRandom &random, const ExeData &exeData);
 
-	void queueGuardSpawn(Game &game);
-	void spawnEnemies(Game &game, int spawnId, int spawnLevel, int spawnCount) const;
+	void spawnEncounterEnemies(Game &game, const EntityEncounterSpawnInfo &spawnInfo) const;
+	void queueCityGuardEncounter(Game &game);
 
 	// Applies any pending scene transition, setting the new level active in the game world and renderer.
 	void applyPendingSceneChange(Game &game, JPH::PhysicsSystem &physicsSystem, double dt);

--- a/OpenTESArena/src/Game/GameState.h
+++ b/OpenTESArena/src/Game/GameState.h
@@ -175,8 +175,6 @@ public:
 	void updateWeatherList(ArenaRandom &random, const ExeData &exeData);
 
 	void queueGuardSpawn(Game &game);
-
-	bool isPlayerTrespassing(ArenaInteriorType interiorType, bool isNight) const;
 	void spawnEnemies(Game &game, int spawnId, int spawnLevel, int spawnCount) const;
 
 	// Applies any pending scene transition, setting the new level active in the game world and renderer.

--- a/OpenTESArena/src/Game/GameState.h
+++ b/OpenTESArena/src/Game/GameState.h
@@ -139,6 +139,8 @@ public:
 	const MapDefinition &getActiveMapDef() const;
 	double getActiveCeilingScale() const;
 	bool isActiveMapNested() const; // True if the active interior is inside an exterior.
+	ArenaEnvironmentType getEnvironmentType() const; // For enemy encounters.
+	ArenaInteriorType getInteriorType() const;
 	const WorldMapDefinition &getWorldMapDefinition() const;
 	const ProvinceDefinition &getProvinceDefinition() const;
 	const LocationDefinition &getLocationDefinition() const;
@@ -174,9 +176,7 @@ public:
 
 	void queueGuardSpawn(Game &game);
 
-	int getArenaEnvironmentType() const;
-	int getArenaBuildingType() const;
-	bool getIsTrespassing(int arenaBuildingType, bool isNight);
+	bool isPlayerTrespassing(ArenaInteriorType interiorType, bool isNight) const;
 	void spawnEnemies(Game &game, int spawnId, int spawnLevel, int spawnCount) const;
 
 	// Applies any pending scene transition, setting the new level active in the game world and renderer.

--- a/OpenTESArena/src/Game/GameState.h
+++ b/OpenTESArena/src/Game/GameState.h
@@ -140,7 +140,7 @@ public:
 	double getActiveCeilingScale() const;
 	bool isActiveMapNested() const; // True if the active interior is inside an exterior.
 	ArenaEnvironmentType getEnvironmentType() const; // For enemy encounters.
-	ArenaInteriorType getInteriorType() const;
+	ArenaBuildingType getBuildingType() const; // For enemy encounters.
 	const WorldMapDefinition &getWorldMapDefinition() const;
 	const ProvinceDefinition &getProvinceDefinition() const;
 	const LocationDefinition &getLocationDefinition() const;

--- a/OpenTESArena/src/Game/GameState.h
+++ b/OpenTESArena/src/Game/GameState.h
@@ -174,6 +174,11 @@ public:
 
 	void queueGuardSpawn(Game &game);
 
+	int getArenaEnvironmentType() const;
+	int getArenaBuildingType() const;
+	bool getIsTrespassing(int arenaBuildingType, bool isNight);
+	void spawnEnemies(Game &game, int spawnId, int spawnLevel, int spawnCount) const;
+
 	// Applies any pending scene transition, setting the new level active in the game world and renderer.
 	void applyPendingSceneChange(Game &game, JPH::PhysicsSystem &physicsSystem, double dt);
 

--- a/OpenTESArena/src/Player/PlayerLogic.cpp
+++ b/OpenTESArena/src/Player/PlayerLogic.cpp
@@ -963,7 +963,7 @@ void PlayerLogic::handleAttack(Game &game, const Int2 &mouseDelta)
 						if (hitEntityBehaviorState.isCitizen())
 						{
 							GameWorldUiController::onCitizenKilled(game);
-							gameState.queueGuardSpawn(game);
+							gameState.queueCityGuardEncounter(game);
 						}
 						else if (hitEntityBehaviorState.isCreature())
 						{

--- a/OpenTESArena/src/World/ArenaInteriorUtils.cpp
+++ b/OpenTESArena/src/World/ArenaInteriorUtils.cpp
@@ -85,3 +85,21 @@ bool ArenaInteriorUtils::isProceduralInterior(ArenaInteriorType interiorType)
 {
 	return interiorType == ArenaInteriorType::Dungeon;
 }
+
+bool ArenaInteriorUtils::isPlayerTrespassing(ArenaInteriorType interiorType, bool isNight)
+{
+	if (interiorType == ArenaInteriorType::House || interiorType == ArenaInteriorType::Noble)
+	{
+		return true;
+	}
+
+	if (isNight)
+	{
+		if (interiorType != ArenaInteriorType::Tavern && interiorType != ArenaInteriorType::Crypt && interiorType != ArenaInteriorType::Tower)
+		{
+			return true;
+		}
+	}
+
+	return false;
+}

--- a/OpenTESArena/src/World/ArenaInteriorUtils.cpp
+++ b/OpenTESArena/src/World/ArenaInteriorUtils.cpp
@@ -86,16 +86,16 @@ bool ArenaInteriorUtils::isProceduralInterior(ArenaInteriorType interiorType)
 	return interiorType == ArenaInteriorType::Dungeon;
 }
 
-bool ArenaInteriorUtils::isPlayerTrespassing(ArenaInteriorType interiorType, bool isNight)
+bool ArenaInteriorUtils::isPlayerTrespassing(ArenaBuildingType buildingType, bool isNight)
 {
-	if (interiorType == ArenaInteriorType::House || interiorType == ArenaInteriorType::Noble)
+	if (buildingType == ArenaBuildingType::House || buildingType == ArenaBuildingType::Noble)
 	{
 		return true;
 	}
 
 	if (isNight)
 	{
-		if (interiorType != ArenaInteriorType::Tavern && interiorType != ArenaInteriorType::Crypt && interiorType != ArenaInteriorType::Tower)
+		if (buildingType != ArenaBuildingType::Tavern && buildingType != ArenaBuildingType::Crypt && buildingType != ArenaBuildingType::Tower)
 		{
 			return true;
 		}

--- a/OpenTESArena/src/World/ArenaInteriorUtils.h
+++ b/OpenTESArena/src/World/ArenaInteriorUtils.h
@@ -41,5 +41,5 @@ namespace ArenaInteriorUtils
 	bool isPrefabInterior(ArenaInteriorType interiorType);
 	bool isProceduralInterior(ArenaInteriorType interiorType);
 
-	bool isPlayerTrespassing(ArenaInteriorType interiorType, bool isNight);
+	bool isPlayerTrespassing(ArenaBuildingType buildingType, bool isNight);
 }

--- a/OpenTESArena/src/World/ArenaInteriorUtils.h
+++ b/OpenTESArena/src/World/ArenaInteriorUtils.h
@@ -40,4 +40,6 @@ namespace ArenaInteriorUtils
 
 	bool isPrefabInterior(ArenaInteriorType interiorType);
 	bool isProceduralInterior(ArenaInteriorType interiorType);
+
+	bool isPlayerTrespassing(ArenaInteriorType interiorType, bool isNight);
 }

--- a/OpenTESArena/src/World/MapDefinition.cpp
+++ b/OpenTESArena/src/World/MapDefinition.cpp
@@ -590,6 +590,12 @@ Span<const LevelInfoDefinition> MapDefinition::getLevelInfos() const
 	return this->levelInfos;
 }
 
+const LevelInfoDefinition &MapDefinition::getLevelInfoForLevel(int levelIndex) const
+{
+	const int levelInfoIndex = this->levelInfoMappings.get(levelIndex);
+	return this->levelInfos.get(levelInfoIndex);
+}
+
 int MapDefinition::getSkyIndexForLevel(int levelIndex) const
 {
 	return this->skyMappings.get(levelIndex);

--- a/OpenTESArena/src/World/MapDefinition.h
+++ b/OpenTESArena/src/World/MapDefinition.h
@@ -131,6 +131,7 @@ public:
 	// use the same level info.
 	Span<const int> getLevelInfoIndices() const;
 	Span<const LevelInfoDefinition> getLevelInfos() const;
+	const LevelInfoDefinition &getLevelInfoForLevel(int levelIndex) const;
 
 	int getSkyIndexForLevel(int levelIndex) const;
 	const SkyDefinition &getSky(int index) const;

--- a/OpenTESArena/src/World/MapGeneration.cpp
+++ b/OpenTESArena/src/World/MapGeneration.cpp
@@ -20,6 +20,7 @@
 #include "../Assets/MIFUtils.h"
 #include "../Assets/TextAssetLibrary.h"
 #include "../Entities/ArenaAnimUtils.h"
+#include "../Entities/ArenaEntityUtils.h"
 #include "../Entities/EntityDefinition.h"
 #include "../Entities/EntityDefinitionLibrary.h"
 #include "../Math/Random.h"
@@ -252,7 +253,7 @@ namespace MapGeneration
 		if (isCreature)
 		{
 			const ArenaItemIndex itemIndex = *optItemIndex;
-			const int creatureID = isCreatureFinalBoss ? ArenaAnimUtils::FinalBossCreatureID : ArenaAnimUtils::getCreatureIDFromItemIndex(itemIndex);
+			const int creatureID = isCreatureFinalBoss ? ArenaEntityUtils::FinalBossCreatureID : ArenaAnimUtils::getCreatureIDFromItemIndex(itemIndex);
 			const int creatureIndex = ArenaAnimUtils::getCreatureIndexFromID(creatureID);
 			const CreatureDefinitionID creatureDefID = creatureIndex;
 


### PR DESCRIPTION
This enables random encounters with conditions close to those of the original game.

There are a few things to note:

1. For spawning enemies I largely copy-pasted code from the guard-spawning function. It can probably be combined into one function to reduce code duplication.

2. The original game checks for trespassing at the moment a player has clicked a building door, not every minute and hour as here. In the original game, you can linger within an interior until after it closes and you still won't be considered trespassing, whereas here you will. The opposite is probably also true (if you break in and linger until opening time you will still be considered trespassing in the original game, but here you will stop being considered as trespassing).

3. In the original game encounters won't happen if there are citizens nearby or enemies nearby. This PR doesn't block these cases. In order to prevent encounters spawning in cities during the day (I think that in the original game the only thing that prevents this is the presence of citizens or guards), this PR adds a check for whether it is night.

4. One parameter to the encounter calculations, terrain, still isn't handled, as I'm not sure about how it translates between the original game and OpenTESArena. With some testing in the original game I got the following values for terrain:

Imperial City = 0
Skyrim = 4
Hammerfell = 3

From a quick look the only place I saw terrain being handled in OpenTESArena was in the context of traveling. Do you know how to access it to pass values like the above to the encounter functions?