### PR TITLE
Add GOG Games Arena install support

### DIFF
--- a/OpenTESArena/src/Game/Game.cpp
+++ b/OpenTESArena/src/Game/Game.cpp
@@ -258,10 +258,12 @@ bool Game::init()
 	const std::string &arenaPathsString = this->options.getMisc_ArenaPaths();
 	const Buffer<std::string> arenaPathsFromOptions = String::split(arenaPathsString, ',');
 	const std::vector<std::string> arenaPathsFromSteam = Platform::getSteamArenaPaths();
+	const std::vector<std::string> arenaPathsFromGog = Platform::getGogArenaPaths();
 
 	std::vector<std::string> allArenaPaths;
 	allArenaPaths.insert(allArenaPaths.end(), arenaPathsFromOptions.begin(), arenaPathsFromOptions.end());
 	allArenaPaths.insert(allArenaPaths.end(), arenaPathsFromSteam.begin(), arenaPathsFromSteam.end());
+	allArenaPaths.insert(allArenaPaths.end(), arenaPathsFromGog.begin(), arenaPathsFromGog.end());
 
 	std::string arenaPath;
 	bool isFloppyDiskVersion;

--- a/OpenTESArena/src/Utilities/Platform.cpp
+++ b/OpenTESArena/src/Utilities/Platform.cpp
@@ -25,6 +25,10 @@ namespace Platform
 	// Steam library's "steamapps" folder.
 	const std::string SteamArenaAppID = "1812290";
 
+	// GOG's product ID for The Elder Scrolls: Arena, used to find its install path in the
+	// Windows registry.
+	const std::string GogArenaProductID = "1435828982";
+
 	// Gets the user's home environment variable ($HOME). Does not have a trailing slash.
 	std::string getHomeEnv()
 	{
@@ -231,6 +235,43 @@ std::vector<std::string> Platform::getSteamArenaPaths()
 			}
 		}
 	}
+
+	return arenaPaths;
+}
+
+std::vector<std::string> Platform::getGogArenaPaths()
+{
+	std::vector<std::string> arenaPaths;
+
+#ifdef _WIN32
+	// GOG Arena is Windows-only and always writes its game install
+	// path under WOW6432Node (even on win64). It is checked explicitly by name
+	// first since Windows exempts direct access to it from the usual 32-bit/64-bit registry
+	// redirection, which should keep this working independently of a 32 or 64-bit build. 
+	// The non-redirected path is kept as a fallback in case that ever changes.
+	const std::string candidateSubKeys[] =
+	{
+		"SOFTWARE\\WOW6432Node\\GOG.com\\Games\\" + Platform::GogArenaProductID,
+		"SOFTWARE\\GOG.com\\Games\\" + Platform::GogArenaProductID
+	};
+
+	for (const std::string &subKey : candidateSubKeys)
+	{
+		char installPathBuffer[MAX_PATH];
+		DWORD installPathSize = sizeof(installPathBuffer);
+		const LSTATUS status = RegGetValueA(HKEY_LOCAL_MACHINE, subKey.c_str(), "path",
+			RRF_RT_REG_SZ, nullptr, installPathBuffer, &installPathSize);
+		if (status == ERROR_SUCCESS)
+		{
+			const std::string installPath = String::replace(std::string(installPathBuffer), '\\', '/');
+
+			// Unlike the Steam release, the GOG release keeps Arena's data directly in the
+			// install root (no "ARENA" subfolder).
+			arenaPaths.emplace_back(installPath);
+			break;
+		}
+	}
+#endif
 
 	return arenaPaths;
 }

--- a/OpenTESArena/src/Utilities/Platform.h
+++ b/OpenTESArena/src/Utilities/Platform.h
@@ -19,6 +19,9 @@ namespace Platform
 	// Gets candidate Arena data folders found inside locally-installed Steam libraries, if any.
 	std::vector<std::string> getSteamArenaPaths();
 
+	// Gets candidate Arena data folders found via a local GOG install, if any.
+	std::vector<std::string> getGogArenaPaths();
+
 	// Gets the options folder path.
 	std::string getOptionsPath();
 


### PR DESCRIPTION
Following from #243 and the comments made on GOG support, similar to the #333 fix: reads from GOG's registry key to get the exact path from WOW6432Node.
GOG installs seem to keep data directly in the install root instead of the ARENA subfolder, so changed that as well.

Tested on Windows:

> ./otesa.exe
> [Game/GameState.cpp(220)] Initializing.
> [Game/Game.cpp(244)] Initializing (Platform: Windows).
> [Game/Options.cpp(515)] Reading defaults "D:/Prog/C++/opentesarena/OpenTESArena/build/options/options-default.txt".
> [Game/Options.cpp(522)] Reading changes "C:/Users/Loqo/AppData/Roaming/OpenTESArena/options/options-changes.txt".
> [Game/Game.cpp(172)] CD version assets found in "C:/Program Files (x86)/GOG Galaxy/Games/Arena".
> [Audio/AudioManager.cpp(472)] Initializing.
> [Audio/WildMidi.cpp(69)] Warning: Cannot play music. Invalid/missing WildMIDI config "D:/Prog/C++/opentesarena/OpenTESArena/build/data/eawpats/timidity.cfg"
> [Rendering/Window.cpp(95)] Initializing.
> [Rendering/Renderer.cpp(158)] Initializing.
> [Rendering/Sdl2DSoft3DRenderBackend.cpp(46)] Created SDL_Renderer with "direct3d" (flags: 0xA).
> [Input/InputManager.cpp(201)] Initializing.
> [Assets/ArenaLevelLibrary.cpp(13)] Initializing Arena level assets.
> [Assets/BinaryAssetLibrary.cpp(278)] Initializing binary assets.
> [Assets/TextAssetLibrary.cpp(917)] Initializing text assets.
> [Audio/AudioManager.cpp(826)] Warning: Failed to play music PERCNTRO.XMI.
> [Game/Options.cpp(625)] Saved settings in "C:/Users/Loqo/AppData/Roaming/OpenTESArena/options/options-changes.txt".
> [Game/GameState.cpp(233)] Closing.
> [Rendering/Renderer.cpp(144)] Closing.

Also on a future note: it is theoretically possible to detect the GOG path on a Linux install via Wine by reading the registry keys of the Wine prefix, but that would require knowing the user's prefix which can vary a lot depending on his setup (Wine/Lutris/PlayOnLinux/Bottles etc). Passing his Wine prefix path on ArenaPaths in options-changes.txt would be functionally the same, right?