### PR TITLE
Fix encounter check for dungeons

### DIFF
--- a/OpenTESArena/src/Entities/ArenaEntityUtils.cpp
+++ b/OpenTESArena/src/Entities/ArenaEntityUtils.cpp
@@ -1025,9 +1025,9 @@ bool ArenaEntityUtils::isEnemyEncounterAllowedOnMinuteChanged(ArenaEnvironmentTy
 		return !areCitizensPresent; // During night
 	}
 
-	if (environmentType == ArenaEnvironmentType::BuildingInterior)
+	if (environmentType != ArenaEnvironmentType::Wilderness)
 	{
-		return !isPlayerCamping;
+		return (!isPlayerCamping || environmentType == ArenaEnvironmentType::BuildingInterior);
 	}
 
 	return false;


### PR DESCRIPTION
I noticed that enemies weren't spawning in Named Dungeons. The `isEnemyEncounterAllowedOnMinuteChanged` logic was not allowing dungeons like the original game does. Also, although it won't make a difference yet since camping isn't implemented, I made `isEnemyEncounterAllowedOnMinuteChanged` return true for `ArenaEnvironmentType::BuildingInterior` when camping like the original game.