### PR TITLE
Match ceiling texture alignment to original game

### DIFF
--- a/OpenTESArena/src/Rendering/RenderVoxelChunkManager.cpp
+++ b/OpenTESArena/src/Rendering/RenderVoxelChunkManager.cpp
@@ -683,8 +683,17 @@ void RenderVoxelChunkManager::updateChunkCombinedVoxelDrawCalls(RenderVoxelChunk
 				const int destinationTexCoordComponentIndex = vertexIndex * MeshUtils::TEX_COORD_COMPONENTS_PER_VERTEX;
 				const double sourceTexCoordU = meshDef.rendererTexCoords[sourceTexCoordComponentIndex];
 				const double sourceTexCoordV = meshDef.rendererTexCoords[sourceTexCoordComponentIndex + 1];
-				quadVertexTexCoords[destinationTexCoordComponentIndex] = sourceTexCoordU * (static_cast<double>(quadVoxelWidth) * Constants::JustBelowOne); // Keep between [0, 1)
-				quadVertexTexCoords[destinationTexCoordComponentIndex + 1] = sourceTexCoordV * (static_cast<double>(quadVoxelHeight) * Constants::JustBelowOne);
+
+				double uScale = quadVoxelWidth;
+				double vScale = quadVoxelHeight;
+
+				if (voxelType == ArenaVoxelType::Ceiling)
+				{
+					std::swap(uScale, vScale);
+				}
+
+				quadVertexTexCoords[destinationTexCoordComponentIndex] = sourceTexCoordU * (uScale * Constants::JustBelowOne); // Keep between [0, 1)
+				quadVertexTexCoords[destinationTexCoordComponentIndex + 1] = sourceTexCoordV * (vScale * Constants::JustBelowOne);
 			}
 
 			combinedFaceVertexBuffer->voxelWidth = quadVoxelWidth;

--- a/OpenTESArena/src/Rendering/RenderVoxelChunkManager.cpp
+++ b/OpenTESArena/src/Rendering/RenderVoxelChunkManager.cpp
@@ -684,16 +684,17 @@ void RenderVoxelChunkManager::updateChunkCombinedVoxelDrawCalls(RenderVoxelChunk
 				const double sourceTexCoordU = meshDef.rendererTexCoords[sourceTexCoordComponentIndex];
 				const double sourceTexCoordV = meshDef.rendererTexCoords[sourceTexCoordComponentIndex + 1];
 
-				double uScale = quadVoxelWidth;
-				double vScale = quadVoxelHeight;
+				double texCoordUScale = static_cast<double>(quadVoxelWidth);
+				double texCoordVScale = static_cast<double>(quadVoxelHeight);
 
+				// Hack for certain meshes that need extra logic on top of their .obj vertex values.
 				if (voxelType == ArenaVoxelType::Ceiling)
 				{
-					std::swap(uScale, vScale);
+					std::swap(texCoordUScale, texCoordVScale);
 				}
 
-				quadVertexTexCoords[destinationTexCoordComponentIndex] = sourceTexCoordU * (uScale * Constants::JustBelowOne); // Keep between [0, 1)
-				quadVertexTexCoords[destinationTexCoordComponentIndex + 1] = sourceTexCoordV * (vScale * Constants::JustBelowOne);
+				quadVertexTexCoords[destinationTexCoordComponentIndex] = sourceTexCoordU * (texCoordUScale * Constants::JustBelowOne); // Keep between [0, 1)
+				quadVertexTexCoords[destinationTexCoordComponentIndex + 1] = sourceTexCoordV * (texCoordVScale * Constants::JustBelowOne);
 			}
 
 			combinedFaceVertexBuffer->voxelWidth = quadVoxelWidth;

--- a/data/meshes/CeilingBottom.obj
+++ b/data/meshes/CeilingBottom.obj
@@ -17,9 +17,9 @@ vn 0.0 -1.0 0.0
 # Tex coords
 # Y=0
 vt 0.0 0.0
-vt 0.0 1.0
-vt 1.0 1.0
 vt 1.0 0.0
+vt 1.0 1.0
+vt 0.0 1.0
 
 # Indices (1-based)
 # Y=0


### PR DESCRIPTION
Fixes #292.

Ceiling tiles match for the start dungeon, and also tested to match for Fang Lair.

Start dungeon in original game. Top is original game, bottom is OpenTESArena after this PR:
<img width="574" height="303" alt="Start" src="https://github.com/user-attachments/assets/f5e110a7-1e02-4301-a3c0-d9c1a74110ed" />