### PR TITLE
Fix for issue #331:  Fix wilderness dens being treated as shopkeepers

### DIFF
--- a/OpenTESArena/src/Entities/ArenaAnimUtils.cpp
+++ b/OpenTESArena/src/Entities/ArenaAnimUtils.cpp
@@ -645,8 +645,13 @@ bool ArenaAnimUtils::isHumanEnemyIndex(ArenaItemIndex itemIndex)
 	return itemIndex >= 55 && itemIndex <= 72;
 }
 
-bool ArenaAnimUtils::isNpcShopkeeper(ArenaItemIndex itemIndex)
+bool ArenaAnimUtils::isNpcShopkeeper(ArenaItemIndex itemIndex, MapType mapType)
 {
+	if (mapType == MapType::Wilderness)
+	{
+		return false; // Avoid wilderness den.
+	}
+
 	return itemIndex == 15;
 }
 
@@ -712,9 +717,14 @@ bool ArenaAnimUtils::isNpcTavernPatron(ArenaItemIndex itemIndex)
 	return isTavernPatronMan || isTavernPatronWoman;
 }
 
-std::optional<StaticNpcPersonalityType> ArenaAnimUtils::tryGetStaticNpcPersonalityType(ArenaItemIndex itemIndex)
+bool ArenaAnimUtils::isWildernessDen(ArenaItemIndex itemIndex, MapType mapType)
 {
-	if (ArenaAnimUtils::isNpcShopkeeper(itemIndex))
+	return (itemIndex == 15) && (mapType == MapType::Wilderness);
+}
+
+std::optional<StaticNpcPersonalityType> ArenaAnimUtils::tryGetStaticNpcPersonalityType(ArenaItemIndex itemIndex, MapType mapType)
+{
+	if (ArenaAnimUtils::isNpcShopkeeper(itemIndex, mapType))
 	{
 		return StaticNpcPersonalityType::Shopkeeper;
 	}

--- a/OpenTESArena/src/Entities/ArenaAnimUtils.h
+++ b/OpenTESArena/src/Entities/ArenaAnimUtils.h
@@ -89,8 +89,8 @@ namespace ArenaAnimUtils
 	// *ITEM 55 to 72 are human enemies (guard, wizard, etc.).
 	bool isHumanEnemyIndex(ArenaItemIndex itemIndex);
 
-	// Blacksmith/bartender/wizard/priest in their respective interior.
-	bool isNpcShopkeeper(ArenaItemIndex itemIndex);
+	// Blacksmith/bartender/wizard/priest in their respective interior. Shares item index with wilderness den.
+	bool isNpcShopkeeper(ArenaItemIndex itemIndex, MapType mapType);
 
 	bool isNpcBeggar(ArenaItemIndex itemIndex);
 	bool isNpcFirebreather(ArenaItemIndex itemIndex);
@@ -105,7 +105,9 @@ namespace ArenaAnimUtils
 	bool isNpcWizard(ArenaItemIndex itemIndex);
 	bool isNpcTavernPatron(ArenaItemIndex itemIndex);
 
-	std::optional<StaticNpcPersonalityType> tryGetStaticNpcPersonalityType(ArenaItemIndex itemIndex);
+	bool isWildernessDen(ArenaItemIndex itemIndex, MapType mapType);
+
+	std::optional<StaticNpcPersonalityType> tryGetStaticNpcPersonalityType(ArenaItemIndex itemIndex, MapType mapType);
 
 	constexpr ArenaItemIndex LockedChestItemIndex = 7;
 	constexpr ArenaItemIndex UnlockedChestItemIndex = 8;

--- a/OpenTESArena/src/Player/PlayerLogic.cpp
+++ b/OpenTESArena/src/Player/PlayerLogic.cpp
@@ -689,6 +689,38 @@ namespace PlayerLogic
 				
 				break;
 			}
+			case EntityDefinitionType::Transition:
+			{
+				// Wilderness dens are sprites, but entering one follows the same map transition path as a wall entrance. 
+				// Synthesize its approached voxel face for the return point.
+				if (passesNpcDistanceTest && canPlayerMoveAndTurn)
+				{
+					if (interactionType == GameWorldInteractionType::Default)
+					{
+						const TransitionEntityDefinition &transitionEntityDef = entityDef.transition;
+						const MapDefinition &mapDef = gameState.getActiveMapDef();
+						const LevelInfoDefinition &levelInfoDef = mapDef.getLevelInfoForLevel(gameState.getActiveLevelIndex());
+						const TransitionDefinition &transitionDef = levelInfoDef.getTransitionDef(transitionEntityDef.transitionDefID);
+
+						const WorldDouble3 playerPosition = player.getFeetPosition();
+						const double deltaX = playerPosition.x - entityPosition.x;
+						const double deltaZ = playerPosition.z - entityPosition.z;
+						const VoxelFacing3D facing = (std::abs(deltaX) >= std::abs(deltaZ)) ?
+							((deltaX >= 0.0) ? VoxelFacing3D::PositiveX : VoxelFacing3D::NegativeX) :
+							((deltaZ >= 0.0) ? VoxelFacing3D::PositiveZ : VoxelFacing3D::NegativeZ);
+
+						RayCastHit transitionHit;
+						transitionHit.initVoxel(hit.t, hit.worldPoint, CoordInt3(entityChunkPos, entityVoxel), facing);
+						MapLogic::handleMapTransition(game, transitionHit, transitionDef);
+					}
+					else
+					{
+						GameWorldUI::setInteractionType(GameWorldInteractionType::Default);
+					}
+				}
+
+				break;
+			}
 			case EntityDefinitionType::Item:
 			{
 				if (passesLootDistanceTest && canPlayerMoveAndTurn)

--- a/OpenTESArena/src/Player/PlayerLogic.cpp
+++ b/OpenTESArena/src/Player/PlayerLogic.cpp
@@ -689,38 +689,6 @@ namespace PlayerLogic
 				
 				break;
 			}
-			case EntityDefinitionType::Transition:
-			{
-				// Wilderness dens are sprites, but entering one follows the same map transition path as a wall entrance. 
-				// Synthesize its approached voxel face for the return point.
-				if (passesNpcDistanceTest && canPlayerMoveAndTurn)
-				{
-					if (interactionType == GameWorldInteractionType::Default)
-					{
-						const TransitionEntityDefinition &transitionEntityDef = entityDef.transition;
-						const MapDefinition &mapDef = gameState.getActiveMapDef();
-						const LevelInfoDefinition &levelInfoDef = mapDef.getLevelInfoForLevel(gameState.getActiveLevelIndex());
-						const TransitionDefinition &transitionDef = levelInfoDef.getTransitionDef(transitionEntityDef.transitionDefID);
-
-						const WorldDouble3 playerPosition = player.getFeetPosition();
-						const double deltaX = playerPosition.x - entityPosition.x;
-						const double deltaZ = playerPosition.z - entityPosition.z;
-						const VoxelFacing3D facing = (std::abs(deltaX) >= std::abs(deltaZ)) ?
-							((deltaX >= 0.0) ? VoxelFacing3D::PositiveX : VoxelFacing3D::NegativeX) :
-							((deltaZ >= 0.0) ? VoxelFacing3D::PositiveZ : VoxelFacing3D::NegativeZ);
-
-						RayCastHit transitionHit;
-						transitionHit.initVoxel(hit.t, hit.worldPoint, CoordInt3(entityChunkPos, entityVoxel), facing);
-						MapLogic::handleMapTransition(game, transitionHit, transitionDef);
-					}
-					else
-					{
-						GameWorldUI::setInteractionType(GameWorldInteractionType::Default);
-					}
-				}
-
-				break;
-			}
 			case EntityDefinitionType::Item:
 			{
 				if (passesLootDistanceTest && canPlayerMoveAndTurn)
@@ -826,6 +794,41 @@ namespace PlayerLogic
 								}
 							}
 						}
+					}
+				}
+
+				break;
+			}
+			case EntityDefinitionType::Transition:
+			{
+				// Wilderness dens are sprites, but entering one follows the same map transition path as a wall entrance. 
+				// Synthesize its approached voxel face for the return point.
+				if (passesNpcDistanceTest && canPlayerMoveAndTurn)
+				{
+					if (interactionType == GameWorldInteractionType::Default)
+					{
+						const TransitionEntityDefinition &transitionEntityDef = entityDef.transition;
+						const MapDefinition &mapDef = gameState.getActiveMapDef();
+						const LevelInfoDefinition &levelInfoDef = mapDef.getLevelInfoForLevel(gameState.getActiveLevelIndex());
+						const TransitionDefinition &transitionDef = levelInfoDef.getTransitionDef(transitionEntityDef.transitionDefID);
+
+						const WorldDouble3 playerPosition = player.getFeetPosition();
+						const Double2 entityToPlayerPositionXZ = (playerPosition - entityPosition).getXZ();
+						const double deltaX = entityToPlayerPositionXZ.x;
+						const double deltaZ = entityToPlayerPositionXZ.y;
+						const VoxelFacing3D facing = (std::abs(deltaX) >= std::abs(deltaZ)) ?
+							((deltaX >= 0.0) ? VoxelFacing3D::PositiveX : VoxelFacing3D::NegativeX) :
+							((deltaZ >= 0.0) ? VoxelFacing3D::PositiveZ : VoxelFacing3D::NegativeZ);
+						const CoordInt3 entityVoxelCoord(entityChunkPos, entityVoxel);
+
+						RayCastHit transitionHit;
+						transitionHit.initVoxel(hit.t, hit.worldPoint, entityVoxelCoord, facing);
+
+						MapLogic::handleMapTransition(game, transitionHit, transitionDef);
+					}
+					else
+					{
+						GameWorldUI::setInteractionType(GameWorldInteractionType::Default);
 					}
 				}
 

--- a/OpenTESArena/src/World/MapGeneration.cpp
+++ b/OpenTESArena/src/World/MapGeneration.cpp
@@ -204,11 +204,10 @@ namespace MapGeneration
 	// @todo: probably want this to be some 'LevelEntityDefinition' with no dependencies on runtime
 	// textures and animations handles, instead using texture filenames for the bulk of things.
 	bool tryMakeEntityDefFromArenaFlat(ArenaFlatIndex flatIndex, MapType mapType,
-		const std::optional<ArenaInteriorType> &interiorType, const std::optional<bool> &rulerIsMale,
-		const INFFile &inf, const CharacterClassLibrary &charClassLibrary,
+		const std::optional<ArenaInteriorType> &interiorType, const std::optional<LevelVoxelTransitionDefID> &transitionDefID,
+		const std::optional<bool> &rulerIsMale, const INFFile &inf, const CharacterClassLibrary &charClassLibrary,
 		const EntityDefinitionLibrary &entityDefLibrary, const BinaryAssetLibrary &binaryAssetLibrary,
-		TextureManager &textureManager, const std::optional<LevelVoxelTransitionDefID> &transitionDefID,
-		EntityDefinition *outDef)
+		TextureManager &textureManager, EntityDefinition *outDef)
 	{
 		const INFFlat &flatData = inf.getFlat(flatIndex);
 		const bool isDynamicEntity = ArenaAnimUtils::isDynamicEntity(flatIndex, inf);
@@ -1349,12 +1348,10 @@ namespace MapGeneration
 					{
 						const ArenaFlatIndex flatIndex = floorFlatID - 1;
 						EntityDefinition entityDef;
-						if (!MapGeneration::tryMakeEntityDefFromArenaFlat(flatIndex, mapType,
-							interiorType, rulerIsMale, inf, charClassLibrary, entityDefLibrary,
-							binaryAssetLibrary, textureManager, std::nullopt, &entityDef))
+						if (!MapGeneration::tryMakeEntityDefFromArenaFlat(flatIndex, mapType, interiorType, std::nullopt, rulerIsMale, inf,
+							charClassLibrary, entityDefLibrary, binaryAssetLibrary, textureManager, &entityDef))
 						{
-							DebugLogWarning("Couldn't make entity definition from FLAT \"" +
-								std::to_string(flatIndex) + "\" with .INF \"" + inf.getName() + "\".");
+							DebugLogWarningFormat("Couldn't make entity definition from FLAT %d with .INF \"%s\".", flatIndex, inf.getName());
 							continue;
 						}
 
@@ -1422,15 +1419,13 @@ namespace MapGeneration
 	}
 
 	// Converts .MIF/.RMD MAP1 voxels to modern voxel + entity format.
-	void readArenaMAP1(Span2D<const ArenaVoxelID> map1, MapType mapType,
-		const std::optional<ArenaInteriorType> &interiorType, const std::optional<uint32_t> &rulerSeed,
-		const std::optional<bool> &rulerIsMale, const std::optional<bool> &palaceIsMainQuestDungeon,
-		const std::optional<ArenaCityType> &cityType,
-		const LocationDungeonDefinition *dungeonDef, const std::optional<bool> &isArtifactDungeon,
-		const INFFile &inf, const CharacterClassLibrary &charClassLibrary,
-		const EntityDefinitionLibrary &entityDefLibrary, const BinaryAssetLibrary &binaryAssetLibrary,
-		TextureManager &textureManager, LevelDefinition *outLevelDef, LevelInfoDefinition *outLevelInfoDef,
-		ArenaVoxelMappingCache *voxelCache, ArenaEntityMappingCache *entityCache,
+	void readArenaMAP1(Span2D<const ArenaVoxelID> map1, MapType mapType, const std::optional<ArenaInteriorType> &interiorType,
+		const std::optional<uint32_t> &rulerSeed, const std::optional<bool> &rulerIsMale,
+		const std::optional<bool> &palaceIsMainQuestDungeon, const std::optional<ArenaCityType> &cityType,
+		const LocationDungeonDefinition *dungeonDef, const std::optional<bool> &isArtifactDungeon, const INFFile &inf,
+		const CharacterClassLibrary &charClassLibrary, const EntityDefinitionLibrary &entityDefLibrary,
+		const BinaryAssetLibrary &binaryAssetLibrary, TextureManager &textureManager, LevelDefinition *outLevelDef,
+		LevelInfoDefinition *outLevelInfoDef, ArenaVoxelMappingCache *voxelCache, ArenaEntityMappingCache *entityCache,
 		ArenaTransitionMappingCache *transitionCache, ArenaDoorMappingCache *doorCache)
 	{
 		for (SNInt map1Z = 0; map1Z < map1.getHeight(); map1Z++)
@@ -1448,6 +1443,9 @@ namespace MapGeneration
 				const SNInt levelX = map1Z;
 				constexpr int levelY = 1;
 				const WEInt levelZ = map1X;
+
+				const WorldInt3 levelWorldVoxel(levelX, levelY, levelZ);
+				const WorldInt2 levelWorldVoxelXZ = levelWorldVoxel.getXZ();
 
 				// Determine if this MAP1 voxel is for a voxel or entity.
 				const uint8_t mostSigNibble = (map1Voxel & 0xF000) >> 12;
@@ -1493,9 +1491,6 @@ namespace MapGeneration
 					outLevelDef->setVoxelShadingID(levelX, levelY, levelZ, voxelShadingDefID);
 					outLevelDef->setVoxelTraitsID(levelX, levelY, levelZ, voxelTraitsDefID);
 
-					const WorldInt3 levelPosition(levelX, levelY, levelZ);
-					const WorldInt2 levelPositionXZ(levelX, levelZ);
-
 					// Try to make transition info if this MAP1 voxel is a transition.
 					const std::optional<MapGenerationTransitionInfo> transitionDefGenInfo =
 						MapGeneration::tryMakeVoxelTransitionDefGenInfo(map1Voxel, mostSigNibble, mapType, inf);
@@ -1506,10 +1501,10 @@ namespace MapGeneration
 						// for interior .MIF name generation so can't really reuse them.
 						LevelVoxelTransitionDefID transitionDefID;
 						const auto iter = std::find_if(transitionCache->begin(), transitionCache->end(),
-							[map1Voxel, levelPositionXZ](const std::pair<TransitionMappingKey, LevelVoxelTransitionDefID> &pair)
+							[map1Voxel, levelWorldVoxelXZ](const std::pair<TransitionMappingKey, LevelVoxelTransitionDefID> &pair)
 						{
 							const TransitionMappingKey &key = pair.first;
-							return (key.voxelID == map1Voxel) && (key.levelXZ == levelPositionXZ);
+							return (key.voxelID == map1Voxel) && (key.levelXZ == levelWorldVoxelXZ);
 						});
 
 						if (iter != transitionCache->end())
@@ -1519,23 +1514,22 @@ namespace MapGeneration
 						else
 						{
 							TransitionDefinition transitionDef = MapGeneration::makeTransitionDef(
-								*transitionDefGenInfo, levelPosition, transitionDefGenInfo->menuID, rulerSeed,
+								*transitionDefGenInfo, levelWorldVoxel, transitionDefGenInfo->menuID, rulerSeed,
 								rulerIsMale, palaceIsMainQuestDungeon, cityType, dungeonDef, isArtifactDungeon,
 								mapType, binaryAssetLibrary.getExeData());
 							transitionDefID = outLevelInfoDef->addTransitionDef(std::move(transitionDef));
 
 							TransitionMappingKey transitionMappingKey;
 							transitionMappingKey.voxelID = map1Voxel;
-							transitionMappingKey.levelXZ = levelPositionXZ;
+							transitionMappingKey.levelXZ = levelWorldVoxelXZ;
 							transitionCache->emplace_back(transitionMappingKey, transitionDefID);
 						}
 
-						outLevelDef->addTransition(transitionDefID, levelPosition);
+						outLevelDef->addTransition(transitionDefID, levelWorldVoxel);
 					}
 
 					// Try to make door info if this MAP1 voxel is a door.
-					const std::optional<MapGenerationDoorInfo> doorDefGenInfo =
-						MapGeneration::tryMakeDoorDefGenInfo(map1Voxel, mostSigNibble);
+					const std::optional<MapGenerationDoorInfo> doorDefGenInfo = MapGeneration::tryMakeDoorDefGenInfo(map1Voxel, mostSigNibble);
 
 					if (doorDefGenInfo.has_value())
 					{
@@ -1553,7 +1547,7 @@ namespace MapGeneration
 							doorCache->emplace(map1Voxel, doorDefID);
 						}
 
-						outLevelDef->addDoor(doorDefID, levelPosition);
+						outLevelDef->addDoor(doorDefID, levelWorldVoxel);
 					}
 				}
 				else
@@ -1568,21 +1562,16 @@ namespace MapGeneration
 					else
 					{
 						const ArenaFlatIndex flatIndex = map1Voxel & 0x00FF;
-						const WorldInt3 levelPosition(levelX, levelY, levelZ);
-						const WorldInt2 levelPositionXZ(levelX, levelZ);
 						std::optional<LevelVoxelTransitionDefID> entityTransitionDefID;
-						const std::optional<MapGenerationTransitionInfo> transitionDefGenInfo =
-							MapGeneration::tryMakeEntityTransitionGenInfo(flatIndex, mapType);
+						const std::optional<MapGenerationTransitionInfo> transitionDefGenInfo = MapGeneration::tryMakeEntityTransitionGenInfo(flatIndex, mapType);
 						if (transitionDefGenInfo.has_value())
 						{
-							// Wild dens have *ITEM 15 in their .INF entry, which normally makes a static shopkeeper. 
-							// Their flat index is the authoritative wilderness transition marker so we cerate the dungeon transition first.
 							const auto iter = std::find_if(transitionCache->begin(), transitionCache->end(),
-								[map1Voxel, levelPositionXZ](const std::pair<TransitionMappingKey, LevelVoxelTransitionDefID> &pair)
+								[map1Voxel, levelWorldVoxelXZ](const std::pair<TransitionMappingKey, LevelVoxelTransitionDefID> &pair)
 							{
-									const TransitionMappingKey &key = pair.first;
-									return (key.voxelID == map1Voxel) && (key.levelXZ == levelPositionXZ);
-								});
+								const TransitionMappingKey &key = pair.first;
+								return (key.voxelID == map1Voxel) && (key.levelXZ == levelWorldVoxelXZ);
+							});
 
 							if (iter != transitionCache->end())
 							{
@@ -1591,25 +1580,22 @@ namespace MapGeneration
 							else
 							{
 								TransitionDefinition transitionDef = MapGeneration::makeTransitionDef(
-									*transitionDefGenInfo, levelPosition, transitionDefGenInfo->menuID, rulerSeed,
-									rulerIsMale, palaceIsMainQuestDungeon, cityType, dungeonDef, isArtifactDungeon,
-									mapType, binaryAssetLibrary.getExeData());
+									*transitionDefGenInfo, levelWorldVoxel, transitionDefGenInfo->menuID, rulerSeed, rulerIsMale, palaceIsMainQuestDungeon,
+									cityType, dungeonDef, isArtifactDungeon, mapType, binaryAssetLibrary.getExeData());
 								entityTransitionDefID = outLevelInfoDef->addTransitionDef(std::move(transitionDef));
 
 								TransitionMappingKey transitionMappingKey;
 								transitionMappingKey.voxelID = map1Voxel;
-								transitionMappingKey.levelXZ = levelPositionXZ;
+								transitionMappingKey.levelXZ = levelWorldVoxelXZ;
 								transitionCache->emplace_back(transitionMappingKey, *entityTransitionDefID);
 							}
 						}
 
 						EntityDefinition entityDef;
-						if (!MapGeneration::tryMakeEntityDefFromArenaFlat(flatIndex, mapType,
-							interiorType, rulerIsMale, inf, charClassLibrary, entityDefLibrary,
-							binaryAssetLibrary, textureManager, entityTransitionDefID, &entityDef))
+						if (!MapGeneration::tryMakeEntityDefFromArenaFlat(flatIndex, mapType, interiorType, entityTransitionDefID, rulerIsMale, inf,
+							charClassLibrary, entityDefLibrary, binaryAssetLibrary, textureManager, &entityDef))
 						{
-							DebugLogWarning("Couldn't make entity definition from FLAT \"" +
-								std::to_string(flatIndex) + "\" with .INF \"" + inf.getName() + "\".");
+							DebugLogWarningFormat("Couldn't make entity definition from FLAT %d with .INF \"%s\".", flatIndex, inf.getName());
 							continue;
 						}
 

--- a/OpenTESArena/src/World/MapGeneration.cpp
+++ b/OpenTESArena/src/World/MapGeneration.cpp
@@ -223,16 +223,18 @@ namespace MapGeneration
 		bool isUnlockedHolderContainer = false;
 		bool isKey = false;
 		bool isQuestItem = false;
+		bool isTransition = false;
 		if (optItemIndex.has_value())
 		{
 			isCreature = ArenaAnimUtils::isCreatureIndex(*optItemIndex, &isCreatureFinalBoss);
 			isHumanEnemy = ArenaAnimUtils::isHumanEnemyIndex(*optItemIndex);
-			staticNpcPersonalityType = ArenaAnimUtils::tryGetStaticNpcPersonalityType(*optItemIndex);
+			staticNpcPersonalityType = ArenaAnimUtils::tryGetStaticNpcPersonalityType(*optItemIndex, mapType);
 			isPileContainer = ArenaAnimUtils::isTreasurePileContainerIndex(*optItemIndex);
 			isLockedHolderContainer = ArenaAnimUtils::isLockedHolderContainerIndex(*optItemIndex);
 			isUnlockedHolderContainer = ArenaAnimUtils::isUnlockedHolderContainerIndex(*optItemIndex);
 			isKey = *optItemIndex == ArenaAnimUtils::KeyItemIndex;
 			isQuestItem = *optItemIndex == ArenaAnimUtils::QuestItemIndex;
+			isTransition = ArenaAnimUtils::isWildernessDen(*optItemIndex, mapType);
 		}
 
 		// Add entity animation data. Static entities have only idle animations (and maybe on/off
@@ -259,11 +261,7 @@ namespace MapGeneration
 
 		DebugAssert(!String::isNullOrEmpty(entityAnimDef.initialStateName));
 
-		if (transitionDefID.has_value())
-		{
-			outDef->initTransition(*transitionDefID, std::move(entityAnimDef));
-		}
-		else if (isCreature)
+		if (isCreature)
 		{
 			const ArenaItemIndex itemIndex = *optItemIndex;
 			const int creatureID = isCreatureFinalBoss ? ArenaEntityUtils::FinalBossCreatureID : ArenaAnimUtils::getCreatureIDFromItemIndex(itemIndex);
@@ -309,6 +307,11 @@ namespace MapGeneration
 		else if (isQuestItem)
 		{
 			outDef->initItemQuestItem(flatData.yOffset, std::move(entityAnimDef));
+		}
+		else if (isTransition)
+		{
+			DebugAssert(transitionDefID.has_value());
+			outDef->initTransition(*transitionDefID, std::move(entityAnimDef));
 		}
 		else
 		{

--- a/OpenTESArena/src/World/MapGeneration.cpp
+++ b/OpenTESArena/src/World/MapGeneration.cpp
@@ -207,7 +207,8 @@ namespace MapGeneration
 		const std::optional<ArenaInteriorType> &interiorType, const std::optional<bool> &rulerIsMale,
 		const INFFile &inf, const CharacterClassLibrary &charClassLibrary,
 		const EntityDefinitionLibrary &entityDefLibrary, const BinaryAssetLibrary &binaryAssetLibrary,
-		TextureManager &textureManager, EntityDefinition *outDef)
+		TextureManager &textureManager, const std::optional<LevelVoxelTransitionDefID> &transitionDefID,
+		EntityDefinition *outDef)
 	{
 		const INFFlat &flatData = inf.getFlat(flatIndex);
 		const bool isDynamicEntity = ArenaAnimUtils::isDynamicEntity(flatIndex, inf);
@@ -258,7 +259,11 @@ namespace MapGeneration
 
 		DebugAssert(!String::isNullOrEmpty(entityAnimDef.initialStateName));
 
-		if (isCreature)
+		if (transitionDefID.has_value())
+		{
+			outDef->initTransition(*transitionDefID, std::move(entityAnimDef));
+		}
+		else if (isCreature)
 		{
 			const ArenaItemIndex itemIndex = *optItemIndex;
 			const int creatureID = isCreatureFinalBoss ? ArenaEntityUtils::FinalBossCreatureID : ArenaAnimUtils::getCreatureIDFromItemIndex(itemIndex);
@@ -1343,7 +1348,7 @@ namespace MapGeneration
 						EntityDefinition entityDef;
 						if (!MapGeneration::tryMakeEntityDefFromArenaFlat(flatIndex, mapType,
 							interiorType, rulerIsMale, inf, charClassLibrary, entityDefLibrary,
-							binaryAssetLibrary, textureManager, &entityDef))
+							binaryAssetLibrary, textureManager, std::nullopt, &entityDef))
 						{
 							DebugLogWarning("Couldn't make entity definition from FLAT \"" +
 								std::to_string(flatIndex) + "\" with .INF \"" + inf.getName() + "\".");
@@ -1560,10 +1565,45 @@ namespace MapGeneration
 					else
 					{
 						const ArenaFlatIndex flatIndex = map1Voxel & 0x00FF;
+						const WorldInt3 levelPosition(levelX, levelY, levelZ);
+						const WorldInt2 levelPositionXZ(levelX, levelZ);
+						std::optional<LevelVoxelTransitionDefID> entityTransitionDefID;
+						const std::optional<MapGenerationTransitionInfo> transitionDefGenInfo =
+							MapGeneration::tryMakeEntityTransitionGenInfo(flatIndex, mapType);
+						if (transitionDefGenInfo.has_value())
+						{
+							// Wild dens have *ITEM 15 in their .INF entry, which normally makes a static shopkeeper. 
+							// Their flat index is the authoritative wilderness transition marker so we cerate the dungeon transition first.
+							const auto iter = std::find_if(transitionCache->begin(), transitionCache->end(),
+								[map1Voxel, levelPositionXZ](const std::pair<TransitionMappingKey, LevelVoxelTransitionDefID> &pair)
+							{
+									const TransitionMappingKey &key = pair.first;
+									return (key.voxelID == map1Voxel) && (key.levelXZ == levelPositionXZ);
+								});
+
+							if (iter != transitionCache->end())
+							{
+								entityTransitionDefID = iter->second;
+							}
+							else
+							{
+								TransitionDefinition transitionDef = MapGeneration::makeTransitionDef(
+									*transitionDefGenInfo, levelPosition, transitionDefGenInfo->menuID, rulerSeed,
+									rulerIsMale, palaceIsMainQuestDungeon, cityType, dungeonDef, isArtifactDungeon,
+									mapType, binaryAssetLibrary.getExeData());
+								entityTransitionDefID = outLevelInfoDef->addTransitionDef(std::move(transitionDef));
+
+								TransitionMappingKey transitionMappingKey;
+								transitionMappingKey.voxelID = map1Voxel;
+								transitionMappingKey.levelXZ = levelPositionXZ;
+								transitionCache->emplace_back(transitionMappingKey, *entityTransitionDefID);
+							}
+						}
+
 						EntityDefinition entityDef;
 						if (!MapGeneration::tryMakeEntityDefFromArenaFlat(flatIndex, mapType,
 							interiorType, rulerIsMale, inf, charClassLibrary, entityDefLibrary,
-							binaryAssetLibrary, textureManager, &entityDef))
+							binaryAssetLibrary, textureManager, entityTransitionDefID, &entityDef))
 						{
 							DebugLogWarning("Couldn't make entity definition from FLAT \"" +
 								std::to_string(flatIndex) + "\" with .INF \"" + inf.getName() + "\".");


### PR DESCRIPTION
Wilderness den entrances use flat 37, whose INF entry, like the shopkeepers, has *ITEM 15, which caused its sprite to be classified as a shopkeeper and open its UI, triggering an assertion on Linux. 

Fix changes wilderness den sprites into transition entities which use the regular interior-transition path on clicking and enter the procgen dungeon.
