### PR TITLE
Match difficulty of chest lockpicking and stealing from services to original game

### DIFF
--- a/OpenTESArena/src/Assets/ExeData.cpp
+++ b/OpenTESArena/src/Assets/ExeData.cpp
@@ -1045,6 +1045,10 @@ bool ExeDataServices::init(Span<const std::byte> exeBytes, const KeyValueFile &k
 	}
 
 	const int tavernRoomHealModifiersOffset = GetExeAddress(*section, "TavernRoomHealModifiers");
+	const int serviceQualityChancesOffset = GetExeAddress(*section, "ServiceQualityChances");
+	const int cityStateServiceQualitiesOffset = GetExeAddress(*section, "CityStateServiceQualities");
+	const int townServiceQualitiesOffset = GetExeAddress(*section, "TownServiceQualities");
+	const int villageServiceQualitiesOffset = GetExeAddress(*section, "VillageServiceQualities");
 	const int palaceClosedAtNightOffset = GetExeAddress(*section, "PalaceClosedAtNight");
 	const int equipmentModalTitleOffset = GetExeAddress(*section, "EquipmentModalTitle");
 	const int equipmentModalBuyOffset = GetExeAddress(*section, "EquipmentModalBuy");
@@ -1116,6 +1120,10 @@ bool ExeDataServices::init(Span<const std::byte> exeBytes, const KeyValueFile &k
 	const int playerGoldRemainingOffset = GetExeAddress(*section, "PlayerGoldRemaining");
 
 	initInt8Array(this->tavernRoomHealModifiers, exeBytes, tavernRoomHealModifiersOffset);
+	initInt8Array(this->serviceQualityChances, exeBytes, serviceQualityChancesOffset);
+	initInt8PairArray(this->cityStateServiceQualities, exeBytes, cityStateServiceQualitiesOffset);
+	initInt8PairArray(this->townServiceQualities, exeBytes, townServiceQualitiesOffset);
+	initInt8PairArray(this->villageServiceQualities, exeBytes, villageServiceQualitiesOffset);
 	this->palaceClosedAtNight = GetExeStringNullTerminated(exeBytes, palaceClosedAtNightOffset);
 	this->equipmentModalTitle = GetExeStringNullTerminated(exeBytes, equipmentModalTitleOffset);
 	this->equipmentModalBuy = GetExeStringNullTerminated(exeBytes, equipmentModalBuyOffset);
@@ -1263,6 +1271,7 @@ bool ExeDataThieving::init(Span<const std::byte> exeBytes, const KeyValueFile &k
 	const int thievingPickpocketJunkThresholdOffset = GetExeAddress(*section, "ThievingPickpocketJunkThreshold");
 	const int thievingPickpocketMaxGoldOffset = GetExeAddress(*section, "ThievingPickpocketMaxGold");
 	const int thievingMagicallyHeldLockDifficultyThresholdOffset = GetExeAddress(*section, "ThievingMagicallyHeldLockDifficultyThreshold");
+	const int thievingChestMaxLockLevelOffset = GetExeAddress(*section, "ThievingChestMaxLockLevel");
 
 	this->thievingInteractionType = GetExeStringNullTerminated(exeBytes, thievingInteractionTypeOffset);
 	this->thievingSuccess = GetExeStringNullTerminated(exeBytes, thievingSuccessOffset);
@@ -1273,6 +1282,7 @@ bool ExeDataThieving::init(Span<const std::byte> exeBytes, const KeyValueFile &k
 	this->thievingPickpocketJunkThreshold = Bytes::getLE16(reinterpret_cast<const uint8_t*>(exeBytes.begin() + thievingPickpocketJunkThresholdOffset));
 	this->thievingPickpocketMaxGold = static_cast<uint8_t>(exeBytes[thievingPickpocketMaxGoldOffset]);
 	this->thievingMagicallyHeldLockDifficultyThreshold = static_cast<uint8_t>(exeBytes[thievingMagicallyHeldLockDifficultyThresholdOffset]);
+	this->thievingChestMaxLockLevel = static_cast<uint8_t>(exeBytes[thievingChestMaxLockLevelOffset]);
 
 	return true;
 }

--- a/OpenTESArena/src/Assets/ExeData.h
+++ b/OpenTESArena/src/Assets/ExeData.h
@@ -556,8 +556,16 @@ struct ExeDataRaisedPlatforms
 
 struct ExeDataServices
 {
-	// Modifiers for the amount healed when resting
+	// Modifiers for the amount healed when resting.
 	int8_t tavernRoomHealModifiers[7];
+
+	// Chances for the quality range of a service.
+	uint8_t serviceQualityChances[4];
+
+	// Min/max format.
+	std::pair<uint8_t, uint8_t> cityStateServiceQualities[4]; 
+	std::pair<uint8_t, uint8_t> townServiceQualities[4];
+	std::pair<uint8_t, uint8_t> villageServiceQualities[4];
 
 	std::string palaceClosedAtNight;
 
@@ -693,6 +701,9 @@ struct ExeDataThieving
 
 	// Locks with difficulty levels of this value or higher show the "magically-held lock" message when examined.
 	uint8_t thievingMagicallyHeldLockDifficultyThreshold;
+
+	// Maximum lock difficulty a chest can have.
+	uint8_t thievingChestMaxLockLevel;
 
 	bool init(Span<const std::byte> exeBytes, const KeyValueFile &keyValueFile);
 };

--- a/OpenTESArena/src/Interface/ChooseAttributesUiState.cpp
+++ b/OpenTESArena/src/Interface/ChooseAttributesUiState.cpp
@@ -827,9 +827,10 @@ void ChooseAttributesUI::onDoneButtonSelected(MouseButtonType mouseButtonType)
 
 			constexpr std::optional<bool> rulerIsMale; // Not needed.
 			const std::string interiorDisplayName; // Unused.
+			constexpr std::optional<uint16_t> doorVoxelOffset; // Not needed.
 
 			MapGenerationInteriorInfo interiorGenInfo;
-			interiorGenInfo.initPrefab(mifName, ArenaInteriorType::Dungeon, rulerIsMale, interiorDisplayName, std::nullopt);
+			interiorGenInfo.initPrefab(mifName, ArenaInteriorType::Dungeon, rulerIsMale, interiorDisplayName, doorVoxelOffset);
 
 			const GameState::WorldMapLocationIDs worldMapLocationIDs(provinceIndex, *locationIndex);
 

--- a/OpenTESArena/src/Interface/ChooseAttributesUiState.cpp
+++ b/OpenTESArena/src/Interface/ChooseAttributesUiState.cpp
@@ -829,7 +829,7 @@ void ChooseAttributesUI::onDoneButtonSelected(MouseButtonType mouseButtonType)
 			const std::string interiorDisplayName; // Unused.
 
 			MapGenerationInteriorInfo interiorGenInfo;
-			interiorGenInfo.initPrefab(mifName, ArenaInteriorType::Dungeon, rulerIsMale, interiorDisplayName);
+			interiorGenInfo.initPrefab(mifName, ArenaInteriorType::Dungeon, rulerIsMale, interiorDisplayName, std::nullopt);
 
 			const GameState::WorldMapLocationIDs worldMapLocationIDs(provinceIndex, *locationIndex);
 

--- a/OpenTESArena/src/Interface/GameWorldUiState.cpp
+++ b/OpenTESArena/src/Interface/GameWorldUiState.cpp
@@ -2511,8 +2511,9 @@ void GameWorldUI::showShopkeeperBackground(const char *titleText)
 	uiManager.setContextEnabled(state.shopkeeperBgContextInstID, true);
 }
 
-int GameWorldUI::getCurrentServiceQuality(const ExeData &exeData , ArenaRandom &arenaRandom)
+int GameWorldUI::getCurrentServiceQuality(ArenaRandom &arenaRandom)
 {
+	GameWorldUiState &state = GameWorldUI::state;
 	Game &game = *state.game;
 	GameState &gameState = game.gameState;
 
@@ -2521,7 +2522,7 @@ int GameWorldUI::getCurrentServiceQuality(const ExeData &exeData , ArenaRandom &
 	const ArenaCityType cityType = cityDef.type;
 
 	const MapDefinitionInterior &mapDefinitionInterior = gameState.getActiveMapDef().getSubDefinition().interior;
-	const std::optional<uint16_t> &doorVoxelOffset = mapDefinitionInterior.getDoorVoxelOffset();
+	const std::optional<uint16_t> &doorVoxelOffset = mapDefinitionInterior.doorVoxelOffset;
 
 	uint16_t doorVoxelOffsetForServiceQuality = 0;
 	if (doorVoxelOffset.has_value())
@@ -2533,6 +2534,7 @@ int GameWorldUI::getCurrentServiceQuality(const ExeData &exeData , ArenaRandom &
 		DebugLog("No door voxel offset; using default of 0 to get service quality.");
 	}
 
+	const ExeData &exeData = BinaryAssetLibrary::getInstance().getExeData();
 	return ArenaInteriorUtils::getServiceQuality(doorVoxelOffsetForServiceQuality, cityType, exeData, arenaRandom);
 }
 
@@ -3617,8 +3619,7 @@ void GameWorldUI::onNpcEquipmentStealButtonSelected(MouseButtonType mouseButtonT
 	uiManager.disableTopMostContext();
 
 	ArenaRandom &arenaRandom = game.arenaRandom;
-	const ExeData &exeData = BinaryAssetLibrary::getInstance().getExeData();
-	const int serviceQuality = getCurrentServiceQuality(exeData, arenaRandom);
+	const int serviceQuality = GameWorldUI::getCurrentServiceQuality(arenaRandom);
 
 	const Player &player = game.player;
 	const CharacterClassDefinition &charClassDef = CharacterClassLibrary::getInstance().getDefinition(player.charClassDefID);
@@ -3760,8 +3761,7 @@ void GameWorldUI::onNpcMagesGuildStealPotionsButtonSelected(MouseButtonType mous
 	uiManager.disableTopMostContext();
 
 	ArenaRandom &arenaRandom = game.arenaRandom;
-	const ExeData &exeData = BinaryAssetLibrary::getInstance().getExeData();
-	const int serviceQuality = getCurrentServiceQuality(exeData, arenaRandom);
+	const int serviceQuality = GameWorldUI::getCurrentServiceQuality(arenaRandom);
 
 	const Player &player = game.player;
 	const CharacterClassDefinition &charClassDef = CharacterClassLibrary::getInstance().getDefinition(player.charClassDefID);
@@ -3789,8 +3789,7 @@ void GameWorldUI::onNpcMagesGuildStealMagicItemsButtonSelected(MouseButtonType m
 	uiManager.disableTopMostContext();
 
 	ArenaRandom &arenaRandom = game.arenaRandom;
-	const ExeData &exeData = BinaryAssetLibrary::getInstance().getExeData();
-	const int serviceQuality = getCurrentServiceQuality(exeData, arenaRandom);
+	const int serviceQuality = GameWorldUI::getCurrentServiceQuality(arenaRandom);
 
 	const Player &player = game.player;
 	const CharacterClassDefinition &charClassDef = CharacterClassLibrary::getInstance().getDefinition(player.charClassDefID);
@@ -3838,12 +3837,13 @@ void GameWorldUI::onNpcTavernSneakIntoARoomButtonSelected(MouseButtonType mouseB
 	GameState &gameState = game.gameState;
 	Random &random = game.random;
 	ArenaRandom &arenaRandom = game.arenaRandom;
-	const ExeData &exeData = BinaryAssetLibrary::getInstance().getExeData();
-	const int serviceQuality = getCurrentServiceQuality(exeData, arenaRandom);
+	const int serviceQuality = GameWorldUI::getCurrentServiceQuality(arenaRandom);
 
 	const Player &player = game.player;
 	const CharacterClassDefinition &charClassDef = CharacterClassLibrary::getInstance().getDefinition(player.charClassDefID);
 	const bool isSneakingSuccessful = ArenaPlayerUtils::attemptThieving(serviceQuality, charClassDef.thievingDivisor, player.level, player.primaryAttributes, arenaRandom);
+	
+	const ExeData &exeData = BinaryAssetLibrary::getInstance().getExeData();
 
 	std::string text;
 	std::string fontName;

--- a/OpenTESArena/src/Interface/GameWorldUiState.cpp
+++ b/OpenTESArena/src/Interface/GameWorldUiState.cpp
@@ -2511,6 +2511,31 @@ void GameWorldUI::showShopkeeperBackground(const char *titleText)
 	uiManager.setContextEnabled(state.shopkeeperBgContextInstID, true);
 }
 
+int GameWorldUI::getCurrentServiceQuality(const ExeData &exeData , ArenaRandom &arenaRandom)
+{
+	Game &game = *state.game;
+	GameState &gameState = game.gameState;
+
+	const LocationDefinition &locationDef = gameState.getLocationDefinition();
+	const LocationCityDefinition &cityDef = locationDef.getCityDefinition();
+	const ArenaCityType cityType = cityDef.type;
+
+	const MapDefinitionInterior &mapDefinitionInterior = gameState.getActiveMapDef().getSubDefinition().interior;
+	const std::optional<uint16_t> &doorVoxelOffset = mapDefinitionInterior.getDoorVoxelOffset();
+
+	uint16_t doorVoxelOffsetForServiceQuality = 0;
+	if (doorVoxelOffset.has_value())
+	{
+		doorVoxelOffsetForServiceQuality = *doorVoxelOffset;
+	}
+	else
+	{
+		DebugLog("No door voxel offset; using default of 0 to get service quality.");
+	}
+
+	return ArenaInteriorUtils::getServiceQuality(doorVoxelOffsetForServiceQuality, cityType, exeData, arenaRandom);
+}
+
 GameWorldPopUpClosedCallback GameWorldUI::makeReturnToMessageBoxCallback(ConversationMessageBoxType messageBoxType)
 {
 	return [messageBoxType]()
@@ -3592,10 +3617,12 @@ void GameWorldUI::onNpcEquipmentStealButtonSelected(MouseButtonType mouseButtonT
 	uiManager.disableTopMostContext();
 
 	ArenaRandom &arenaRandom = game.arenaRandom;
+	const ExeData &exeData = BinaryAssetLibrary::getInstance().getExeData();
+	const int serviceQuality = getCurrentServiceQuality(exeData, arenaRandom);
 
 	const Player &player = game.player;
 	const CharacterClassDefinition &charClassDef = CharacterClassLibrary::getInstance().getDefinition(player.charClassDefID);
-	const bool isStealSuccessful = ArenaPlayerUtils::attemptThieving(5, charClassDef.thievingDivisor, player.level, player.primaryAttributes, arenaRandom);
+	const bool isStealSuccessful = ArenaPlayerUtils::attemptThieving(serviceQuality, charClassDef.thievingDivisor, player.level, player.primaryAttributes, arenaRandom);
 	if (isStealSuccessful)
 	{
 		ItemLibraryPredicate stealableItemsPredicate = [](const ItemDefinition &itemDef)
@@ -3733,10 +3760,12 @@ void GameWorldUI::onNpcMagesGuildStealPotionsButtonSelected(MouseButtonType mous
 	uiManager.disableTopMostContext();
 
 	ArenaRandom &arenaRandom = game.arenaRandom;
+	const ExeData &exeData = BinaryAssetLibrary::getInstance().getExeData();
+	const int serviceQuality = getCurrentServiceQuality(exeData, arenaRandom);
 
 	const Player &player = game.player;
 	const CharacterClassDefinition &charClassDef = CharacterClassLibrary::getInstance().getDefinition(player.charClassDefID);
-	const bool isStealSuccessful = ArenaPlayerUtils::attemptThieving(3, charClassDef.thievingDivisor, player.level, player.primaryAttributes, arenaRandom);
+	const bool isStealSuccessful = ArenaPlayerUtils::attemptThieving(serviceQuality, charClassDef.thievingDivisor, player.level, player.primaryAttributes, arenaRandom);
 	if (isStealSuccessful)
 	{
 		ItemLibraryPredicate stealableItemsPredicate = [](const ItemDefinition &itemDef)
@@ -3760,10 +3789,12 @@ void GameWorldUI::onNpcMagesGuildStealMagicItemsButtonSelected(MouseButtonType m
 	uiManager.disableTopMostContext();
 
 	ArenaRandom &arenaRandom = game.arenaRandom;
+	const ExeData &exeData = BinaryAssetLibrary::getInstance().getExeData();
+	const int serviceQuality = getCurrentServiceQuality(exeData, arenaRandom);
 
 	const Player &player = game.player;
 	const CharacterClassDefinition &charClassDef = CharacterClassLibrary::getInstance().getDefinition(player.charClassDefID);
-	const bool isStealSuccessful = ArenaPlayerUtils::attemptThieving(6, charClassDef.thievingDivisor, player.level, player.primaryAttributes, arenaRandom);
+	const bool isStealSuccessful = ArenaPlayerUtils::attemptThieving(serviceQuality, charClassDef.thievingDivisor, player.level, player.primaryAttributes, arenaRandom);
 	if (isStealSuccessful)
 	{
 		ItemLibraryPredicate stealableItemsPredicate = [](const ItemDefinition &itemDef)
@@ -3808,10 +3839,11 @@ void GameWorldUI::onNpcTavernSneakIntoARoomButtonSelected(MouseButtonType mouseB
 	Random &random = game.random;
 	ArenaRandom &arenaRandom = game.arenaRandom;
 	const ExeData &exeData = BinaryAssetLibrary::getInstance().getExeData();
+	const int serviceQuality = getCurrentServiceQuality(exeData, arenaRandom);
 
 	const Player &player = game.player;
 	const CharacterClassDefinition &charClassDef = CharacterClassLibrary::getInstance().getDefinition(player.charClassDefID);
-	const bool isSneakingSuccessful = ArenaPlayerUtils::attemptThieving(1, charClassDef.thievingDivisor, player.level, player.primaryAttributes, arenaRandom);
+	const bool isSneakingSuccessful = ArenaPlayerUtils::attemptThieving(serviceQuality, charClassDef.thievingDivisor, player.level, player.primaryAttributes, arenaRandom);
 
 	std::string text;
 	std::string fontName;

--- a/OpenTESArena/src/Interface/GameWorldUiState.h
+++ b/OpenTESArena/src/Interface/GameWorldUiState.h
@@ -140,6 +140,7 @@ namespace GameWorldUI
 	void showConversationMessageBox(ConversationMessageBoxType messageBoxType);
 	void showConversationListBox(ConversationListBoxType listBoxType);
 	void showShopkeeperBackground(const char *titleText);
+	int getCurrentServiceQuality(const ExeData &exeData, ArenaRandom &arenaRandom);
 	GameWorldPopUpClosedCallback makeReturnToMessageBoxCallback(ConversationMessageBoxType messageBoxType);
 	void setShopkeeperPlayerGoldVisible(bool visible);
 	UiButtonCallback makeDirectionsEntryCallback(const DialogueDirectionsEntry &entry);

--- a/OpenTESArena/src/Interface/GameWorldUiState.h
+++ b/OpenTESArena/src/Interface/GameWorldUiState.h
@@ -140,7 +140,7 @@ namespace GameWorldUI
 	void showConversationMessageBox(ConversationMessageBoxType messageBoxType);
 	void showConversationListBox(ConversationListBoxType listBoxType);
 	void showShopkeeperBackground(const char *titleText);
-	int getCurrentServiceQuality(const ExeData &exeData, ArenaRandom &arenaRandom);
+	int getCurrentServiceQuality(ArenaRandom &arenaRandom);
 	GameWorldPopUpClosedCallback makeReturnToMessageBoxCallback(ConversationMessageBoxType messageBoxType);
 	void setShopkeeperPlayerGoldVisible(bool visible);
 	UiButtonCallback makeDirectionsEntryCallback(const DialogueDirectionsEntry &entry);

--- a/OpenTESArena/src/Interface/MainMenuUiMVC.cpp
+++ b/OpenTESArena/src/Interface/MainMenuUiMVC.cpp
@@ -682,9 +682,10 @@ void MainMenuUiController::onQuickStartButtonSelected(Game &game, int testType, 
 			}();
 
 			const std::string interiorDisplayName = "Test Interior";
+			constexpr std::optional<uint16_t> doorVoxelOffset; // Not needed.
 
 			MapGenerationInteriorInfo interiorGenInfo;
-			interiorGenInfo.initPrefab(mifName, interiorType, rulerIsMale, interiorDisplayName, std::nullopt);
+			interiorGenInfo.initPrefab(mifName, interiorType, rulerIsMale, interiorDisplayName, doorVoxelOffset);
 
 			const GameState::WorldMapLocationIDs worldMapLocationIDs(provinceIndex, locationIndex);
 

--- a/OpenTESArena/src/Interface/MainMenuUiMVC.cpp
+++ b/OpenTESArena/src/Interface/MainMenuUiMVC.cpp
@@ -684,7 +684,7 @@ void MainMenuUiController::onQuickStartButtonSelected(Game &game, int testType, 
 			const std::string interiorDisplayName = "Test Interior";
 
 			MapGenerationInteriorInfo interiorGenInfo;
-			interiorGenInfo.initPrefab(mifName, interiorType, rulerIsMale, interiorDisplayName);
+			interiorGenInfo.initPrefab(mifName, interiorType, rulerIsMale, interiorDisplayName, std::nullopt);
 
 			const GameState::WorldMapLocationIDs worldMapLocationIDs(provinceIndex, locationIndex);
 

--- a/OpenTESArena/src/Interface/WorldMapUiMVC.cpp
+++ b/OpenTESArena/src/Interface/WorldMapUiMVC.cpp
@@ -575,9 +575,10 @@ void FastTravelUiController::onAnimationFinished(Game &game, int targetProvinceI
 
 		constexpr std::optional<bool> rulerIsMale; // Not needed.
 		const std::string interiorDisplayName; // Unused.
+		constexpr std::optional<uint16_t> doorVoxelOffset; // Not needed.
 
 		MapGenerationInteriorInfo interiorGenInfo;
-		interiorGenInfo.initPrefab(mainQuestDungeonDef.mapFilename, ArenaInteriorType::Dungeon, rulerIsMale, interiorDisplayName, std::nullopt);
+		interiorGenInfo.initPrefab(mainQuestDungeonDef.mapFilename, ArenaInteriorType::Dungeon, rulerIsMale, interiorDisplayName, doorVoxelOffset);
 
 		const std::optional<VoxelInt2> playerStartOffset; // Unused for main quest dungeon.
 		const GameState::WorldMapLocationIDs worldMapLocationIDs(targetProvinceID, targetLocationID);

--- a/OpenTESArena/src/Interface/WorldMapUiMVC.cpp
+++ b/OpenTESArena/src/Interface/WorldMapUiMVC.cpp
@@ -577,7 +577,7 @@ void FastTravelUiController::onAnimationFinished(Game &game, int targetProvinceI
 		const std::string interiorDisplayName; // Unused.
 
 		MapGenerationInteriorInfo interiorGenInfo;
-		interiorGenInfo.initPrefab(mainQuestDungeonDef.mapFilename, ArenaInteriorType::Dungeon, rulerIsMale, interiorDisplayName);
+		interiorGenInfo.initPrefab(mainQuestDungeonDef.mapFilename, ArenaInteriorType::Dungeon, rulerIsMale, interiorDisplayName, std::nullopt);
 
 		const std::optional<VoxelInt2> playerStartOffset; // Unused for main quest dungeon.
 		const GameState::WorldMapLocationIDs worldMapLocationIDs(targetProvinceID, targetLocationID);

--- a/OpenTESArena/src/Player/PlayerLogic.cpp
+++ b/OpenTESArena/src/Player/PlayerLogic.cpp
@@ -748,23 +748,32 @@ namespace PlayerLogic
 			{
 				if (passesLootDistanceTest && canPlayerMoveAndTurn)
 				{
-					const ContainerEntityDefinition &containerDef = entityDef.container;
-					const ContainerEntityDefinitionType containerDefType = containerDef.type;
+					bool isContainerInventoryAccessible = true;
+					if (entityInst.canBeLocked())
+					{
+						const EntityLockState& lockState = entityChunkManager.lockStates.get(entityInst.lockStateID);
+						isContainerInventoryAccessible = !lockState.isLocked;
+					}
+
+					int lockLevel = 0;
+					if (!isContainerInventoryAccessible)
+					{
+						lockLevel = ArenaLevelUtils::getChestVoxelLockLevel(entityPosition.x * MIFUtils::ARENA_UNITS, entityPosition.z * MIFUtils::ARENA_UNITS, arenaRandom, exeData);
+					}
 
 					if (interactionType == GameWorldInteractionType::Default)
 					{
-						bool isContainerInventoryAccessible = true;
-						if (entityInst.canBeLocked())
-						{
-							const EntityLockState &lockState = entityChunkManager.lockStates.get(entityInst.lockStateID);
-							isContainerInventoryAccessible = !lockState.isLocked;
-						}
-
 						if (isContainerInventoryAccessible)
 						{
 							ItemInventory &containerItemInventory = entityChunkManager.itemInventories.get(entityInst.itemInventoryInstID);
 							constexpr bool destroyEntityIfEmpty = true; // Always for piles/chests.
 							GameWorldUiController::onContainerInventoryOpened(game, entityInstID, containerItemInventory, destroyEntityIfEmpty);
+						}
+						else
+						{
+							const int lockDifficultyIndex = ArenaPlayerUtils::getLockDifficultyMessageIndex(lockLevel, charClassDef.thievingDivisor, player.level, player.primaryAttributes, exeData, arenaRandom);
+							const std::string lockDifficultyMsg = GameWorldUiModel::getLockDifficultyMessage(lockDifficultyIndex, exeData);
+							GameWorldUI::setActionText(lockDifficultyMsg.c_str());
 						}
 					}
 					else if (interactionType == GameWorldInteractionType::Thieving)
@@ -777,7 +786,6 @@ namespace PlayerLogic
 							const bool canAttemptLockpicking = lockState.isLocked;
 							if (canAttemptLockpicking)
 							{
-								const int lockLevel = 5; // @todo get original chest lock level
 								const bool isLockpickingSuccessful = ArenaPlayerUtils::attemptThieving(lockLevel, charClassDef.thievingDivisor, player.level, player.primaryAttributes, arenaRandom);
 								if (isLockpickingSuccessful)
 								{

--- a/OpenTESArena/src/Player/PlayerLogic.cpp
+++ b/OpenTESArena/src/Player/PlayerLogic.cpp
@@ -749,16 +749,20 @@ namespace PlayerLogic
 				if (passesLootDistanceTest && canPlayerMoveAndTurn)
 				{
 					bool isContainerInventoryAccessible = true;
+					int lockLevel = 0;
 					if (entityInst.canBeLocked())
 					{
-						const EntityLockState& lockState = entityChunkManager.lockStates.get(entityInst.lockStateID);
+						const EntityLockState &lockState = entityChunkManager.lockStates.get(entityInst.lockStateID);
 						isContainerInventoryAccessible = !lockState.isLocked;
-					}
 
-					int lockLevel = 0;
-					if (!isContainerInventoryAccessible)
-					{
-						lockLevel = ArenaLevelUtils::getChestVoxelLockLevel(entityPosition.x * MIFUtils::ARENA_UNITS, entityPosition.z * MIFUtils::ARENA_UNITS, arenaRandom, exeData);
+						if (lockState.isLocked)
+						{
+							const OriginalDouble2 entityOriginalPosition = VoxelUtils::worldPointToOriginalPoint(entityPosition.getXZ());
+							const OriginalInt2 entityOriginalPositionArenaUnits(
+								static_cast<WEInt>(entityOriginalPosition.x * MIFUtils::ARENA_UNITS),
+								static_cast<SNInt>(entityOriginalPosition.y * MIFUtils::ARENA_UNITS));
+							lockLevel = ArenaLevelUtils::getChestVoxelLockLevel(entityOriginalPositionArenaUnits.x, entityOriginalPositionArenaUnits.y, arenaRandom, exeData);
+						}
 					}
 
 					if (interactionType == GameWorldInteractionType::Default)

--- a/OpenTESArena/src/Voxels/VoxelUtils.cpp
+++ b/OpenTESArena/src/Voxels/VoxelUtils.cpp
@@ -8,6 +8,16 @@
 
 #include "components/debug/Debug.h"
 
+WorldDouble2 VoxelUtils::originalPointToWorldPoint(OriginalDouble2 point)
+{
+	return WorldDouble2(point.y, point.x);
+}
+
+OriginalDouble2 VoxelUtils::worldPointToOriginalPoint(WorldDouble2 point)
+{
+	return OriginalDouble2(point.y, point.x);
+}
+
 WorldInt2 VoxelUtils::originalVoxelToWorldVoxel(const OriginalInt2 &voxel)
 {
 	return WorldInt2(voxel.y, voxel.x);
@@ -15,7 +25,7 @@ WorldInt2 VoxelUtils::originalVoxelToWorldVoxel(const OriginalInt2 &voxel)
 
 OriginalInt2 VoxelUtils::worldVoxelToOriginalVoxel(const WorldInt2 &voxel)
 {
-	return VoxelUtils::originalVoxelToWorldVoxel(voxel);
+	return OriginalInt2(voxel.y, voxel.x);
 }
 
 OriginalInt2 VoxelUtils::worldVoxelToOriginalVoxelMapTypeAware(WorldInt2 worldVoxel, MapType mapType)

--- a/OpenTESArena/src/Voxels/VoxelUtils.h
+++ b/OpenTESArena/src/Voxels/VoxelUtils.h
@@ -25,6 +25,8 @@ namespace VoxelUtils
 	// Transformation methods for converting voxel coordinates between the original game's format
 	// (+X west, +Z south) and the new format (+X south, +Z west). This is a bi-directional
 	// conversion (i.e., it works both ways).
+	WorldDouble2 originalPointToWorldPoint(OriginalDouble2 point);
+	OriginalDouble2 worldPointToOriginalPoint(WorldDouble2 point);
 	WorldInt2 originalVoxelToWorldVoxel(const OriginalInt2 &voxel);
 	OriginalInt2 worldVoxelToOriginalVoxel(const WorldInt2 &voxel);
 	OriginalInt2 worldVoxelToOriginalVoxelMapTypeAware(WorldInt2 worldVoxel, MapType mapType);

--- a/OpenTESArena/src/World/ArenaInteriorUtils.cpp
+++ b/OpenTESArena/src/World/ArenaInteriorUtils.cpp
@@ -112,7 +112,7 @@ int ArenaInteriorUtils::getServiceQuality(uint16_t doorVoxelOffset, ArenaCityTyp
 	const Span<const std::pair<uint8_t, uint8_t>> villageServiceQualities = exeData.services.villageServiceQualities;
 	const uint32_t savedSeed = random.getSeed();
 
-	uint32_t seed = (doorVoxelOffset & 0xFF00) | ((doorVoxelOffset & 0x00FF) >> 1);
+	const uint32_t seed = (doorVoxelOffset & 0xFF00) | ((doorVoxelOffset & 0x00FF) >> 1);
 	random.srand(seed);
 	const int roll = random.next(101);
 
@@ -123,26 +123,24 @@ int ArenaInteriorUtils::getServiceQuality(uint16_t doorVoxelOffset, ArenaCityTyp
 		DebugAssertIndex(serviceQualityChances, serviceQualityIndex);
 	}
 
-	int min;
-	int max;
-
+	Span<const std::pair<uint8_t, uint8_t>> selectedServiceQualities;
 	if (cityType == ArenaCityType::CityState)
 	{
-		min = cityStateServiceQualities[serviceQualityIndex].first;
-		max = cityStateServiceQualities[serviceQualityIndex].second;
+		selectedServiceQualities = cityStateServiceQualities;
 	}
 	else if (cityType == ArenaCityType::Town)
 	{
-		min = townServiceQualities[serviceQualityIndex].first;
-		max = townServiceQualities[serviceQualityIndex].second;
+		selectedServiceQualities = townServiceQualities;
 	}
 	else
 	{
-		min = villageServiceQualities[serviceQualityIndex].first;
-		max = villageServiceQualities[serviceQualityIndex].second;
+		selectedServiceQualities = villageServiceQualities;
 	}
 
-	const int result = min + random.next(max - min);
+	const std::pair<uint8_t, uint8_t> &selectedServiceQualityPair = selectedServiceQualities[serviceQualityIndex];
+	const int qualityMin = selectedServiceQualityPair.first;
+	const int qualityMax = selectedServiceQualityPair.second;
+	const int result = qualityMin + random.next(qualityMax - qualityMin);
 	random.srand(savedSeed);
 
 	return result;

--- a/OpenTESArena/src/World/ArenaInteriorUtils.cpp
+++ b/OpenTESArena/src/World/ArenaInteriorUtils.cpp
@@ -103,3 +103,47 @@ bool ArenaInteriorUtils::isPlayerTrespassing(ArenaBuildingType buildingType, boo
 
 	return false;
 }
+
+int ArenaInteriorUtils::getServiceQuality(uint16_t doorVoxelOffset, ArenaCityType cityType, const ExeData &exeData, ArenaRandom &random)
+{
+	const Span<const uint8_t> serviceQualityChances = exeData.services.serviceQualityChances;
+	const Span<const std::pair<uint8_t, uint8_t>> cityStateServiceQualities = exeData.services.cityStateServiceQualities;
+	const Span<const std::pair<uint8_t, uint8_t>> townServiceQualities = exeData.services.townServiceQualities;
+	const Span<const std::pair<uint8_t, uint8_t>> villageServiceQualities = exeData.services.villageServiceQualities;
+	const uint32_t savedSeed = random.getSeed();
+
+	uint32_t seed = (doorVoxelOffset & 0xFF00) | ((doorVoxelOffset & 0x00FF) >> 1);
+	random.srand(seed);
+	const int roll = random.next(101);
+
+	int serviceQualityIndex = 0;
+	while (serviceQualityChances[serviceQualityIndex] < roll)
+	{
+		serviceQualityIndex++;
+		DebugAssertIndex(serviceQualityChances, serviceQualityIndex);
+	}
+
+	int min;
+	int max;
+
+	if (cityType == ArenaCityType::CityState)
+	{
+		min = cityStateServiceQualities[serviceQualityIndex].first;
+		max = cityStateServiceQualities[serviceQualityIndex].second;
+	}
+	else if (cityType == ArenaCityType::Town)
+	{
+		min = townServiceQualities[serviceQualityIndex].first;
+		max = townServiceQualities[serviceQualityIndex].second;
+	}
+	else
+	{
+		min = villageServiceQualities[serviceQualityIndex].first;
+		max = villageServiceQualities[serviceQualityIndex].second;
+	}
+
+	const int result = min + random.next(max - min);
+	random.srand(savedSeed);
+
+	return result;
+}

--- a/OpenTESArena/src/World/ArenaInteriorUtils.h
+++ b/OpenTESArena/src/World/ArenaInteriorUtils.h
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "../Assets/ArenaTypes.h"
+#include "../Assets/ExeData.h"
 #include "../Voxels/VoxelUtils.h"
 
 class ArenaRandom;
@@ -42,4 +43,6 @@ namespace ArenaInteriorUtils
 	bool isProceduralInterior(ArenaInteriorType interiorType);
 
 	bool isPlayerTrespassing(ArenaBuildingType buildingType, bool isNight);
+
+	int getServiceQuality(uint16_t doorVoxelOffset, ArenaCityType cityType, const ExeData &exeData, ArenaRandom &random);
 }

--- a/OpenTESArena/src/World/ArenaLevelUtils.cpp
+++ b/OpenTESArena/src/World/ArenaLevelUtils.cpp
@@ -86,6 +86,11 @@ uint16_t ArenaLevelUtils::getDoorVoxelOffset(WEInt x, SNInt y)
 	return (y << 8) + (x << 1);
 }
 
+uint16_t ArenaLevelUtils::getChestLockLevelSeed(WEInt x, SNInt y)
+{
+	return ((static_cast<uint16_t>((x >> 7) & 0xFF) << 8) | (static_cast<uint16_t>(((y >> 7) << 1) & 0xFF)));
+}
+
 std::string ArenaLevelUtils::getDoorVoxelMifName(WEInt x, SNInt y, int menuID, uint32_t rulerSeed,
 	bool palaceIsMainQuestDungeon, ArenaCityType cityType, MapType mapType, const ExeData &exeData)
 {
@@ -226,7 +231,17 @@ int ArenaLevelUtils::getDoorVoxelLockLevel(WEInt x, SNInt y, ArenaRandom &random
 	const uint16_t offset = ArenaLevelUtils::getDoorVoxelOffset(x, y);
 	const uint32_t lockLevelSeed = offset + (offset << 16);
 	random.srand(lockLevelSeed);
-	int lockLevel = random.next(10) + 1; // 0..9 + 1.
+	const int lockLevel = random.next(10) + 1; // 0..9 + 1.
+	random.srand(savedSeed);
+	return lockLevel;
+}
+
+int ArenaLevelUtils::getChestVoxelLockLevel(WEInt x, SNInt y, ArenaRandom &random, const ExeData &exeData)
+{
+	const uint32_t savedSeed = random.getSeed();
+	const uint32_t lockLevelSeed = ArenaLevelUtils::getChestLockLevelSeed(x, y);
+	random.srand(lockLevelSeed);
+	const int lockLevel = random.next(exeData.thieving.thievingChestMaxLockLevel) + 1;
 	random.srand(savedSeed);
 	return lockLevel;
 }

--- a/OpenTESArena/src/World/ArenaLevelUtils.h
+++ b/OpenTESArena/src/World/ArenaLevelUtils.h
@@ -57,6 +57,9 @@ namespace ArenaLevelUtils
 	// (.MIF name, lock level).
 	uint16_t getDoorVoxelOffset(WEInt x, SNInt y);
 
+	// Gets the RNG seed to determine a chest's lock level.
+	uint16_t getChestLockLevelSeed(WEInt x, SNInt y);
+
 	// Gets the .MIF name for a door voxel in a city or the wilderness.
 	std::string getDoorVoxelMifName(WEInt x, SNInt y, int menuID, uint32_t rulerSeed,
 		bool palaceIsMainQuestDungeon, ArenaCityType cityType, MapType mapType,
@@ -64,6 +67,9 @@ namespace ArenaLevelUtils
 
 	// Gets the lock level for a door voxel at the given XY coordinate.
 	int getDoorVoxelLockLevel(WEInt x, SNInt y, ArenaRandom &random);
+
+	// Gets the lock level for a chest voxel at the given XY coordinate.
+	int getChestVoxelLockLevel(WEInt x, SNInt y, ArenaRandom &random, const ExeData &exeData);
 
 	// Gets the '#' number used in IN#.0x and RE#.0x save files.
 	int getServiceSaveFileNumber(WEInt doorX, SNInt doorY);

--- a/OpenTESArena/src/World/MapDefinition.cpp
+++ b/OpenTESArena/src/World/MapDefinition.cpp
@@ -35,11 +35,6 @@ void MapDefinitionInterior::init(ArenaInteriorType interiorType, const std::stri
 	this->displayName = displayName;
 }
 
-const std::optional<uint16_t> &MapDefinitionInterior::getDoorVoxelOffset() const
-{
-	return this->doorVoxelOffset;
-}
-
 void MapDefinitionInterior::clear()
 {
 	this->interiorType = static_cast<ArenaInteriorType>(-1);

--- a/OpenTESArena/src/World/MapDefinition.cpp
+++ b/OpenTESArena/src/World/MapDefinition.cpp
@@ -35,6 +35,11 @@ void MapDefinitionInterior::init(ArenaInteriorType interiorType, const std::stri
 	this->displayName = displayName;
 }
 
+const std::optional<uint16_t> &MapDefinitionInterior::getDoorVoxelOffset() const
+{
+	return this->doorVoxelOffset;
+}
+
 void MapDefinitionInterior::clear()
 {
 	this->interiorType = static_cast<ArenaInteriorType>(-1);
@@ -446,6 +451,7 @@ bool MapDefinition::initInterior(const MapGenerationInteriorInfo &generationInfo
 			charClassLibrary, entityDefLibrary, binaryAssetLibrary, textureManager);
 		this->initStartPoints(mif);
 		this->startLevelIndex = mif.getStartingLevelIndex();
+		this->subDefinition.interior.doorVoxelOffset = generationInfo.prefab.doorVoxelOffset;
 	}
 	else if (interiorType == MapGenerationInteriorType::Dungeon)
 	{

--- a/OpenTESArena/src/World/MapDefinition.h
+++ b/OpenTESArena/src/World/MapDefinition.h
@@ -34,9 +34,13 @@ struct MapDefinitionInterior
 	// - probably store the music filename here, or make it retrievable by the interior type
 	std::string displayName;
 
+	std::optional<uint16_t> doorVoxelOffset;
+
 	MapDefinitionInterior();
 
 	void init(ArenaInteriorType interiorType, const std::string &displayName);
+
+	const std::optional<uint16_t> &getDoorVoxelOffset() const;
 
 	void clear();
 };

--- a/OpenTESArena/src/World/MapDefinition.h
+++ b/OpenTESArena/src/World/MapDefinition.h
@@ -40,8 +40,6 @@ struct MapDefinitionInterior
 
 	void init(ArenaInteriorType interiorType, const std::string &displayName);
 
-	const std::optional<uint16_t> &getDoorVoxelOffset() const;
-
 	void clear();
 };
 

--- a/OpenTESArena/src/World/MapGeneration.cpp
+++ b/OpenTESArena/src/World/MapGeneration.cpp
@@ -168,6 +168,9 @@ namespace MapGeneration
 		MapType mapType, const ExeData &exeData)
 	{
 		const OriginalInt2 originalPos = VoxelUtils::worldVoxelToOriginalVoxel(WorldInt2(position.x, position.z));
+
+		const uint16_t doorVoxelOffset = ArenaLevelUtils::getDoorVoxelOffset(originalPos.x, originalPos.y);
+
 		std::string mifName = ArenaLevelUtils::getDoorVoxelMifName(originalPos.x, originalPos.y, menuID,
 			rulerSeed, palaceIsMainQuestDungeon, cityType, mapType, exeData);
 
@@ -180,7 +183,7 @@ namespace MapGeneration
 		const std::string interiorDisplayName; // Provided later in generation due to circular dependency between transitions and building names :/
 
 		MapGenerationInteriorInfo interiorGenInfo;
-		interiorGenInfo.initPrefab(mifName, revisedInteriorType, rulerIsMale, interiorDisplayName);
+		interiorGenInfo.initPrefab(mifName, revisedInteriorType, rulerIsMale, interiorDisplayName, doorVoxelOffset);
 		return interiorGenInfo;
 	}
 
@@ -2372,12 +2375,13 @@ namespace MapGeneration
 }
 
 void MapGenerationInteriorPrefabInfo::init(const std::string &mifName, ArenaInteriorType interiorType, const std::optional<bool> &rulerIsMale,
-	const std::string &displayName)
+	const std::string &displayName, const std::optional<uint16_t> &doorVoxelOffset)
 {
 	this->mifName = mifName;
 	this->interiorType = interiorType;
 	this->rulerIsMale = rulerIsMale;
 	this->displayName = displayName;
+	this->doorVoxelOffset = doorVoxelOffset;
 }
 
 void MapGenerationInteriorDungeonInfo::init(const LocationDungeonDefinition &dungeonDef, bool isArtifactDungeon)
@@ -2393,11 +2397,11 @@ MapGenerationInteriorInfo::MapGenerationInteriorInfo()
 }
 
 void MapGenerationInteriorInfo::initPrefab(const std::string &mifName, ArenaInteriorType interiorType, const std::optional<bool> &rulerIsMale,
-	const std::string &displayName)
+	const std::string &displayName, const std::optional<uint16_t> &doorVoxelOffset)
 {
 	this->type = MapGenerationInteriorType::Prefab;
 	this->interiorType = interiorType;
-	this->prefab.init(mifName, interiorType, rulerIsMale, displayName);
+	this->prefab.init(mifName, interiorType, rulerIsMale, displayName, doorVoxelOffset);
 }
 
 void MapGenerationInteriorInfo::initDungeon(const LocationDungeonDefinition &dungeonDef, bool isArtifactDungeon)

--- a/OpenTESArena/src/World/MapGeneration.cpp
+++ b/OpenTESArena/src/World/MapGeneration.cpp
@@ -167,9 +167,7 @@ namespace MapGeneration
 		uint32_t rulerSeed, const std::optional<bool> &rulerIsMale, bool palaceIsMainQuestDungeon, ArenaCityType cityType,
 		MapType mapType, const ExeData &exeData)
 	{
-		const OriginalInt2 originalPos = VoxelUtils::worldVoxelToOriginalVoxel(WorldInt2(position.x, position.z));
-
-		const uint16_t doorVoxelOffset = ArenaLevelUtils::getDoorVoxelOffset(originalPos.x, originalPos.y);
+		const OriginalInt2 originalPos = VoxelUtils::worldVoxelToOriginalVoxel(position.getXZ());
 
 		std::string mifName = ArenaLevelUtils::getDoorVoxelMifName(originalPos.x, originalPos.y, menuID,
 			rulerSeed, palaceIsMainQuestDungeon, cityType, mapType, exeData);
@@ -181,14 +179,14 @@ namespace MapGeneration
 		}
 
 		const std::string interiorDisplayName; // Provided later in generation due to circular dependency between transitions and building names :/
+		const uint16_t doorVoxelOffset = ArenaLevelUtils::getDoorVoxelOffset(originalPos.x, originalPos.y);
 
 		MapGenerationInteriorInfo interiorGenInfo;
 		interiorGenInfo.initPrefab(mifName, revisedInteriorType, rulerIsMale, interiorDisplayName, doorVoxelOffset);
 		return interiorGenInfo;
 	}
 
-	MapGenerationInteriorInfo makeProceduralInteriorGenInfo(
-		const LocationDungeonDefinition &dungeonDef, bool isArtifactDungeon)
+	MapGenerationInteriorInfo makeProceduralInteriorGenInfo(const LocationDungeonDefinition &dungeonDef, bool isArtifactDungeon)
 	{
 		MapGenerationInteriorInfo interiorGenInfo;
 		interiorGenInfo.initDungeon(dungeonDef, isArtifactDungeon);

--- a/OpenTESArena/src/World/MapGeneration.h
+++ b/OpenTESArena/src/World/MapGeneration.h
@@ -47,8 +47,9 @@ struct MapGenerationInteriorPrefabInfo
 	ArenaInteriorType interiorType;
 	std::optional<bool> rulerIsMale;
 	std::string displayName;
+	std::optional<uint16_t> doorVoxelOffset;
 
-	void init(const std::string &mifName, ArenaInteriorType interiorType, const std::optional<bool> &rulerIsMale, const std::string &displayName);
+	void init(const std::string &mifName, ArenaInteriorType interiorType, const std::optional<bool> &rulerIsMale, const std::string &displayName, const std::optional<uint16_t> &doorVoxelOffset);
 };
 
 // Input: RANDOM1.MIF + RD1.INF (loaded internally) + seed + chunk dimensions
@@ -71,7 +72,7 @@ struct MapGenerationInteriorInfo
 
 	MapGenerationInteriorInfo();
 
-	void initPrefab(const std::string &mifName, ArenaInteriorType interiorType, const std::optional<bool> &rulerIsMale, const std::string &displayName);
+	void initPrefab(const std::string &mifName, ArenaInteriorType interiorType, const std::optional<bool> &rulerIsMale, const std::string &displayName, const std::optional<uint16_t> &doorVoxelOffset);
 	void initDungeon(const LocationDungeonDefinition &dungeonDef, bool isArtifactDungeon);
 };
 

--- a/data/exe/aExeStrings.txt
+++ b/data/exe/aExeStrings.txt
@@ -285,6 +285,10 @@ Box4=0x48306
 
 [Services]
 TavernRoomHealModifiers=0x3D8F9
+ServiceQualityChances=0x40238
+CityStateServiceQualities=0x4023C
+TownServiceQualities=0x40244
+VillageServiceQualities=0x4024C
 PalaceClosedAtNight=0x43F2C
 EquipmentModalTitle=0x440D0
 EquipmentModalBuy=0x440F3
@@ -354,10 +358,6 @@ CitizenRumorsModalWorkAskInTown=0x43B0C
 CitizenWhereIsOptionsCity=0x43C2F
 CitizenWhereIsOptionsWilderness=0x43C91
 PlayerGoldRemaining=0x401D4
-ServiceQualityChances=0x40238
-CityStateServiceQualities=0x4023C
-TownServiceQualities=0x40244
-VillageServiceQualities=0x4024C
 
 [Status]
 PopUp=0x411D7

--- a/data/exe/aExeStrings.txt
+++ b/data/exe/aExeStrings.txt
@@ -354,6 +354,10 @@ CitizenRumorsModalWorkAskInTown=0x43B0C
 CitizenWhereIsOptionsCity=0x43C2F
 CitizenWhereIsOptionsWilderness=0x43C91
 PlayerGoldRemaining=0x401D4
+ServiceQualityChances=0x40238
+CityStateServiceQualities=0x4023C
+TownServiceQualities=0x40244
+VillageServiceQualities=0x4024C
 
 [Status]
 PopUp=0x411D7
@@ -387,6 +391,7 @@ ThievingEntranceNoGuardsChance=0x4082
 ThievingPickpocketJunkThreshold=0x1E455
 ThievingPickpocketMaxGold=0x1E464
 ThievingMagicallyHeldLockDifficultyThreshold=0x21F47
+ThievingChestMaxLockLevel=0x2802C
 
 [Travel]
 LocationFormatTexts=0x374AD

--- a/data/exe/acdExeStrings.txt
+++ b/data/exe/acdExeStrings.txt
@@ -285,6 +285,10 @@ Box4=0x48674
 
 [Services]
 TavernRoomHealModifiers=0x3DC9D
+ServiceQualityChances=0x40572
+CityStateServiceQualities=0x40576
+TownServiceQualities=0x4057E
+VillageServiceQualities=0x40586
 PalaceClosedAtNight=0x442D0
 EquipmentModalTitle=0x44474
 EquipmentModalBuy=0x44497
@@ -354,10 +358,6 @@ CitizenRumorsModalWorkAskInTown=0x43EB0
 CitizenWhereIsOptionsCity=0x43FD3
 CitizenWhereIsOptionsWilderness=0x44035
 PlayerGoldRemaining=0x4050E
-ServiceQualityChances=0x40572
-CityStateServiceQualities=0x40576
-TownServiceQualities=0x4057E
-VillageServiceQualities=0x40586
 
 [Status]
 PopUp=0x4157B

--- a/data/exe/acdExeStrings.txt
+++ b/data/exe/acdExeStrings.txt
@@ -354,6 +354,10 @@ CitizenRumorsModalWorkAskInTown=0x43EB0
 CitizenWhereIsOptionsCity=0x43FD3
 CitizenWhereIsOptionsWilderness=0x44035
 PlayerGoldRemaining=0x4050E
+ServiceQualityChances=0x40572
+CityStateServiceQualities=0x40576
+TownServiceQualities=0x4057E
+VillageServiceQualities=0x40586
 
 [Status]
 PopUp=0x4157B
@@ -387,6 +391,7 @@ ThievingEntranceNoGuardsChance=0x40B0
 ThievingPickpocketJunkThreshold=0x200CF
 ThievingPickpocketMaxGold=0x200DE
 ThievingMagicallyHeldLockDifficultyThreshold=0x237AB
+ThievingChestMaxLockLevel=0x299FE
 
 [Travel]
 LocationFormatTexts=0x376AD


### PR DESCRIPTION
Chest lockpicking:
Lock difficulty is calculated like the original game.
Clicking on a chest in the default interaction mode shows a lock difficulty message like the original game.

Stealing from services:
Difficulty is calculated like the original game.