### PR TITLE
Match pickpocketing and lockpicking chances to original game

### DIFF
--- a/OpenTESArena/src/Assets/ExeData.cpp
+++ b/OpenTESArena/src/Assets/ExeData.cpp
@@ -15,6 +15,19 @@
 
 namespace
 {
+	uint8_t readU8(Span<const std::byte> exeBytes, int exeAddress)
+	{
+		return static_cast<uint8_t>(exeBytes[exeAddress]);
+	}
+
+	uint16_t readU16(Span<const std::byte> exeBytes, int exeAddress)
+	{
+		const uint16_t lo = static_cast<uint16_t>(exeBytes[exeAddress]);
+		const uint16_t hi = static_cast<uint16_t>(exeBytes[exeAddress + 1]);
+
+		return (lo | (hi << 8));
+	}
+
 	static constexpr char PAIR_SEPARATOR = ',';
 
 	template<typename T, size_t Length>
@@ -1204,12 +1217,20 @@ bool ExeDataThieving::init(Span<const std::byte> exeBytes, const KeyValueFile &k
 	const int thievingSuccessChestOffset = GetExeAddress(*section, "ThievingSuccessChest");
 	const int thievingFailureOffset = GetExeAddress(*section, "ThievingFailure");
 	const int thievingFailureChestOffset = GetExeAddress(*section, "ThievingFailureChest");
+	const int thievingEntranceNoGuardsChanceOffset = GetExeAddress(*section, "ThievingEntranceNoGuardsChance");
+	const int thievingPickpocketJunkThresholdOffset = GetExeAddress(*section, "ThievingPickpocketJunkThreshold");
+	const int thievingPickpocketMaxGoldOffset = GetExeAddress(*section, "ThievingPickpocketMaxGold");
+	const int thievingMagicallyHeldLockDifficultyThresholdOffset = GetExeAddress(*section, "ThievingMagicallyHeldLockDifficultyThreshold");
 
 	this->thievingInteractionType = GetExeStringNullTerminated(exeBytes, thievingInteractionTypeOffset);
 	this->thievingSuccess = GetExeStringNullTerminated(exeBytes, thievingSuccessOffset);
 	this->thievingSuccessChest = GetExeStringNullTerminated(exeBytes, thievingSuccessChestOffset);
 	this->thievingFailure = GetExeStringNullTerminated(exeBytes, thievingFailureOffset);
 	this->thievingFailureChest = GetExeStringNullTerminated(exeBytes, thievingFailureChestOffset);
+	this->thievingEntranceNoGuardsChance = readU8(exeBytes,thievingEntranceNoGuardsChanceOffset);
+	this->thievingPickpocketJunkThreshold = readU16(exeBytes,thievingPickpocketJunkThresholdOffset);
+	this->thievingPickpocketMaxGold = readU8(exeBytes,thievingPickpocketMaxGoldOffset);
+	this->thievingMagicallyHeldLockDifficultyThreshold = readU8(exeBytes, thievingMagicallyHeldLockDifficultyThresholdOffset);
 
 	return true;
 }

--- a/OpenTESArena/src/Assets/ExeData.cpp
+++ b/OpenTESArena/src/Assets/ExeData.cpp
@@ -15,19 +15,6 @@
 
 namespace
 {
-	uint8_t readU8(Span<const std::byte> exeBytes, int exeAddress)
-	{
-		return static_cast<uint8_t>(exeBytes[exeAddress]);
-	}
-
-	uint16_t readU16(Span<const std::byte> exeBytes, int exeAddress)
-	{
-		const uint16_t lo = static_cast<uint16_t>(exeBytes[exeAddress]);
-		const uint16_t hi = static_cast<uint16_t>(exeBytes[exeAddress + 1]);
-
-		return (lo | (hi << 8));
-	}
-
 	static constexpr char PAIR_SEPARATOR = ',';
 
 	template<typename T, size_t Length>
@@ -1227,10 +1214,10 @@ bool ExeDataThieving::init(Span<const std::byte> exeBytes, const KeyValueFile &k
 	this->thievingSuccessChest = GetExeStringNullTerminated(exeBytes, thievingSuccessChestOffset);
 	this->thievingFailure = GetExeStringNullTerminated(exeBytes, thievingFailureOffset);
 	this->thievingFailureChest = GetExeStringNullTerminated(exeBytes, thievingFailureChestOffset);
-	this->thievingEntranceNoGuardsChance = readU8(exeBytes,thievingEntranceNoGuardsChanceOffset);
-	this->thievingPickpocketJunkThreshold = readU16(exeBytes,thievingPickpocketJunkThresholdOffset);
-	this->thievingPickpocketMaxGold = readU8(exeBytes,thievingPickpocketMaxGoldOffset);
-	this->thievingMagicallyHeldLockDifficultyThreshold = readU8(exeBytes, thievingMagicallyHeldLockDifficultyThresholdOffset);
+	this->thievingEntranceNoGuardsChance = static_cast<uint8_t>(exeBytes[thievingEntranceNoGuardsChanceOffset]);
+	this->thievingPickpocketJunkThreshold = Bytes::getLE16(reinterpret_cast<const uint8_t*>(exeBytes.begin() + thievingPickpocketJunkThresholdOffset));
+	this->thievingPickpocketMaxGold = static_cast<uint8_t>(exeBytes[thievingPickpocketMaxGoldOffset]);
+	this->thievingMagicallyHeldLockDifficultyThreshold = static_cast<uint8_t>(exeBytes[thievingMagicallyHeldLockDifficultyThresholdOffset]);
 
 	return true;
 }

--- a/OpenTESArena/src/Assets/ExeData.h
+++ b/OpenTESArena/src/Assets/ExeData.h
@@ -649,6 +649,18 @@ struct ExeDataThieving
 	std::string thievingFailure;
 	std::string thievingFailureChest;
 
+	// Chance that no guards will spawn when the player fails an attempt to pick a locked entrance.
+	uint8_t thievingEntranceNoGuardsChance;
+
+	// Compared against a random number when pickpocketing to determine whether a junk message is shown or gold pieces are received.
+	uint16_t thievingPickpocketJunkThreshold;
+
+	// Maximum amount of gold pieces the player can get from a pickpocket attempt.
+	uint8_t thievingPickpocketMaxGold;
+
+	// Locks with difficulty levels of this value or higher show the "magically-held lock" message when examined.
+	uint8_t thievingMagicallyHeldLockDifficultyThreshold;
+
 	bool init(Span<const std::byte> exeBytes, const KeyValueFile &keyValueFile);
 };
 

--- a/OpenTESArena/src/Combat/CombatLogic.cpp
+++ b/OpenTESArena/src/Combat/CombatLogic.cpp
@@ -287,7 +287,7 @@ void CombatLogic::onEntityHitByPlayer(EntityInstanceID hitEntityInstID, bool isF
 			if (hitEntityBehaviorState.isCitizen())
 			{
 				GameWorldUiController::onCitizenKilled(game);
-				gameState.queueCityGuardEncounter(game);
+				gameState.queueCityGuardEncounter(game, true);
 			}
 			else if (hitEntityBehaviorState.isCreature())
 			{

--- a/OpenTESArena/src/Entities/ArenaEntityUtils.cpp
+++ b/OpenTESArena/src/Entities/ArenaEntityUtils.cpp
@@ -925,9 +925,9 @@ bool ArenaEntityUtils::doGuardsAppearForViolence(int playerLevel, ArenaRandom &r
 	return random.next(100) < chance;
 }
 
-bool ArenaEntityUtils::doGuardsAppearForTheft(int thievingSkill, ArenaRandom &random)
+bool ArenaEntityUtils::doGuardsAppearForTheft(int chance, ArenaRandom &random)
 {
-	return random.next(100) < (100 - thievingSkill);
+	return random.next(100) < (100 - chance);
 }
 
 int ArenaEntityUtils::getGuardType(const ExeData &exeData, ArenaRandom &random)

--- a/OpenTESArena/src/Entities/ArenaEntityUtils.h
+++ b/OpenTESArena/src/Entities/ArenaEntityUtils.h
@@ -111,7 +111,7 @@ namespace ArenaEntityUtils
 	std::string getWeaponNameFromItemID(int itemID, const ExeData &exeData);
 
 	bool doGuardsAppearForViolence(int playerLevel, ArenaRandom &random);
-	bool doGuardsAppearForTheft(int thievingSkill, ArenaRandom &random);
+	bool doGuardsAppearForTheft(int chance, ArenaRandom &random);
 	int getGuardType(const ExeData &exeData, ArenaRandom &random);
 	int getGuardLevel(ArenaCityType cityType, int tierBonus, const ExeData &exeData, ArenaRandom &random);
 	int getNumberOfGuardsToSpawn(ArenaRandom &random);

--- a/OpenTESArena/src/Game/GameState.cpp
+++ b/OpenTESArena/src/Game/GameState.cpp
@@ -125,6 +125,7 @@ void GuardSpawnState::clearQueue()
 EntityEncounterSpawnInfo::EntityEncounterSpawnInfo()
 {
 	this->guardType = -1;
+	this->isResponseToViolence = false;
 	this->level = 0;
 	this->count = 0;
 }
@@ -137,9 +138,10 @@ void EntityEncounterSpawnInfo::initCreaturesOrHumans(int spawnID, int level, int
 	this->entityDefPredicate = MakeOriginalSpawnEntityDefinitionPredicate(spawnID);
 }
 
-void EntityEncounterSpawnInfo::initCityGuards(int guardType, int level, int count)
+void EntityEncounterSpawnInfo::initCityGuards(int guardType, bool isResponseToViolence, int level, int count)
 {
 	this->guardType = guardType;
+	this->isResponseToViolence = isResponseToViolence;
 	this->level = level;
 	this->count = count;
 	this->entityDefPredicate = CityGuardEntityDefinitionPredicate;
@@ -847,10 +849,11 @@ void GameState::spawnEncounterEnemies(Game &game, const EntityEncounterSpawnInfo
 			const bool isFirstSpawnedGuard = actualSpawnCount == 0;
 			if (isFirstSpawnedGuard)
 			{
+				const char *guardSpawnSfxName = spawnInfo.isResponseToViolence ? ArenaSoundName::Halt : ArenaSoundName::StopThief;
 				const WorldDouble3 spawnSoundPosition = VoxelUtils::getVoxelCenter(spawnWorldVoxel, ceilingScale);
 
 				AudioManager &audioManager = game.audioManager;
-				audioManager.playSoundOneShot(ArenaSoundName::Halt, spawnSoundPosition);
+				audioManager.playSoundOneShot(guardSpawnSfxName, spawnSoundPosition);
 			}
 		}
 
@@ -858,7 +861,7 @@ void GameState::spawnEncounterEnemies(Game &game, const EntityEncounterSpawnInfo
 	}
 }
 
-void GameState::queueCityGuardEncounter(Game &game)
+void GameState::queueCityGuardEncounter(Game &game, bool isViolence)
 {
 	if (this->guardSpawnState.isQueued())
 	{
@@ -870,7 +873,7 @@ void GameState::queueCityGuardEncounter(Game &game)
 	constexpr double originalSecondsTillGuardSpawn = originalSecondsPerFrame * static_cast<double>(originalGameUpdatesTillGuardSpawn);
 	this->guardSpawnState.secondsTillSpawn = originalSecondsTillGuardSpawn;
 
-	this->guardSpawnState.spawnFunc = [this, &game]()
+	this->guardSpawnState.spawnFunc = [this, &game, isViolence]()
 	{
 		const Player &player = game.player;
 		const WorldDouble3 playerPosition = player.getEyePosition();
@@ -881,14 +884,26 @@ void GameState::queueCityGuardEncounter(Game &game)
 			return;
 		}
 
-		ArenaRandom &arenaRandom = game.arenaRandom;
-		if (!ArenaEntityUtils::doGuardsAppearForViolence(player.level, arenaRandom))
-		{
-			DebugLog("Not spawning guards because of random chance.");
-			return;
-		}
-
 		const ExeData &exeData = BinaryAssetLibrary::getInstance().getExeData();
+		ArenaRandom &arenaRandom = game.arenaRandom;
+
+		if (isViolence)
+		{
+			if (!ArenaEntityUtils::doGuardsAppearForViolence(player.level, arenaRandom))
+			{
+				DebugLog("Not spawning guards for violence because of random chance.");
+				return;
+			}
+		}
+		else
+		{
+			if (!ArenaEntityUtils::doGuardsAppearForTheft(exeData.thieving.thievingEntranceNoGuardsChance, arenaRandom))
+			{
+				DebugLog("Not spawning guards for theft because of random chance.");
+				return;
+			}
+		}		
+
 		const LocationDefinition &locationDef = this->getLocationDefinition();
 		const LocationCityDefinition &cityDef = locationDef.getCityDefinition();
 		const ArenaCityType cityType = cityDef.type;
@@ -897,7 +912,7 @@ void GameState::queueCityGuardEncounter(Game &game)
 		const int guardCount = ArenaEntityUtils::getNumberOfGuardsToSpawn(arenaRandom);
 
 		EntityEncounterSpawnInfo encounterSpawnInfo;
-		encounterSpawnInfo.initCityGuards(guardType, guardLevel, guardCount);
+		encounterSpawnInfo.initCityGuards(guardType, isViolence, guardLevel, guardCount);
 		this->spawnEncounterEnemies(game, encounterSpawnInfo);
 	};
 }

--- a/OpenTESArena/src/Game/GameState.h
+++ b/OpenTESArena/src/Game/GameState.h
@@ -46,6 +46,7 @@ struct GuardSpawnState
 struct EntityEncounterSpawnInfo
 {
 	int guardType; // Non-negative if for city guards.
+	bool isResponseToViolence;
 	int level;
 	int count;
 	EntityDefinitionPredicate entityDefPredicate; // Filters to matching definitions from library.
@@ -53,7 +54,7 @@ struct EntityEncounterSpawnInfo
 	EntityEncounterSpawnInfo();
 
 	void initCreaturesOrHumans(int spawnID, int level, int count);
-	void initCityGuards(int guardType, int level, int count);
+	void initCityGuards(int guardType, bool isResponseToViolence, int level, int count);
 
 	bool isCityGuards() const;
 };
@@ -244,7 +245,7 @@ public:
 	void addCombatEntityResult(EntityInstanceID entityInstID, bool isFromMeleeWeapon);
 
 	void spawnEncounterEnemies(Game &game, const EntityEncounterSpawnInfo &spawnInfo) const;
-	void queueCityGuardEncounter(Game &game);
+	void queueCityGuardEncounter(Game &game, bool isViolence);
 
 	// Applies any pending scene transition, setting the new level active in the game world and renderer.
 	void applyPendingSceneChange(Game &game, JPH::PhysicsSystem &physicsSystem, double dt);

--- a/OpenTESArena/src/Interface/GameWorldUiState.cpp
+++ b/OpenTESArena/src/Interface/GameWorldUiState.cpp
@@ -2897,7 +2897,7 @@ void GameWorldUI::onPlayerStealItemFailure()
 		GameWorldUI::onCloseConversationButtonSelected(MouseButtonType::Left);
 
 		GameState &gameState = game.gameState;
-		gameState.queueCityGuardEncounter(game);
+		gameState.queueCityGuardEncounter(game, false);
 	};
 
 	GameWorldUI::showTextPopUp(text.c_str(), ArenaFontName::A, GameWorldUiView::StatusPopUpTextAlignment, callback);
@@ -3828,7 +3828,7 @@ void GameWorldUI::onNpcTavernSneakIntoARoomButtonSelected(MouseButtonType mouseB
 		{
 			uiManager.disableTopMostContext();
 			GameWorldUI::onCloseConversationButtonSelected(MouseButtonType::Left);
-			gameState.queueCityGuardEncounter(game);
+			gameState.queueCityGuardEncounter(game, false);
 		};
 	}
 

--- a/OpenTESArena/src/Interface/GameWorldUiState.cpp
+++ b/OpenTESArena/src/Interface/GameWorldUiState.cpp
@@ -2817,7 +2817,7 @@ void GameWorldUI::onPlayerStealItemFailure()
 		GameWorldUI::onCloseConversationButtonSelected(MouseButtonType::Right);
 
 		GameState &gameState = game.gameState;
-		gameState.queueCityGuardEncounter(game);
+		gameState.queueCityGuardEncounter(game, false);
 	};
 
 	GameWorldUI::showTextPopUp(text.c_str(), ArenaFontName::A, GameWorldUiView::StatusPopUpTextAlignment, callback);

--- a/OpenTESArena/src/Interface/GameWorldUiState.cpp
+++ b/OpenTESArena/src/Interface/GameWorldUiState.cpp
@@ -3589,8 +3589,11 @@ void GameWorldUI::onNpcEquipmentStealButtonSelected(MouseButtonType mouseButtonT
 	UiManager &uiManager = game.uiManager;
 	uiManager.disableTopMostContext();
 
-	Random &random = game.random;
-	const bool isStealSuccessful = random.nextBool();
+	ArenaRandom &arenaRandom = game.arenaRandom;
+
+	const Player &player = game.player;
+	const CharacterClassDefinition &charClassDef = CharacterClassLibrary::getInstance().getDefinition(player.charClassDefID);
+	const bool isStealSuccessful = ArenaPlayerUtils::attemptThieving(5, charClassDef.thievingDivisor, player.level, player.primaryAttributes, arenaRandom);
 	if (isStealSuccessful)
 	{
 		ItemLibraryPredicate stealableItemsPredicate = [](const ItemDefinition &itemDef)
@@ -3727,8 +3730,11 @@ void GameWorldUI::onNpcMagesGuildStealPotionsButtonSelected(MouseButtonType mous
 	UiManager &uiManager = game.uiManager;
 	uiManager.disableTopMostContext();
 
-	Random &random = game.random;
-	const bool isStealSuccessful = random.nextBool();
+	ArenaRandom &arenaRandom = game.arenaRandom;
+
+	const Player &player = game.player;
+	const CharacterClassDefinition &charClassDef = CharacterClassLibrary::getInstance().getDefinition(player.charClassDefID);
+	const bool isStealSuccessful = ArenaPlayerUtils::attemptThieving(3, charClassDef.thievingDivisor, player.level, player.primaryAttributes, arenaRandom);
 	if (isStealSuccessful)
 	{
 		ItemLibraryPredicate stealableItemsPredicate = [](const ItemDefinition &itemDef)
@@ -3751,8 +3757,11 @@ void GameWorldUI::onNpcMagesGuildStealMagicItemsButtonSelected(MouseButtonType m
 	UiManager &uiManager = game.uiManager;
 	uiManager.disableTopMostContext();
 
-	Random &random = game.random;
-	const bool isStealSuccessful = random.nextBool();
+	ArenaRandom &arenaRandom = game.arenaRandom;
+
+	const Player &player = game.player;
+	const CharacterClassDefinition &charClassDef = CharacterClassLibrary::getInstance().getDefinition(player.charClassDefID);
+	const bool isStealSuccessful = ArenaPlayerUtils::attemptThieving(6, charClassDef.thievingDivisor, player.level, player.primaryAttributes, arenaRandom);
 	if (isStealSuccessful)
 	{
 		ItemLibraryPredicate stealableItemsPredicate = [](const ItemDefinition &itemDef)

--- a/OpenTESArena/src/Interface/GameWorldUiState.cpp
+++ b/OpenTESArena/src/Interface/GameWorldUiState.cpp
@@ -3795,9 +3795,12 @@ void GameWorldUI::onNpcTavernSneakIntoARoomButtonSelected(MouseButtonType mouseB
 
 	GameState &gameState = game.gameState;
 	Random &random = game.random;
+	ArenaRandom &arenaRandom = game.arenaRandom;
 	const ExeData &exeData = BinaryAssetLibrary::getInstance().getExeData();
 
-	const bool isSneakingSuccessful = random.nextReal() <= 0.70; // Arbitrary
+	const Player &player = game.player;
+	const CharacterClassDefinition &charClassDef = CharacterClassLibrary::getInstance().getDefinition(player.charClassDefID);
+	const bool isSneakingSuccessful = ArenaPlayerUtils::attemptThieving(1, charClassDef.thievingDivisor, player.level, player.primaryAttributes, arenaRandom);
 
 	std::string text;
 	std::string fontName;

--- a/OpenTESArena/src/Player/ArenaPlayerUtils.cpp
+++ b/OpenTESArena/src/Player/ArenaPlayerUtils.cpp
@@ -2,6 +2,7 @@
 #include <cmath>
 
 #include "ArenaPlayerUtils.h"
+#include "../Entities/ArenaEntityUtils.h"
 #include "../Assets/ExeData.h"
 #include "../Math/Random.h"
 #include "../Player/Player.h"
@@ -187,35 +188,68 @@ DerivedAttributes ArenaPlayerUtils::calculateTotalDerivedBonuses(const PrimaryAt
 	return totalDerivedAttributes;
 }
 
-int ArenaPlayerUtils::getThievingChance(int difficultyLevel, int thievingDivisor, int playerLevel, const PrimaryAttributes &attributes)
+bool ArenaPlayerUtils::attemptThieving(int difficultyLevel, int thievingDivisor, int playerLevel, const PrimaryAttributes &attributes, ArenaRandom &random, int *outThievingChance)
 {
 	DebugAssert(thievingDivisor > 0);
 	DebugAssert(difficultyLevel > 0);
 
 	const int attributesModifier = attributes.intelligence.maxValue + attributes.agility.maxValue;
-	const int ability = ((((attributesModifier / thievingDivisor) * (playerLevel + 1)) * 100) / (difficultyLevel * 100));
-	const int clampedAbility = std::clamp(ability, 0, 100);
-	return clampedAbility;
-}
+	const int ability = (((attributesModifier / thievingDivisor) * (playerLevel + 1)) / difficultyLevel);
+	const int thievingChance = std::clamp(ability, 0, 100);
 
-bool ArenaPlayerUtils::attemptThieving(int difficultyLevel, int thievingDivisor, int playerLevel, const PrimaryAttributes &attributes, Random &random)
-{
-	const int thievingChance = ArenaPlayerUtils::getThievingChance(difficultyLevel, thievingDivisor, playerLevel, attributes);
+	if (outThievingChance != nullptr)
+	{
+		*outThievingChance = thievingChance;
+	}
+
 	const int roll = random.next(100);
 	return thievingChance >= roll;
 }
 
-int ArenaPlayerUtils::getLockDifficultyMessageIndex(int difficultyLevel, int thievingDivisor, int playerLevel, const PrimaryAttributes &attributes, const ExeData &exeData)
+bool ArenaPlayerUtils::attemptPickpocket(ArenaCityType cityType, int thievingDivisor, int playerLevel, const PrimaryAttributes &attributes, ArenaRandom &random, const ExeData &exeData, int *outTemplateIndex, int *outGoldAmount, bool *outGuardsAppear)
+{
+	constexpr int goldTemplateIndexStart = 1379;
+	constexpr int junkTemplateIndex = 1384;
+	const int difficultyLevel = 4 - static_cast<int>(cityType);
+	int thievingChance;
+	*outGoldAmount = 0;
+	*outGuardsAppear = false;
+
+	const bool result = ArenaPlayerUtils::attemptThieving(difficultyLevel, thievingDivisor, playerLevel, attributes, random, &thievingChance);
+	if (result)
+	{
+		const int randomValue = random.next();
+		if (randomValue < exeData.thieving.thievingPickpocketJunkThreshold)
+		{
+			const int roll = random.next(exeData.thieving.thievingPickpocketMaxGold);
+			*outGoldAmount = roll + 1;
+			*outTemplateIndex = roll + goldTemplateIndexStart;
+		}
+		else
+		{
+			*outTemplateIndex = junkTemplateIndex;
+		}
+	}
+	else
+	{
+		*outGuardsAppear = ArenaEntityUtils::doGuardsAppearForTheft(thievingChance, random);
+	}
+
+	return result;
+}
+
+int ArenaPlayerUtils::getLockDifficultyMessageIndex(int difficultyLevel, int thievingDivisor, int playerLevel, const PrimaryAttributes &attributes, const ExeData &exeData, ArenaRandom &random)
 {
 	int index;
-	if (difficultyLevel >= 20)
+	if (difficultyLevel >= exeData.thieving.thievingMagicallyHeldLockDifficultyThreshold)
 	{
-		// Magically-locked door. Use the last message.
+		// Magically-held lock. Use the last message.
 		index = static_cast<int>(std::size(exeData.status.lockDifficultyMessages)) - 1;
 	}
 	else
 	{
-		const int thievingChance = ArenaPlayerUtils::getThievingChance(difficultyLevel, thievingDivisor, playerLevel, attributes);
+		int thievingChance;
+		ArenaPlayerUtils::attemptThieving(difficultyLevel, thievingDivisor, playerLevel, attributes, random, &thievingChance);
 		index = (thievingChance / 5) - 6;
 		index = std::clamp(index, 0, static_cast<int>(std::size(exeData.status.lockDifficultyMessages) - 2));
 	}

--- a/OpenTESArena/src/Player/ArenaPlayerUtils.cpp
+++ b/OpenTESArena/src/Player/ArenaPlayerUtils.cpp
@@ -2,8 +2,8 @@
 #include <cmath>
 
 #include "ArenaPlayerUtils.h"
-#include "../Entities/ArenaEntityUtils.h"
 #include "../Assets/ExeData.h"
+#include "../Entities/ArenaEntityUtils.h"
 #include "../Math/Random.h"
 #include "../Player/Player.h"
 #include "../Stats/ArenaStatUtils.h"
@@ -208,16 +208,17 @@ bool ArenaPlayerUtils::attemptThieving(int difficultyLevel, int thievingDivisor,
 
 bool ArenaPlayerUtils::attemptPickpocket(ArenaCityType cityType, int thievingDivisor, int playerLevel, const PrimaryAttributes &attributes, ArenaRandom &random, const ExeData &exeData, int *outTemplateIndex, int *outGoldAmount, bool *outGuardsAppear)
 {
-	constexpr int goldTemplateIndexStart = 1379;
-	constexpr int junkTemplateIndex = 1384;
-	const int difficultyLevel = 4 - static_cast<int>(cityType);
-	int thievingChance;
 	*outGoldAmount = 0;
 	*outGuardsAppear = false;
 
-	const bool result = ArenaPlayerUtils::attemptThieving(difficultyLevel, thievingDivisor, playerLevel, attributes, random, &thievingChance);
-	if (result)
+	const int difficultyLevel = 4 - static_cast<int>(cityType);
+	int thievingChance;
+	const bool success = ArenaPlayerUtils::attemptThieving(difficultyLevel, thievingDivisor, playerLevel, attributes, random, &thievingChance);
+	if (success)
 	{
+		constexpr int goldTemplateIndexStart = 1379;
+		constexpr int junkTemplateIndex = 1384;
+
 		const int randomValue = random.next();
 		if (randomValue < exeData.thieving.thievingPickpocketJunkThreshold)
 		{
@@ -235,7 +236,7 @@ bool ArenaPlayerUtils::attemptPickpocket(ArenaCityType cityType, int thievingDiv
 		*outGuardsAppear = ArenaEntityUtils::doGuardsAppearForTheft(thievingChance, random);
 	}
 
-	return result;
+	return success;
 }
 
 int ArenaPlayerUtils::getLockDifficultyMessageIndex(int difficultyLevel, int thievingDivisor, int playerLevel, const PrimaryAttributes &attributes, const ExeData &exeData, ArenaRandom &random)

--- a/OpenTESArena/src/Player/ArenaPlayerUtils.h
+++ b/OpenTESArena/src/Player/ArenaPlayerUtils.h
@@ -1,7 +1,9 @@
 #pragma once
 
+class ArenaRandom;
 class Random;
 
+enum class ArenaCityType;
 struct ExeData;
 struct Player;
 struct PrimaryAttributes;
@@ -56,9 +58,9 @@ namespace ArenaPlayerUtils
 	DerivedAttributes calculatePersonalityDerivedBonuses(int personality);
 	DerivedAttributes calculateTotalDerivedBonuses(const PrimaryAttributes &attributes);
 
-	int getThievingChance(int difficultyLevel, int thievingDivisor, int playerLevel, const PrimaryAttributes &attributes);
-	bool attemptThieving(int difficultyLevel, int thievingDivisor, int playerLevel, const PrimaryAttributes &attributes, Random &random);
-	int getLockDifficultyMessageIndex(int difficultyLevel, int thievingDivisor, int playerLevel, const PrimaryAttributes &attributes, const ExeData &exeData);
+	bool attemptThieving(int difficultyLevel, int thievingDivisor, int playerLevel, const PrimaryAttributes &attributes, ArenaRandom &random, int *outThievingChance = nullptr);
+	bool attemptPickpocket(ArenaCityType cityType, int thievingDivisor, int playerLevel, const PrimaryAttributes &attributes, ArenaRandom &random, const ExeData &exeData, int *outTemplateIndex, int *outGoldAmount, bool *outGuardsAppear);
+	int getLockDifficultyMessageIndex(int difficultyLevel, int thievingDivisor, int playerLevel, const PrimaryAttributes &attributes, const ExeData &exeData, ArenaRandom &random);
 
 	constexpr int DoorBashMinDamageRequired = 6;
 

--- a/OpenTESArena/src/Player/ArenaPlayerUtils.h
+++ b/OpenTESArena/src/Player/ArenaPlayerUtils.h
@@ -4,6 +4,7 @@ class ArenaRandom;
 class Random;
 
 enum class ArenaCityType;
+
 struct ExeData;
 struct Player;
 struct PrimaryAttributes;

--- a/OpenTESArena/src/Player/PlayerLogic.cpp
+++ b/OpenTESArena/src/Player/PlayerLogic.cpp
@@ -410,7 +410,7 @@ namespace PlayerLogic
 						{
 							if (isLocked)
 							{
-								const int lockDifficultyIndex = ArenaPlayerUtils::getLockDifficultyMessageIndex(lockLevel, charClassDef.thievingDivisor, player.level, player.primaryAttributes, exeData);
+								const int lockDifficultyIndex = ArenaPlayerUtils::getLockDifficultyMessageIndex(lockLevel, charClassDef.thievingDivisor, player.level, player.primaryAttributes, exeData, arenaRandom);
 								const std::string lockDifficultyMsg = GameWorldUiModel::getLockDifficultyMessage(lockDifficultyIndex, exeData);
 								GameWorldUI::setActionText(lockDifficultyMsg.c_str());
 							}
@@ -425,11 +425,14 @@ namespace PlayerLogic
 
 							if (isLocked)
 							{
-								const bool isLockpickingSuccessful = random.nextBool(); // @todo use original chances
+								const bool isLockpickingSuccessful = ArenaPlayerUtils::attemptThieving(lockLevel, charClassDef.thievingDivisor, player.level, player.primaryAttributes, arenaRandom, nullptr);
 								if (!isLockpickingSuccessful)
 								{
 									GameWorldUI::setActionText(exeData.thieving.thievingFailure.c_str());
-									gameState.queueCityGuardEncounter(game);
+									if (ArenaEntityUtils::doGuardsAppearForTheft(exeData.thieving.thievingEntranceNoGuardsChance, arenaRandom))
+									{
+										gameState.queueCityGuardEncounter(game);
+									}
 									return;
 								}
 
@@ -508,7 +511,7 @@ namespace PlayerLogic
 						if (!isApplyingDoorKeyToLock && interactionType == GameWorldInteractionType::Thieving)
 						{
 							isAttemptingLockpick = true;
-							isLockpickingSuccessful = random.nextBool(); // @todo original chances
+							isLockpickingSuccessful = ArenaPlayerUtils::attemptThieving(lockLevel, charClassDef.thievingDivisor, player.level, player.primaryAttributes, arenaRandom, nullptr);
 							canDoorBeOpened = isLockpickingSuccessful;
 						}
 					}
@@ -531,7 +534,7 @@ namespace PlayerLogic
 				}
 				else
 				{
-					const int lockDifficultyIndex = ArenaPlayerUtils::getLockDifficultyMessageIndex(lockLevel, charClassDef.thievingDivisor, player.level, player.primaryAttributes, exeData);
+					const int lockDifficultyIndex = ArenaPlayerUtils::getLockDifficultyMessageIndex(lockLevel, charClassDef.thievingDivisor, player.level, player.primaryAttributes, exeData, arenaRandom);
 					const std::string lockDifficultyMsg = GameWorldUiModel::getLockDifficultyMessage(lockDifficultyIndex, exeData);
 					GameWorldUI::setActionText(lockDifficultyMsg.c_str());
 				}
@@ -569,6 +572,7 @@ namespace PlayerLogic
 		const bool canPlayerMoveAndTurn = game.canPlayerMoveAndTurn();
 
 		Random &random = game.random;
+		ArenaRandom &arenaRandom = game.arenaRandom;
 
 		if (isPrimaryInteraction)
 		{
@@ -637,21 +641,29 @@ namespace PlayerLogic
 
 						const ArenaTemplateDat &templateDat = TextAssetLibrary::getInstance().templateDat;
 
-						constexpr double pickpocketGoldChance = 0.20; // @todo original chances
-						constexpr double pickpocketJunkChance = 0.90;
-						const double pickpocketTypeRoll = random.nextReal();
+						const LocationDefinition &locationDef = gameState.getLocationDefinition();
+						const LocationCityDefinition &cityDef = locationDef.getCityDefinition();
+						const ArenaCityType cityType = cityDef.type;
+						const CharacterClassLibrary &charClassLibrary = CharacterClassLibrary::getInstance();
+						const CharacterClassDefinition &charClassDef = charClassLibrary.getDefinition(player.charClassDefID);
+						int pickpocketGoldAmount;
+						int pickpocketResultTemplateDatIndex;
+						bool guardsAppear;
+
+						bool pickPocketSuccess = ArenaPlayerUtils::attemptPickpocket(cityType, charClassDef.thievingDivisor, player.level, player.primaryAttributes, arenaRandom, exeData, &pickpocketResultTemplateDatIndex, &pickpocketGoldAmount, &guardsAppear);
 						const ArenaTemplateDatEntry *pickpocketResultTemplateDatEntry = nullptr;
-						if (pickpocketTypeRoll <= pickpocketGoldChance)
+						if (pickPocketSuccess)
 						{
-							constexpr int pickpocketGoldMin = 1;
-							constexpr int pickpocketGoldMax = 5;
-							const int pickpocketGoldAmount = pickpocketGoldMin + random.next(pickpocketGoldMax);
-							pickpocketResultTemplateDatEntry = &templateDat.getEntry(1379 + (pickpocketGoldAmount - 1));
+							pickpocketResultTemplateDatEntry = &templateDat.getEntry(pickpocketResultTemplateDatIndex);
 							player.gold += pickpocketGoldAmount;
 						}
-						else if (pickpocketTypeRoll <= pickpocketJunkChance)
+						else
 						{
-							pickpocketResultTemplateDatEntry = &templateDat.getEntry(1384);
+							if (guardsAppear)
+							{
+								gameState.queueCityGuardEncounter(game);
+							}
+							GameWorldUI::setActionText(exeData.thieving.thievingFailure.c_str());
 						}
 
 						if (pickpocketResultTemplateDatEntry != nullptr)
@@ -661,11 +673,6 @@ namespace PlayerLogic
 							std::string pickpocketResultString = pickpocketResultTemplateDatEntry->values[entryVariantIndex];
 							pickpocketResultString = String::distributeNewlines(pickpocketResultString, 60);
 							GameWorldUI::showTextPopUp(pickpocketResultString.c_str(), GameWorldUiView::StatusPopUpFontName, TextAlignment::TopLeft);
-						}
-						else
-						{
-							gameState.queueCityGuardEncounter(game);
-							GameWorldUI::setActionText(exeData.thieving.thievingFailure.c_str());
 						}
 					}
 				}

--- a/OpenTESArena/src/Player/PlayerLogic.cpp
+++ b/OpenTESArena/src/Player/PlayerLogic.cpp
@@ -429,10 +429,7 @@ namespace PlayerLogic
 								if (!isLockpickingSuccessful)
 								{
 									GameWorldUI::setActionText(exeData.thieving.thievingFailure.c_str());
-									if (ArenaEntityUtils::doGuardsAppearForTheft(exeData.thieving.thievingEntranceNoGuardsChance, arenaRandom))
-									{
-										gameState.queueCityGuardEncounter(game);
-									}
+									gameState.queueCityGuardEncounter(game, false);
 									return;
 								}
 
@@ -659,11 +656,12 @@ namespace PlayerLogic
 						}
 						else
 						{
+							GameWorldUI::setActionText(exeData.thieving.thievingFailure.c_str());
+
 							if (guardsAppear)
 							{
-								gameState.queueCityGuardEncounter(game);
+								gameState.queueCityGuardEncounter(game, false);
 							}
-							GameWorldUI::setActionText(exeData.thieving.thievingFailure.c_str());
 						}
 
 						if (pickpocketResultTemplateDatEntry != nullptr)

--- a/OpenTESArena/src/Player/PlayerLogic.cpp
+++ b/OpenTESArena/src/Player/PlayerLogic.cpp
@@ -568,6 +568,9 @@ namespace PlayerLogic
 		Player &player = game.player;
 		const bool canPlayerMoveAndTurn = game.canPlayerMoveAndTurn();
 
+		const CharacterClassLibrary &charClassLibrary = CharacterClassLibrary::getInstance();
+		const CharacterClassDefinition &charClassDef = charClassLibrary.getDefinition(player.charClassDefID);
+
 		Random &random = game.random;
 		ArenaRandom &arenaRandom = game.arenaRandom;
 
@@ -641,8 +644,6 @@ namespace PlayerLogic
 						const LocationDefinition &locationDef = gameState.getLocationDefinition();
 						const LocationCityDefinition &cityDef = locationDef.getCityDefinition();
 						const ArenaCityType cityType = cityDef.type;
-						const CharacterClassLibrary &charClassLibrary = CharacterClassLibrary::getInstance();
-						const CharacterClassDefinition &charClassDef = charClassLibrary.getDefinition(player.charClassDefID);
 						int pickpocketGoldAmount;
 						int pickpocketResultTemplateDatIndex;
 						bool guardsAppear;
@@ -776,7 +777,8 @@ namespace PlayerLogic
 							const bool canAttemptLockpicking = lockState.isLocked;
 							if (canAttemptLockpicking)
 							{
-								const bool isLockpickingSuccessful = random.nextBool(); // @todo use original chances
+								const int lockLevel = 5; // @todo get original chest lock level
+								const bool isLockpickingSuccessful = ArenaPlayerUtils::attemptThieving(lockLevel, charClassDef.thievingDivisor, player.level, player.primaryAttributes, arenaRandom);
 								if (isLockpickingSuccessful)
 								{
 									lockState.isLocked = false;

--- a/OpenTESArena/src/Player/PlayerLogic.cpp
+++ b/OpenTESArena/src/Player/PlayerLogic.cpp
@@ -425,7 +425,7 @@ namespace PlayerLogic
 
 							if (isLocked)
 							{
-								const bool isLockpickingSuccessful = ArenaPlayerUtils::attemptThieving(lockLevel, charClassDef.thievingDivisor, player.level, player.primaryAttributes, arenaRandom, nullptr);
+								const bool isLockpickingSuccessful = ArenaPlayerUtils::attemptThieving(lockLevel, charClassDef.thievingDivisor, player.level, player.primaryAttributes, arenaRandom);
 								if (!isLockpickingSuccessful)
 								{
 									GameWorldUI::setActionText(exeData.thieving.thievingFailure.c_str());

--- a/OpenTESArena/src/World/ArenaLevelUtils.cpp
+++ b/OpenTESArena/src/World/ArenaLevelUtils.cpp
@@ -222,10 +222,13 @@ std::string ArenaLevelUtils::getDoorVoxelMifName(WEInt x, SNInt y, int menuID, u
 
 int ArenaLevelUtils::getDoorVoxelLockLevel(WEInt x, SNInt y, ArenaRandom &random)
 {
+	const uint32_t savedSeed = random.getSeed();
 	const uint16_t offset = ArenaLevelUtils::getDoorVoxelOffset(x, y);
-	const uint32_t seed = offset + (offset << 16);
-	random.srand(seed);
-	return random.next(10) + 1; // 0..9 + 1.
+	const uint32_t lockLevelSeed = offset + (offset << 16);
+	random.srand(lockLevelSeed);
+	int lockLevel = random.next(10) + 1; // 0..9 + 1.
+	random.srand(savedSeed);
+	return lockLevel;
 }
 
 int ArenaLevelUtils::getServiceSaveFileNumber(WEInt doorX, SNInt doorY)

--- a/data/exe/aExeStrings.txt
+++ b/data/exe/aExeStrings.txt
@@ -361,6 +361,10 @@ ThievingSuccess=0x4325B
 ThievingSuccessChest=0x432A1
 ThievingFailure=0x43250
 ThievingFailureChest=0x4328D
+ThievingEntranceNoGuardsChance=0x4082
+ThievingPickpocketJunkThreshold=0x1E455
+ThievingPickpocketMaxGold=0x1E464
+ThievingMagicallyHeldLockDifficultyThreshold=0x21F47
 
 [Travel]
 LocationFormatTexts=0x374AD

--- a/data/exe/acdExeStrings.txt
+++ b/data/exe/acdExeStrings.txt
@@ -361,6 +361,10 @@ ThievingSuccess=0x43605
 ThievingSuccessChest=0x4364B
 ThievingFailure=0x435FA
 ThievingFailureChest=0x43637
+ThievingEntranceNoGuardsChance=0x40B0
+ThievingPickpocketJunkThreshold=0x200CF
+ThievingPickpocketMaxGold=0x200DE
+ThievingMagicallyHeldLockDifficultyThreshold=0x237AB
 
 [Travel]
 LocationFormatTexts=0x376AD


### PR DESCRIPTION
Matches pickpocketing and lockpicking chances (only doors) to the original game.

Guards that appear for theft use "STPTHIEF.VOC" in the original game, but that isn't implemented here.

Previously I split out `getThievingChance` from `attemptThieving` even though they are a single function in the original game because `getLockDifficultyMessageIndex`, the only thing that was using it, only needs the thieving chance to show the difficulty message. The original game runs `attemptThieving` every time you examine a door and just takes the thieving chance value, ignoring the success/failure result. That does mean the RNG runs every time you examine a door, though. It might not matter, but with this PR the original game behavior is replicated in that `attemptThieving` will run each time a lock is examined.

In the original game failing to pick a lock will add that voxel's coordinates to a list, and further attempts on that lock will fail. That isn't implemented here.

There's currently an issue that `ArenaRandom` seems to be getting its seed reset every time an attempt is made to pick the lock of an entrance, so the result is always the same.